### PR TITLE
Check both per-obj and global permissions

### DIFF
--- a/metaci/users/models.py
+++ b/metaci/users/models.py
@@ -21,3 +21,11 @@ class User(GuardianUserMixin, AbstractUser):
 
     def get_absolute_url(self):
         return reverse('users:detail', kwargs={'username': self.username})
+
+    def has_perm(self, perm, obj=None):
+        if obj is not None:
+            has_local_perm = super(User, self).has_perm(perm, obj)
+        else:
+            has_local_perm = False
+        has_global_perm = super(User, self).has_perm(perm)
+        return has_local_perm or has_global_perm


### PR DESCRIPTION
Tested with a non-staff user locally and this seemed to help for the has_perm checks. I couldn't reproduce the error loading the create-org view so I'm wondering if that one was caching-related somehow.