### PR TITLE
Fix release creation migration script

### DIFF
--- a/metaci/release/migrations/0003_populate_releases.py
+++ b/metaci/release/migrations/0003_populate_releases.py
@@ -31,6 +31,13 @@ def populate_releases(apps, schema_editor):
         repo = github.repository(info['repo'].owner, info['repo'].name) 
         for release in repo.iter_releases():
             if release.tag_name in info['tags']:
+                existing = Release.objects.filter(
+                    repo = info['repo'],
+                    git_tag = release.tag_name,
+                )
+                if existing.exists():
+                    continue
+                
                 ref = repo.ref('tags/{}'.format(release.tag_name))
                 rel = Release(
                     repo = info['repo'],

--- a/metaci/release/migrations/0003_populate_releases.py
+++ b/metaci/release/migrations/0003_populate_releases.py
@@ -11,6 +11,8 @@ from django.db import migrations
 from django.utils.dateparse import parse_date
 from github3 import login
 
+from metaci.release.utils import update_release_from_github
+
 logger = logging.getLogger(__name__)
 
 def populate_releases(apps, schema_editor):
@@ -29,49 +31,21 @@ def populate_releases(apps, schema_editor):
     github = login(settings.GITHUB_USERNAME, settings.GITHUB_PASSWORD)
     for info in repos.values():
         repo = github.repository(info['repo'].owner, info['repo'].name) 
-        for release in repo.iter_releases():
-            if release.tag_name in info['tags']:
-                existing = Release.objects.filter(
-                    repo = info['repo'],
-                    git_tag = release.tag_name,
-                )
-                if existing.exists():
-                    continue
-                
-                ref = repo.ref('tags/{}'.format(release.tag_name))
-                rel = Release(
-                    repo = info['repo'],
-                    status = 'published',
-                    version_name = release.name,
-                    version_number = release.name,
-                    git_tag = release.tag_name,
-                    github_release = release.html_url,
-                    release_creation_date = release.created_at,
-                    created_from_commit = ref.object.sha,
-                )
-                sandbox_date = re.findall(
-                    r'^Sandbox orgs: (20[\d][\d]-[\d][\d]-[\d][\d])', release.body
-                )
-                if sandbox_date:
-                    rel.sandbox_push_date = parse_date(sandbox_date[0], '%Y-%m-%d')
-                    
-                prod_date = re.findall(
-                    r'^Production orgs: (20[\d][\d]-[\d][\d]-[\d][\d])', release.body
-                )
-                if prod_date:
-                    rel.production_push_date = parse_date(prod_date[0], '%Y-%m-%d')
-
-                package_version_id = re.findall(r'(04t[\w]{15,18})', release.body)
-                if package_version_id:
-                    rel.package_version_id = package_version_id[0]
-
-                trialforce_id = re.findall(
-                    r'^(0TT[\w]{15,18})', release.body
-                )
-                if trialforce_id:
-                    rel.trialforce_id = trialforce_id[0]
-
-                rel.save()
+        for tag in info['tags']:
+            existing = Release.objects.filter(
+                repo = info['repo'],
+                git_tag = tag,
+            )
+            if existing.exists():
+                continue
+            
+            release = Release(
+                repo = info['repo'],
+                status = 'published',
+                git_tag = tag,
+            )
+            update_release_from_github(release)
+            release.save()
 
 def populate_build_release(apps, schema_editor):
     Build = apps.get_model('build.Build')

--- a/metaci/release/models.py
+++ b/metaci/release/models.py
@@ -13,7 +13,6 @@ from model_utils.models import StatusModel
 from model_utils.fields import AutoCreatedField, AutoLastModifiedField
 
 from metaci.release.utils import update_release_from_github
-from metaci.repository.utils import get_github_api
 
 class Release(StatusModel):
     STATUS = Choices('draft', 'published', 'hidden')

--- a/metaci/release/models.py
+++ b/metaci/release/models.py
@@ -1,11 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-import re
-
 from django.db import models
-from django.utils.dateparse import parse_date
-from django.utils.dateparse import parse_datetime
 from django.utils.translation import ugettext_lazy as _
 
 from model_utils import Choices

--- a/metaci/release/models.py
+++ b/metaci/release/models.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-import logging
 import re
 
 from django.db import models
@@ -15,8 +14,6 @@ from model_utils.fields import AutoCreatedField, AutoLastModifiedField
 
 from metaci.release.utils import update_release_from_github
 from metaci.repository.utils import get_github_api
-
-logger = logging.getLogger(__name__)
 
 class Release(StatusModel):
     STATUS = Choices('draft', 'published', 'hidden')

--- a/metaci/release/models.py
+++ b/metaci/release/models.py
@@ -1,12 +1,22 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import logging
+import re
+
 from django.db import models
+from django.utils.dateparse import parse_date
+from django.utils.dateparse import parse_datetime
 from django.utils.translation import ugettext_lazy as _
 
 from model_utils import Choices
 from model_utils.models import StatusModel
 from model_utils.fields import AutoCreatedField, AutoLastModifiedField
+
+from metaci.release.utils import update_release_from_github
+from metaci.repository.utils import get_github_api
+
+logger = logging.getLogger(__name__)
 
 class Release(StatusModel):
     STATUS = Choices('draft', 'published', 'hidden')
@@ -38,3 +48,6 @@ class Release(StatusModel):
 
     def __unicode__(self):
         return "{}: {}".format(self.repo, self.version_name)
+
+    def update_from_github(self):
+        update_release_from_github(self)

--- a/metaci/release/utils.py
+++ b/metaci/release/utils.py
@@ -51,3 +51,5 @@ def update_release_from_github(release):
     )
     if trialforce_id:
         release.trialforce_id = trialforce_id[0]
+
+    return release

--- a/metaci/release/utils.py
+++ b/metaci/release/utils.py
@@ -7,23 +7,22 @@ import re
 from django.utils.dateparse import parse_date
 from django.utils.dateparse import parse_datetime
 
-from metaci.repository.utils import get_github_api
-
 logger = logging.getLogger(__name__)
 
-def update_release_from_github(release):
+def update_release_from_github(release, repo_api=None):
+    if not repo_api:
+        repo_api = release.repo.github_api
     if not release.git_tag:
         logger.info('Cannot update release, no git_tag specified')
         return
-    repo = get_github_api(release.repo)
-    ref = repo.ref('tags/{}'.format(release.git_tag))
+    ref = repo_api.ref('tags/{}'.format(release.git_tag))
     if not ref:
         logger.info(
             'Cannot update release, ref tags/{} not found in Github'.format(release.git_tag)
         )
         return
-    url = repo._build_url('releases/tags/{}'.format(release.git_tag), base_url=repo._api)
-    gh_release = repo._get(url).json()
+    url = repo_api._build_url('releases/tags/{}'.format(release.git_tag), base_url=repo_api._api)
+    gh_release = repo_api._get(url).json()
     release.status = 'published'
     release.version_name = gh_release['name']
     release.version_number = gh_release['name']

--- a/metaci/release/utils.py
+++ b/metaci/release/utils.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import logging
+import re
+
+from django.utils.dateparse import parse_date
+from django.utils.dateparse import parse_datetime
+
+from metaci.repository.utils import get_github_api
+
+logger = logging.getLogger(__name__)
+
+def update_release_from_github(release):
+    if not release.git_tag:
+        logger.info('Cannot update release, no git_tag specified')
+        return
+    repo = get_github_api(release.repo)
+    ref = repo.ref('tags/{}'.format(release.git_tag))
+    if not ref:
+        logger.info(
+            'Cannot update release, ref tags/{} not found in Github'.format(release.git_tag)
+        )
+        return
+    url = repo._build_url('releases/tags/{}'.format(release.git_tag), base_url=repo._api)
+    gh_release = repo._get(url).json()
+    release.status = 'published'
+    release.version_name = gh_release['name']
+    release.version_number = gh_release['name']
+    release.github_release = gh_release['html_url']
+    release.release_creation_date = parse_datetime(gh_release['created_at'])
+    release.created_from_commit = ref.object.sha
+    sandbox_date = re.findall(
+        r'^Sandbox orgs: (20[\d][\d]-[\d][\d]-[\d][\d])', gh_release['body']
+    )
+    if sandbox_date:
+        release.sandbox_push_date = parse_date(sandbox_date[0], '%Y-%m-%d')
+
+    prod_date = re.findall(
+        r'^Production orgs: (20[\d][\d]-[\d][\d]-[\d][\d])', gh_release['body']
+    )
+    if prod_date:
+        release.production_push_date = parse_date(prod_date[0], '%Y-%m-%d')
+
+    package_version_id = re.findall(r'(04t[\w]{15,18})', gh_release['body'])
+    if package_version_id:
+        release.package_version_id = package_version_id[0]
+
+    trialforce_id = re.findall(
+        r'^(0TT[\w]{15,18})', gh_release['body']
+    )
+    if trialforce_id:
+        release.trialforce_id = trialforce_id[0]

--- a/metaci/repository/models.py
+++ b/metaci/repository/models.py
@@ -1,12 +1,11 @@
 from __future__ import unicode_literals
 
-from django.db import models
-from django.urls import reverse
-
-from github3 import login
+from cumulusci.core.github import get_github_api
 from django.apps import apps
 from django.conf import settings
+from django.db import models
 from django.http import Http404
+from django.urls import reverse
 from model_utils.models import SoftDeletableModel
 
 class RepositoryQuerySet(models.QuerySet):
@@ -48,7 +47,7 @@ class Repository(models.Model):
    
     @property 
     def github_api(self):
-        gh = login(settings.GITHUB_USERNAME, settings.GITHUB_PASSWORD)
+        gh = get_github_api(settings.GITHUB_USERNAME, settings.GITHUB_PASSWORD)
         repo = gh.repository(self.owner, self.name)
         return repo
 

--- a/metaci/repository/utils.py
+++ b/metaci/repository/utils.py
@@ -1,14 +1,18 @@
 from django.conf import settings
 from github3 import login
 
+def get_github_api(repo):
+    github = login(settings.GITHUB_USERNAME, settings.GITHUB_PASSWORD)
+    return github.repository(repo.owner, repo.name)
+
+    
 
 def create_status(build):
     if not build.plan.context:
         # skip setting Github status if the context field is empty
         return
 
-    github = login(settings.GITHUB_USERNAME, settings.GITHUB_PASSWORD)
-    repo = github.repository(build.repo.owner, build.repo.name)
+    repo = get_github_api(build.repo)
 
     print build.get_status()
 

--- a/metaci/repository/utils.py
+++ b/metaci/repository/utils.py
@@ -1,11 +1,9 @@
 from django.conf import settings
-from github3 import login
+from cumulusci.core.github import get_github_api
 
 def get_github_api(repo):
-    github = login(settings.GITHUB_USERNAME, settings.GITHUB_PASSWORD)
+    github = get_github_api(settings.GITHUB_USERNAME, settings.GITHUB_PASSWORD)
     return github.repository(repo.owner, repo.name)
-
-    
 
 def create_status(build):
     if not build.plan.context:

--- a/metaci/repository/utils.py
+++ b/metaci/repository/utils.py
@@ -1,18 +1,11 @@
 from django.conf import settings
-from cumulusci.core.github import get_github_api
-
-def get_github_api(repo):
-    github = get_github_api(settings.GITHUB_USERNAME, settings.GITHUB_PASSWORD)
-    return github.repository(repo.owner, repo.name)
 
 def create_status(build):
     if not build.plan.context:
         # skip setting Github status if the context field is empty
         return
 
-    repo = get_github_api(build.repo)
-
-    print build.get_status()
+    repo = build.repo.github_api
 
     if build.get_status() == 'queued':
         state = 'pending'


### PR DESCRIPTION
- Added metaci.release.utils.update_release_from_github
- Added method Release.update_from_github
- Changed migration script to create release then call
  update_release_from_github to avoid Github API throttling caused by