### PR TITLE
Fix triggering builds from new tags

### DIFF
--- a/metaci/plan/models.py
+++ b/metaci/plan/models.py
@@ -144,12 +144,8 @@ class Plan(models.Model):
             if not re.match(self.regex, tag):
                 return run_build, commit, commit_message
 
-            if push["head_commit"]:
-                # Skip... for some reason a second push event is sent that has no 'before' but does have a head_commit
-                return run_build, commit, commit_message
-
             run_build = True
-            commit = push["before"]
+            commit = push["head_commit"]["id"]
             return run_build, commit, commit_message
 
         return run_build, commit, commit_message

--- a/metaci/plan/tests/test_models.py
+++ b/metaci/plan/tests/test_models.py
@@ -53,12 +53,13 @@ class PlanTestCase(TestCase):
     def test_check_push_tag_matches(self):
         push = {
             "ref": "refs/tags/test/matches",
-            "before": "0123456789",
-            "head_commit": None,
+            "head_commit": {
+                "id": "0123456789"
+            },
         }
         run_build, commit, commit_message = self.tag_plan.check_push(push)
         self.assertTrue(run_build)
-        self.assertEquals(commit, push["before"])
+        self.assertEquals(commit, push["head_commit"]["id"])
 
     def test_check_push_tag_does_not_match(self):
         push = {"ref": "refs/tags/no-match", "head_commit": None}


### PR DESCRIPTION
(Github appears to now be only sending a single webhook for new tags,
probably due to changes in how tags are created related to the github3.py upgrade)