### PR TITLE
Check for DevHub Capacity

### DIFF
--- a/app.json
+++ b/app.json
@@ -77,6 +77,11 @@
       "value": "1",
       "required": false
     },
+    "METACI_SCRATCH_ORG_RESERVE": {
+      "description": "The number of scratch orgs to always reserve in the DevHub (for non CI use). Ten is a good number, but if your DevHub is a free DE, you'll need to set it to something lower, like one.",
+      "value": "10",
+      "required": false
+    },
     "SFDX_HUB_KEY": {
       "description": "The private key for the JWT authentication to the devhub for Salesforce DX.  Required to use scratch orgs",
       "value": "",

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -290,6 +290,8 @@ SFDX_HUB_USERNAME = None
 # Application Behaviors
 GITHUB_STATUS_UPDATES_ENABLED = env.bool("GITHUB_STATUS_UPDATES_ENABLED", True)
 METACI_FLOW_SUBCLASS_ENABLED = env.bool("METACI_FLOW_SUBCLASS_ENABLED", True)
+SCRATCH_ORG_RESERVE = env.int("METACI_SCRATCH_ORG_RESERVE", 10)
+# number of scratch orgs to leave available in the org.
 
 # Django REST Framework
 REST_FRAMEWORK = {

--- a/metaci/build/tasks.py
+++ b/metaci/build/tasks.py
@@ -121,8 +121,6 @@ def check_queued_build(build_id):
         build.save()
         return ('DevHub has scratch org capacity, running the build ' +
                 'as task {}'.format(res_run.id))
-
-
     else:
         # For persistent orgs, use the cache to lock the org
         status = cache.add(

--- a/metaci/build/tasks.py
+++ b/metaci/build/tasks.py
@@ -1,6 +1,8 @@
 import os
 import time
 
+from collections import namedtuple
+
 from django import db
 from django.conf import settings
 from django.core.cache import cache
@@ -12,10 +14,23 @@ from metaci.cumulusci.models import Org, jwt_session, sf_session
 from metaci.repository.utils import create_status
 
 BUILD_TIMEOUT = 28800
+ACTIVESCRATCHORGLIMITS_KEY = 'metaci:activescratchorgs:limits'
 
+ActiveScratchOrgLimits = namedtuple('ActiveScratchOrgLimits', ['remaining', 'max'])
 
 def reset_database_connection():
     db.connection.close()
+
+def scratch_org_limits():
+    cached = cache.get(ACTIVESCRATCHORGLIMITS_KEY, None)
+    if cached:
+        return cached
+
+    sfjwt = jwt_session(username=settings.SFDX_HUB_USERNAME)
+    limits = sf_session(sfjwt).limits()['ActiveScratchOrgs']
+    value = ActiveScratchOrgLimits(remaining=limits['Remaining'], max=limits['Max'])
+    cache.set(ACTIVESCRATCHORGLIMITS_KEY, value, 65)
+
 
 
 @django_rq.job('default', timeout=BUILD_TIMEOUT)
@@ -93,23 +108,20 @@ def check_queued_build(build_id):
     if org.scratch:
         # For scratch orgs, we don't need concurrency blocking logic, 
         # but we need to check capacity
-        sfjwt = jwt_session(username=settings.SFDX_HUB_USERNAME)
-        sf = sf_session(sfjwt)
-        remaining_orgs = sf.limits()['ActiveScratchOrgs']['Remaining']
 
-        if remaining_orgs > 10:
-            res_run = run_build.delay(build.id)
-            build.task_id_check = None
-            build.task_id_run = res_run.id
-            build.save()
-            return ('DevHub has scratch org capacity, running the build ' +
-                    'as task {}'.format(res_run.id))
-        else:
+        if scratch_org_limits().remaining < settings.SCRATCH_ORG_RESERVE:
             build.task_id_check = None
             build.set_status('waiting')
-            build.log = "Waiting on DevHub scratch org availability"
+            build.log = "Waiting on DevHub scratch org availability."
             build.save()
             return "DevHub does not have enough capacity to start this build. Requeueing task."
+        res_run = run_build.delay(build.id)
+        build.task_id_check = None
+        build.task_id_run = res_run.id
+        build.save()
+        return ('DevHub has scratch org capacity, running the build ' +
+                'as task {}'.format(res_run.id))
+
 
     else:
         # For persistent orgs, use the cache to lock the org


### PR DESCRIPTION
In check_queued_build, check the number of remaining scratch orgs before trying the build.

This can definitely be done cleaner... Just wanted to get an idea out there for comment...

should we allow MetaCI to use all orgs, or is reserving a capacity (i did ten in this version) useful? Obviously this isn't a strict guarantee and there are race conditions to consider...

Should we cache the number available in some way, so that we don't hit the devhub with another call on every queued build? Probably not that big of a deal and would invalidate quickly.

This requires functional testing on staging, to test how it behaves with the full check_waiting_builds lifecycle. I should probably seperate the gate from the requeueing logic, so that on staging we can fake low capacity.