### PR TITLE
Link to the failed test result view instead of the test history view

### DIFF
--- a/metaci/build/templates/build/detail_tests.html
+++ b/metaci/build/templates/build/detail_tests.html
@@ -15,7 +15,7 @@
 
     {% for test in tests.failed_tests %}
       <div class="slds-tile slds-m-bottom--medium">
-        <h3 class="slds-truncate slds-text-heading--small" title="{{ test.method.testclass }}.{{ test.method }}"><a href="/tests/method/{{ test.method.id }}">{{ test.method.testclass }}.{{ test.method }}</a></h3>
+        <h3 class="slds-truncate slds-text-heading--small" title="{{ test.method.testclass }}.{{ test.method }}"><a href="/tests/result/{{ test.id }}">{{ test.method.testclass }}.{{ test.method }}</a></h3>
         <h4><a href="/tests/trend/method/{{ test.method.id }}">Trend</a></h4>
         <div class="slds-tile__detail slds-text-body--small">
           <dl class="slds-list--horizontal slds-wrap">


### PR DESCRIPTION
When viewing the Tests tab of a build with failing tests, the test name should link to the results instead of the history view for the method.