### PR TITLE
Fix FlowTask.__str__ following flowrunner refactor

### DIFF
--- a/metaci/build/models.py
+++ b/metaci/build/models.py
@@ -715,7 +715,7 @@ class FlowTask(models.Model):
     objects = FlowTaskManager()
 
     def __str__(self):
-        return "{}: {} - {}".format(self.build_flow_id, self.stepnum, self.name)
+        return "{}: {} - {}".format(self.build_flow_id, self.stepnum, self.path)
 
     class Meta:
         ordering = ["-build_flow", "stepnum"]


### PR DESCRIPTION
This field got renamed without updating this line to use the new name.