### PR TITLE
Run tests with pytest instead of nose

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,3 @@
 [run]
 include = metaci/*
 omit = *migrations*, *tests*
-plugins =
-    django_coverage_plugin

--- a/.gitignore
+++ b/.gitignore
@@ -35,8 +35,8 @@ npm-debug.log*
 # Unit test / coverage reports
 .coverage
 .tox
-nosetests.xml
 htmlcov
+*.tap
 
 # Translations
 *.mo

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -85,6 +85,15 @@ LOCAL_APPS = (
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#installed-apps
 INSTALLED_APPS = DJANGO_APPS + THIRD_PARTY_APPS + LOCAL_APPS
 
+ALLOWED_HOSTS = [
+    "127.0.0.1",
+    "127.0.0.1:8000",
+    "127.0.0.1:8080",
+    "localhost",
+    "localhost:8000",
+    "localhost:8080",
+]
+
 # MIDDLEWARE CONFIGURATION
 # ------------------------------------------------------------------------------
 MIDDLEWARE = (

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -14,6 +14,9 @@ from .common import *  # noqa
 DEBUG = False
 TEMPLATES[0]["OPTIONS"]["debug"] = False
 
+# Allow requests with Host: testserver
+ALLOWED_HOSTS = ['testserver']
+
 # SECRET CONFIGURATION
 # ------------------------------------------------------------------------------
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#secret-key
@@ -44,14 +47,6 @@ RQ_QUEUES = {
     "default": {"URL": REDIS_URL, "DEFAULT_TIMEOUT": 7200, "AUTOCOMMIT": False},
     "short": {"URL": REDIS_URL, "DEFAULT_TIMEOUT": 500, "AUTOCOMMIT": False},
 }
-
-# Add django_nose to INSTALLED_APPS
-INSTALLED_APPS = INSTALLED_APPS + ("django_nose",)
-
-# TESTING
-# ------------------------------------------------------------------------------
-TEST_RUNNER = "django_nose.NoseTestSuiteRunner"
-NOSE_ARGS = ["--with-tap", "--tap-stream", "--with-coverage", "--cover-package=metaci"]
 
 
 # PASSWORD HASHING

--- a/heroku_ci.sh
+++ b/heroku_ci.sh
@@ -5,7 +5,7 @@ git clone -b "$HEROKU_TEST_RUN_BRANCH" --single-branch https://github.com/SFDO-T
 cd MetaCI_checkout
 git reset --hard $HEROKU_TEST_RUN_COMMIT_VERSION
 export DJANGO_SETTINGS_MODULE=config.settings.test
-python manage.py test
+coverage run $(which pytest) --tap-stream
 exit_status=$?
 coveralls
 if [ "$exit_status" != "0" ]; then

--- a/metaci/api/tests.py
+++ b/metaci/api/tests.py
@@ -1,7 +1,6 @@
 from rest_framework.reverse import reverse
 from test_plus.test import TestCase
 
-
 class TestURLReversals(TestCase):
     """Test URL patterns for APIs app."""
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
-DJANGO_SETTINGS_MODULE=config.settings.local
+DJANGO_SETTINGS_MODULE=config.settings.test
+python_files = test*.py

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -12,6 +12,3 @@ django-debug-toolbar==1.11
 
 # improved REPL
 ipdb==0.11
-
-pytest-django==3.4.8
-# pytest-sugar==0.9.2

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,13 +2,10 @@
 -r base.txt
 
 pytest==4.3.0
+pytest-django==3.4.8
+pytest-tap==2.3
 coverage==4.5.3
-django_coverage_plugin==1.6.0
+coveralls==1.6.0
 flake8==3.7.7
 django-test-plus==1.1.1
 factory_boy==2.11.1
-
-# nosetests with support for TAP and coveralls
-django_nose==1.4.6
-nose-tap==1.9
-coveralls==1.6.0


### PR DESCRIPTION
Switching to pytest because nose-tap errors out on Python 3 when there's a test failure, and nose is generally unmaintained.

`./manage.py test` is no longer the recommended way to run the tests. Instead just run `pytest`.

Also adding a default ALLOWED_HOSTS setting that allows local access.