### PR TITLE
Quiet pytest warnings relating to certain classes.

### DIFF
--- a/metaci/api/tests/test_testmethod_perf.py
+++ b/metaci/api/tests/test_testmethod_perf.py
@@ -1,4 +1,5 @@
 from metaci.conftest import StaffSuperuserFactory, TestResultFactory
+import pytest
 
 from urllib.parse import urlencode
 import random
@@ -49,6 +50,7 @@ class _TestingHelpers:
             TestResultFactory(**fields, build_flow__tests_total=1, method=t1.method)
 
 
+@pytest.mark.filterwarnings("ignore: Using the add method")
 class TestTestMethodPerfRESTAPI(APITestCase, _TestingHelpers):
     """Test the testmethodperf REST API"""
 
@@ -309,6 +311,7 @@ class TestTestMethodPerfRESTAPI(APITestCase, _TestingHelpers):
             self.assertIn(row["method_name"], ["Bar2", "Bar3"])
             self.assertNotIn(row["method_name"], ["Bar1", "Bar4"])
 
+    @pytest.mark.filterwarnings("ignore:DateTimeField")
     def test_filter_by_recent_date(self):
         yesterday = timezone.make_aware(datetime.today() - timedelta(1))
         day_before = timezone.make_aware(datetime.today() - timedelta(2))

--- a/metaci/api/views/testmethod_perf.py
+++ b/metaci/api/views/testmethod_perf.py
@@ -145,6 +145,8 @@ class BuildFlowFilterSet(TurnFilterSetOffByDefaultBase):
 class TestMethodPerfFilter(BuildFlowFilterSet, django_filters.rest_framework.FilterSet):
     """This filterset works on the output queries"""
 
+    __test__ = False  # Tell pytest that this is not a test.
+
     method_name = django_filters.rest_framework.CharFilter(
         field_name="method_name", label="Method Name"
     )
@@ -223,6 +225,8 @@ class TestMethodPerfListView(generics.ListAPIView, viewsets.ViewSet):
     Note that the number of build flows covered is limited to **BUILD_FLOWS_LIMIT** for performance reasons. You can
     change this default with the build_flows_limit parameter.
     """
+
+    __test__ = False  # Tell pytest that this is not a test.
 
     serializer_class = SimpleDictSerializer
     filter_backends = (django_filters.rest_framework.DjangoFilterBackend,)

--- a/metaci/testresults/models.py
+++ b/metaci/testresults/models.py
@@ -11,6 +11,7 @@ from metaci.testresults.choices import TEST_TYPE_CHOICES
 
 
 class TestClass(models.Model):
+    __test__ = False  # Tell pytest that this is not a test.
     name = models.CharField(max_length=255, db_index=True)
     test_type = models.CharField(
         max_length=32, choices=TEST_TYPE_CHOICES, db_index=True
@@ -28,6 +29,7 @@ class TestClass(models.Model):
 
 
 class TestMethod(models.Model):
+    __test__ = False  # Not a unit test
     name = models.CharField(max_length=255, db_index=True)
     testclass = models.ForeignKey(
         TestClass, related_name="methods", on_delete=models.CASCADE
@@ -43,6 +45,8 @@ class TestMethod(models.Model):
 
 
 class TestResultManager(models.Manager):
+    __test__ = False  # Not a unit test
+
     def update_summary_fields(self):
         for summary in self.all():
             summary.update_summary_fields()
@@ -51,10 +55,11 @@ class TestResultManager(models.Manager):
 
         results = OrderedDict()
         for build_flow in build_flows:
-            test_results = build_flow.test_results \
-                .select_related('method') \
-                .select_related('method__testclass') \
+            test_results = (
+                build_flow.test_results.select_related("method")
+                .select_related("method__testclass")
                 .all()
+            )
             for result in test_results:
                 cls = result.method.testclass.name
                 method = result.method.name
@@ -97,6 +102,7 @@ class TestResultManager(models.Manager):
 
 
 class TestResult(models.Model):
+    __test__ = False  # Tell pytest that this is not a test.
     build_flow = models.ForeignKey(
         "build.BuildFlow", related_name="test_results", on_delete=models.CASCADE
     )
@@ -149,29 +155,15 @@ class TestResult(models.Model):
     callouts_used = models.IntegerField(null=True, blank=True)
     callouts_allowed = models.IntegerField(null=True, blank=True)
     callouts_percent = models.IntegerField(null=True, blank=True)
-    test_email_invocations_used = models.IntegerField(
-        null=True, blank=True
-    )
-    test_email_invocations_allowed = models.IntegerField(
-        null=True, blank=True
-    )
-    test_email_invocations_percent = models.IntegerField(
-        null=True, blank=True
-    )
+    test_email_invocations_used = models.IntegerField(null=True, blank=True)
+    test_email_invocations_allowed = models.IntegerField(null=True, blank=True)
+    test_email_invocations_percent = models.IntegerField(null=True, blank=True)
     test_soql_queries_used = models.IntegerField(null=True, blank=True)
-    test_soql_queries_allowed = models.IntegerField(
-        null=True, blank=True
-    )
-    test_soql_queries_percent = models.IntegerField(
-        null=True, blank=True
-    )
+    test_soql_queries_allowed = models.IntegerField(null=True, blank=True)
+    test_soql_queries_percent = models.IntegerField(null=True, blank=True)
     test_future_calls_used = models.IntegerField(null=True, blank=True)
-    test_future_calls_allowed = models.IntegerField(
-        null=True, blank=True
-    )
-    test_future_calls_percent = models.IntegerField(
-        null=True, blank=True
-    )
+    test_future_calls_allowed = models.IntegerField(null=True, blank=True)
+    test_future_calls_percent = models.IntegerField(null=True, blank=True)
     test_dml_rows_used = models.IntegerField(null=True, blank=True)
     test_dml_rows_allowed = models.IntegerField(null=True, blank=True)
     test_dml_rows_percent = models.IntegerField(null=True, blank=True)
@@ -182,38 +174,20 @@ class TestResult(models.Model):
     test_query_rows_allowed = models.IntegerField(null=True, blank=True)
     test_query_rows_percent = models.IntegerField(null=True, blank=True)
     test_dml_statements_used = models.IntegerField(null=True, blank=True)
-    test_dml_statements_allowed = models.IntegerField(
-        null=True, blank=True
-    )
-    test_dml_statements_percent = models.IntegerField(
-        null=True, blank=True
-    )
-    test_mobile_apex_push_used = models.IntegerField(
-        null=True, blank=True
-    )
-    test_mobile_apex_push_allowed = models.IntegerField(
-        null=True, blank=True
-    )
-    test_mobile_apex_push_percent = models.IntegerField(
-        null=True, blank=True
-    )
+    test_dml_statements_allowed = models.IntegerField(null=True, blank=True)
+    test_dml_statements_percent = models.IntegerField(null=True, blank=True)
+    test_mobile_apex_push_used = models.IntegerField(null=True, blank=True)
+    test_mobile_apex_push_allowed = models.IntegerField(null=True, blank=True)
+    test_mobile_apex_push_percent = models.IntegerField(null=True, blank=True)
     test_heap_size_used = models.IntegerField(null=True, blank=True)
     test_heap_size_allowed = models.IntegerField(null=True, blank=True)
     test_heap_size_percent = models.IntegerField(null=True, blank=True)
     test_sosl_queries_used = models.IntegerField(null=True, blank=True)
-    test_sosl_queries_allowed = models.IntegerField(
-        null=True, blank=True
-    )
-    test_sosl_queries_percent = models.IntegerField(
-        null=True, blank=True
-    )
+    test_sosl_queries_allowed = models.IntegerField(null=True, blank=True)
+    test_sosl_queries_percent = models.IntegerField(null=True, blank=True)
     test_queueable_jobs_used = models.IntegerField(null=True, blank=True)
-    test_queueable_jobs_allowed = models.IntegerField(
-        null=True, blank=True
-    )
-    test_queueable_jobs_percent = models.IntegerField(
-        null=True, blank=True
-    )
+    test_queueable_jobs_allowed = models.IntegerField(null=True, blank=True)
+    test_queueable_jobs_percent = models.IntegerField(null=True, blank=True)
     test_callouts_used = models.IntegerField(null=True, blank=True)
     test_callouts_allowed = models.IntegerField(null=True, blank=True)
     test_callouts_percent = models.IntegerField(null=True, blank=True)
@@ -270,6 +244,7 @@ def asset_upload_to(instance, filename):
 
 
 class TestResultAsset(models.Model):
+    __test__ = False  # Tell pytest that this is not a test.
     result = models.ForeignKey(
         TestResult, related_name="assets", on_delete=models.CASCADE
     )

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 DJANGO_SETTINGS_MODULE=config.settings.test
 python_files = test*.py
+norecursedirs = node_modules dist src


### PR DESCRIPTION
Pytest infers that any class with a name starting with the word Test must be a test-case. This checkin quiets warnings relating to certain classes.

Another option would be to disable all classname-based discovery and rely on subclass discovery only.

The pros/cons of that are documented here:

https://stackoverflow.com/a/43349055/11151197

Black also did its thing on some lines.
