### PR TITLE
Switch from Black to Orange

### DIFF
--- a/metaci/build/templates/build/build_list.html
+++ b/metaci/build/templates/build/build_list.html
@@ -45,7 +45,7 @@
       </th>
       <td data-label="Status">
         <div
-          class="slds-truncate slds-badge {% if build.get_status == 'fail'%}slds-theme--error{% elif build.get_status == 'error' %}slds-theme--warning{% elif build.get_status == 'success' %}slds-theme--success{% endif %}"
+          class="slds-truncate slds-badge {% if build.get_status == 'fail'%}slds-theme--error{% elif build.get_status == 'error' %}slds-theme--offline{% elif build.get_status == 'success' %}slds-theme--success{% endif %}"
           title="{{ build.get_status }}">
           {{ build.get_status.upper }}
         </div>

--- a/metaci/build/templates/build/detail_layout.html
+++ b/metaci/build/templates/build/detail_layout.html
@@ -41,7 +41,7 @@
       <p class="slds-text-title slds-truncate slds-m-bottom--xx-small" title="Status">Status</p>
       <p class="slds-text-body--regular slds-truncate" title="{{ build.get_status }}">
         <div
-          class="slds-badge {% if build.get_status == 'fail' %} slds-theme--error {% elif build.get_status == 'error' %}slds-theme--warning{% elif build.get_status == 'success' %}slds-theme--success{% endif %}">
+          class="slds-badge {% if build.get_status == 'fail' %} slds-theme--error {% elif build.get_status == 'error' %}slds-theme--offline{% elif build.get_status == 'success' %}slds-theme--success{% endif %}">
           {{ build.get_status }}
         </div>
       </p>

--- a/metaci/build/templates/build/detail_rebuilds.html
+++ b/metaci/build/templates/build/detail_rebuilds.html
@@ -29,7 +29,7 @@
         <div class="slds-truncate" title="{{ rebuild.id }}"><a href="{{ rebuild.get_absolute_url }}">{{ rebuild.id }}</a></div>
       </th>
       <td data-label="Status">
-        <div class="slds-truncate slds-badge {% if rebuild.status == 'fail'%} slds-theme--error {% elif rebuild.status == 'error' %}slds-theme--warning{% elif rebuild.status == 'success' %}slds-theme--success{% endif %}" title="{{ rebuild.status }}">{{ rebuild.status }}</div>
+        <div class="slds-truncate slds-badge {% if rebuild.status == 'fail'%} slds-theme--error {% elif rebuild.status == 'error' %}slds-theme--offline{% elif rebuild.status == 'success' %}slds-theme--success{% endif %}" title="{{ rebuild.status }}">{{ rebuild.status }}</div>
       </td>
       <th data-label="User">
         <div class="slds-truncate" title="{{ rebuild.user }}">{{ rebuild.user }}</div>
@@ -51,7 +51,7 @@
       </th>
       <td data-label="Status">
         <div
-          class="slds-truncate slds-badge {% if build.status == 'fail'%} slds-theme--error {% elif build.status == 'error' %}slds-theme--warning{% elif build.status == 'success' %}slds-theme--success{% endif %}"
+          class="slds-truncate slds-badge {% if build.status == 'fail'%} slds-theme--error {% elif build.status == 'error' %}slds-theme--offline{% elif build.status == 'success' %}slds-theme--success{% endif %}"
           title="{{ build.status }}">
           {{ build.status }}
         </div>

--- a/metaci/build/templates/build/detail_tests.html
+++ b/metaci/build/templates/build/detail_tests.html
@@ -1,7 +1,7 @@
 {% extends "build/detail_layout.html" %}
 
 {% block tab_content %}
-<div class="slds-box slds-m-bottom--large {% if tests.fail %}slds-theme--offline{% else %}slds-theme--success{% endif %}">
+<div class="slds-box slds-m-bottom--large {% if tests.fail %}slds-theme--error{% else %}slds-theme--success{% endif %}">
   <h3 class="slds-text-heading--large">{{ tests.pass }} of {{ tests.total }} tests passed</h3>
 </div>
 {% if tests.fail %}

--- a/metaci/build/templates/build/detail_tests.html
+++ b/metaci/build/templates/build/detail_tests.html
@@ -1,7 +1,7 @@
 {% extends "build/detail_layout.html" %}
 
 {% block tab_content %}
-<div class="slds-box slds-m-bottom--large {% if tests.fail %}slds-theme--warning{% else %}slds-theme--success{% endif %}">
+<div class="slds-box slds-m-bottom--large {% if tests.fail %}slds-theme--offline{% else %}slds-theme--success{% endif %}">
   <h3 class="slds-text-heading--large">{{ tests.pass }} of {{ tests.total }} tests passed</h3>
 </div>
 {% if tests.fail %}

--- a/metaci/cumulusci/templates/cumulusci/org_detail.html
+++ b/metaci/cumulusci/templates/cumulusci/org_detail.html
@@ -100,7 +100,7 @@
           </th>
           <td data-label="Status">
             <div
-              class="slds-truncate slds-badge {% if build.get_status == 'fail'%} slds-theme--error{% elif build.get_status == 'error' %}slds-theme--warning{% elif build.get_status == 'success' %}slds-theme--success{% endif %}"
+              class="slds-truncate slds-badge {% if build.get_status == 'fail'%} slds-theme--error{% elif build.get_status == 'error' %}slds-theme--offline{% elif build.get_status == 'success' %}slds-theme--success{% endif %}"
               title="{{ build.get_status }}">
               {{ build.get_status }}
             </div>
@@ -133,7 +133,7 @@
       </tbody>
     </table>
     {% include 'build/build_pagination.html' %}
-    
+
   </div>
 </div>
 

--- a/metaci/cumulusci/templates/cumulusci/org_instance_detail.html
+++ b/metaci/cumulusci/templates/cumulusci/org_instance_detail.html
@@ -95,7 +95,7 @@
           </th>
           <td data-label="Status">
             <div
-              class="slds-truncate slds-badge {% if build.get_status == 'fail' %}  slds-theme--error {% elif build.get_status == 'error' %}slds-theme--warning{% elif build.get_status == 'success' %}slds-theme--success{% endif %}"
+              class="slds-truncate slds-badge {% if build.get_status == 'fail' %}  slds-theme--error {% elif build.get_status == 'error' %}slds-theme--offline{% elif build.get_status == 'success' %}slds-theme--success{% endif %}"
               title="{{ build.get_status }}">
               {{ build.get_status }}
             </div>
@@ -120,7 +120,7 @@
       </tbody>
     </table>
     {% include 'build/build_pagination.html' %}
-    
+
   </div>
 </div>
 

--- a/metaci/plan/templates/plan/detail.html
+++ b/metaci/plan/templates/plan/detail.html
@@ -121,7 +121,7 @@
         <div class="slds-truncate" title="{{ build.id }}"><a href="/builds/{{ build.id }}">{{ build.id }}</a></div>
       </th>
       <td data-label="Status">
-        <div class="slds-truncate slds-badge {% if build.get_status == 'fail'%} slds-theme--error {%elif build.get_status == 'error' %}slds-theme--warning{% elif build.get_status == 'success' %}slds-theme--success{% endif %}"
+        <div class="slds-truncate slds-badge {% if build.get_status == 'fail'%} slds-theme--error {%elif build.get_status == 'error' %}slds-theme--offline{% elif build.get_status == 'success' %}slds-theme--success{% endif %}"
           title="{{ build.get_status }}">{{ build.get_status }}</div>
       </td>
       <td data-label="Repository">

--- a/metaci/plan/templates/plan/plan_repo_detail.html
+++ b/metaci/plan/templates/plan/plan_repo_detail.html
@@ -6,7 +6,7 @@
 
 {% block layout_header_details %}
   <ul class="slds-grid slds-page-header__detail-row">
-  
+
     <li class="slds-page-header__detail-block">
       <p class="slds-text-title slds-truncate slds-m-bottom--xx-small" title="Repository">Repository</p>
       <p class="slds-text-body--regular slds-truncate" title="{{ repo.name }}">
@@ -98,7 +98,7 @@
         <div class="slds-truncate" title="{{ build.id }}"><a href="/builds/{{ build.id }}">{{ build.id }}</a></div>
       </th>
       <td data-label="Status">
-        <div class="slds-truncate slds-badge {% if build.get_status == 'fail' %} slds-theme--error {% elif build.get_status == 'error' %}slds-theme--warning{% elif build.get_status == 'success' %}slds-theme--success{% endif %}" title="{{ build.get_status }}">{{ build.get_status }}</div>
+        <div class="slds-truncate slds-badge {% if build.get_status == 'fail' %} slds-theme--error {% elif build.get_status == 'error' %}slds-theme--offline{% elif build.get_status == 'success' %}slds-theme--success{% endif %}" title="{{ build.get_status }}">{{ build.get_status }}</div>
       </td>
       <td data-label="Commit">
         <div class="slds-truncate" title="{{ build.commit }}">{{ build.commit }}</div>

--- a/metaci/repository/templates/repository/branch_detail.html
+++ b/metaci/repository/templates/repository/branch_detail.html
@@ -47,7 +47,7 @@
       </th>
       <td data-label="Status">
         <div
-          class="slds-truncate slds-badge {% if build.get_status == 'fail'%}  slds-theme--error {% elif build.get_status == 'error' %}slds-theme--warning{% elif build.get_status == 'success' %}slds-theme--success{% endif %}"
+          class="slds-truncate slds-badge {% if build.get_status == 'fail'%}  slds-theme--error {% elif build.get_status == 'error' %}slds-theme--offline{% elif build.get_status == 'success' %}slds-theme--success{% endif %}"
           title="{{ build.get_status }}">
           {{ build.get_status }}
         </div>

--- a/metaci/repository/templates/repository/commit_detail.html
+++ b/metaci/repository/templates/repository/commit_detail.html
@@ -47,7 +47,7 @@
       </th>
       <td data-label="Status">
         <div
-          class="slds-truncate slds-badge {% if build.get_status == 'fail' %} slds-theme--error {% elif build.get_status == 'error' %}slds-theme--warning{% elif build.get_status == 'success' %}slds-theme--success{% endif %}"
+          class="slds-truncate slds-badge {% if build.get_status == 'fail' %} slds-theme--error {% elif build.get_status == 'error' %}slds-theme--offline{% elif build.get_status == 'success' %}slds-theme--success{% endif %}"
           title="{{ build.get_status }}">
           {{ build.get_status }}
         </div>

--- a/metaci/repository/templates/repository/repo_detail.html
+++ b/metaci/repository/templates/repository/repo_detail.html
@@ -61,7 +61,7 @@
             <div class="slds-truncate" title="{{ build.id }}"><a href="/builds/{{ build.id }}">{{ build.id }}</a></div>
           </th>
           <td data-label="Status">
-            <div class="slds-truncate slds-badge {% if build.get_status == 'fail' %} slds-theme--error {% elif build.get_status == 'error' %} slds-theme--warning {% elif build.get_status == 'success' %}slds-theme--success{% endif %}" title="{{ build.get_status }}">{{ build.get_status }}</div>
+            <div class="slds-truncate slds-badge {% if build.get_status == 'fail' %} slds-theme--error {% elif build.get_status == 'error' %} slds-theme--offline {% elif build.get_status == 'success' %}slds-theme--success{% endif %}" title="{{ build.get_status }}">{{ build.get_status }}</div>
           </td>
           <td data-label="Plan">
             <div class="slds-truncate" title="{{ build.plan }}">{{ build.plan }}</div>


### PR DESCRIPTION
David and Jason (?) preferred Black to Orange for builds failed due to build infrastructure problems. i.e. "ERROR" rather than "FAIL" builds.