### PR TITLE
Feature/fix page load initialization

### DIFF
--- a/src/js/components/perfTable.js
+++ b/src/js/components/perfTable.js
@@ -115,8 +115,6 @@ export const UnwrappedPerfTable = ({doPerfRESTFetch, doPerfREST_UI_Fetch,
       changeUrl({ repo });
       doPerfRESTFetch(null, { ...queryParts(), repo });
       doPerfREST_UI_Fetch();
-
-      changeUrl({ repo: pathParts[pathParts.length - 2] });
     }, []);
 
     var items;

--- a/src/js/components/perfTable.js
+++ b/src/js/components/perfTable.js
@@ -106,14 +106,17 @@ export const UnwrappedPerfTable = ({doPerfRESTFetch, doPerfREST_UI_Fetch,
     let changeUrl = queryparams.set;
 
     useEffect(() => {
-      doPerfRESTFetch(null, queryParts());
-      doPerfREST_UI_Fetch();
-      let pathParts = window.location.pathname.split("/");
-
       /* Special case for getting repo name from URL
-        * path into query params with other filters
-        */
-      changeUrl({repo: pathParts[pathParts.length-2]})
+       * path into query params with other filters
+       */
+
+      let pathParts = window.location.pathname.split('/');
+      let repo = pathParts[pathParts.length - 2];
+      changeUrl({ repo });
+      doPerfRESTFetch(null, { ...queryParts(), repo });
+      doPerfREST_UI_Fetch();
+
+      changeUrl({ repo: pathParts[pathParts.length - 2] });
     }, []);
 
     var items;


### PR DESCRIPTION
Fairly embarrassing bug that had the app behaving differently on page load than thereafter because things were initialized in the wrong order. The URL bar is supposed to have information that if used to do the server query.

I keep information in the URL bar so that page states can be shared.