### PR TITLE
📦 Remove sentry-sdk

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -85,7 +85,3 @@ django-postgres-stats==1.0.0
 
 # Let Javascript refer to Django URLs by name
 django-js-reverse==0.8.2
-
-# Sentry
-sentry-sdk==0.7.10
-

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.7.1
+python-3.7.2


### PR DESCRIPTION
Currently we are getting build errors reported to sentry twice: once by cumulusci, and once by django-rq. Removing sentry-sdk will prevent django-rq's reporting.

The bump to the Python version is partly to avoid Heroku's cache of the site-packages so the package actually goes away, but it's overdue anyway.