### PR TITLE
Disable sentry in default queue workers

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,5 +1,5 @@
 web: gunicorn config.wsgi:application
-worker: python manage.py rqworker default --worker-class metaci.build.worker.RequeueingWorker
+worker: python manage.py rqworker default --worker-class metaci.build.worker.RequeueingWorker --sentry-dsn=""
 worker_short: honcho start -f Procfile_worker_short
 dev_worker: honcho start -f Procfile_dev_worker
 release: python manage.py migrate --noinput

--- a/Procfile_dev_worker
+++ b/Procfile_dev_worker
@@ -1,3 +1,3 @@
-worker_dev: python manage.py rqworker default --worker-class metaci.build.worker.RequeueingWorker 
-worker_short_dev: python manage.py rqworker short --worker-class metaci.build.worker.RequeueingWorker 
-worker_scheduler: python manage.py rqscheduler 
+worker_dev: python manage.py rqworker default --worker-class metaci.build.worker.RequeueingWorker --sentry-dsn=""
+worker_short_dev: python manage.py rqworker short --worker-class metaci.build.worker.RequeueingWorker
+worker_scheduler: python manage.py rqscheduler

--- a/Procfile_worker_short
+++ b/Procfile_worker_short
@@ -1,3 +1,3 @@
-worker_short_a: python manage.py rqworker short --worker-class metaci.build.worker.RequeueingWorker
+worker_short_a: python manage.py rqworker short --worker-class metaci.build.worker.RequeueingWorker --sentry-dsn=""
 worker_short_b: python manage.py rqworker short --worker-class metaci.build.worker.RequeueingWorker
 worker_scheduler: python manage.py rqscheduler


### PR DESCRIPTION
The newest version of django-rq tries to set up reporting to Sentry using sentry-sdk if SENTRY_DSN is configured in Django settings, and then it breaks when sentry-sdk is not installed.

We still need SENTRY_DSN for the web dyno, but this should disable it for the worker (which already reports failed flows to sentry in CumulusCI).