### PR TITLE
Add a way to skip release-phase django migrations using an environment variable

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -2,4 +2,4 @@ web: gunicorn config.wsgi:application
 worker: python manage.py rqworker default --worker-class metaci.build.worker.RequeueingWorker --sentry-dsn=""
 worker_short: honcho start -f Procfile_worker_short
 dev_worker: honcho start -f Procfile_dev_worker
-release: python manage.py migrate --noinput
+release: ./release.sh

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,2 @@
+# Run Django migrations unless disabled
+[ -z $SKIP_DJANGO_MIGRATIONS ] && python manage.py migrate --noinput


### PR DESCRIPTION
This paves the way to running worker dynos in a separate app so that we can deploy the web app without interrupting builds in progress, without worrying about accidentally running the migration in both apps concurrently.

The web app will be deployed more frequently and always run the migrations. The worker app will only be deployed when necessary and can assume the migrations were already run.

When deploying both apps at the same time, it's mostly okay if the worker app starts
before the migrations are complete because no builds will be triggered until the web app is being served. Although there's a small risk of scheduled jobs running too early. If that's unacceptable we'll need a more complex solution with a db-level lock.