### PR TITLE
Default branch for dramatically faster page load

### DIFF
--- a/src/js/components/perfPages/perfPage.js
+++ b/src/js/components/perfPages/perfPage.js
@@ -72,8 +72,9 @@ export const UnwrappedPerfPage = ({
      */
     const pathParts = window.location.pathname.split('/');
     const repo = pathParts[pathParts.length - 2];
-    queryparams.set({ repo });
-    doPerfRESTFetch({ ...queryparams.getAll(), repo });
+    const branch = 'master';
+    queryparams.set({ repo, branch });
+    doPerfRESTFetch({ ...queryparams.getAll(), repo, branch });
     doPerfREST_UI_Fetch();
   }, []);
 


### PR DESCRIPTION
The initial page load for Cumulus is horrendous because it has so many branches. Limiting to the master branch provides 95% of the benefit and the page load is much faster.