### PR TITLE
Various small metaci perf viewer cleanups

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -172,4 +172,3 @@ Sentry is an error logging aggregator service. You can sign up for a free accoun
 The system is setup with reasonable defaults, including 404 logging and integration with the WSGI application.
 
 Setting the Sentry DSN in production is optional but highly recommended.  Having good error management for your CI app is really nice!
-

--- a/metaci/api/tests/test_testmethod_perf_UI.py
+++ b/metaci/api/tests/test_testmethod_perf_UI.py
@@ -67,7 +67,6 @@ class TestTestMethodPerfUI_RESTAPI(APITestCase, _TestingHelpers):
         other_buildflow_filters = buildflow_filters["other_buildflow_filters"]
 
         self.assertIn("daterange", other_buildflow_filters)
-        self.assertIn("build_flows_limit", other_buildflow_filters)
 
         self.assertIn("Repo1", keys(choice_filters["repo"]["choices"]))
         self.assertIn("Repo2", keys(choice_filters["repo"]["choices"]))

--- a/metaci/api/views/testmethod_perf.py
+++ b/metaci/api/views/testmethod_perf.py
@@ -17,7 +17,6 @@ from django.db import connection
 
 
 class DEFAULTS:
-    build_flows_limit = 100
     page_size = 50
     max_page_size = 100
 
@@ -98,12 +97,6 @@ class BuildFlowFilterSet(django_filters.rest_framework.FilterSet):
         field_name="week_start",
         label="Date range",
         widget=DateRangeWidget(attrs={"type": "date"}),
-    )
-
-    # This is not really a filter. It's actually just a query input but putting it
-    # here lets me get it in the django-filters form.
-    build_flows_limit = django_filters.rest_framework.NumberFilter(
-        method="dummy_filter", label="Build Flows Limit (default: 100)"
     )
 
     def dummy_filter(self, queryset, name, value):

--- a/metaci/api/views/testmethod_perf.py
+++ b/metaci/api/views/testmethod_perf.py
@@ -19,6 +19,7 @@ from django.db import connection
 class DEFAULTS:
     page_size = 50
     max_page_size = 100
+    branch = "master"
 
 
 def set_timeout(timeout):

--- a/src/js/components/perfPages/perfPage.js
+++ b/src/js/components/perfPages/perfPage.js
@@ -71,10 +71,12 @@ export const UnwrappedPerfPage = ({
      * path into query params with other filters
      */
     const pathParts = window.location.pathname.split('/');
-    const repo = pathParts[pathParts.length - 2];
-    const branch = 'master';
+    const default_repo = pathParts[pathParts.length - 2];
+    const default_branch = 'master';
+    const repo = (queryparams.get('repo') || default_repo).toString();
+    const branch = (queryparams.get('branch') || default_branch).toString();
     queryparams.set({ repo, branch });
-    doPerfRESTFetch({ ...queryparams.getAll(), repo, branch });
+    doPerfRESTFetch({ repo, branch, ...queryparams.getAll() });
     doPerfREST_UI_Fetch();
   }, []);
 

--- a/src/js/components/perfPages/perfPage.js
+++ b/src/js/components/perfPages/perfPage.js
@@ -71,12 +71,9 @@ export const UnwrappedPerfPage = ({
      * path into query params with other filters
      */
     const pathParts = window.location.pathname.split('/');
-    const default_repo = pathParts[pathParts.length - 2];
-    const default_branch = 'master';
-    const repo = (queryparams.get('repo') || default_repo).toString();
-    const branch = (queryparams.get('branch') || default_branch).toString();
-    queryparams.set({ repo, branch });
-    doPerfRESTFetch({ repo, branch, ...queryparams.getAll() });
+    const repo = pathParts[pathParts.length - 2];
+    queryparams.set({ repo });
+    doPerfRESTFetch({ ...queryparams.getAll() });
     doPerfREST_UI_Fetch();
   }, []);
 

--- a/src/js/components/perfPages/perfTableOptionsUI.js
+++ b/src/js/components/perfPages/perfTableOptionsUI.js
@@ -98,7 +98,7 @@ const PerfTableOptionsUI: ComponentType<Props & ReduxProps> = ({
   // arrived
   const filters = uiAvailable ? gatherFilters(testMethodPerfUI) : [];
 
-  const exclude = ['o', 'include_fields', 'build_flows_limit'];
+  const exclude = ['o', 'include_fields'];
   const filterPanelFilters = filters.filter(
     filter => !exclude.includes(filter.name),
   );

--- a/src/js/components/perfPages/perfTableOptionsUI.js
+++ b/src/js/components/perfPages/perfTableOptionsUI.js
@@ -196,15 +196,38 @@ const PerfTableOptionsUI: ComponentType<Props & ReduxProps> = ({
   );
 };
 
-const AllFilters = ({ filters }: { filters: Field[] }) => (
-  <div key="filterGrid" className="slds-grid slds-wrap slds-gutters">
-    {filters.map(filter => (
-      <div key={filter.name} className="slds-col slds-size_3-of-12">
-        {filter.render()}
-      </div>
-    ))}
-  </div>
-);
+// This is a gross hack but its a legitimately hard problem: the server
+// controls what fields it sends but the client needs to make it look nice.
+// I need the fourth field (which I know is "Success Percentage") to wrap
+// to the next line.
+//
+// There is no good place to put the responsibility for deciding how to lay
+// things out. In the future we will use a filter UI more like Salesforce's
+// and this hack can go away.
+//
+// Essentially random layout of server fields is why so many enterprise apps
+// look horrible. This small hack is a compromise. It means that the client
+// and server are more tightly bound then they otherwise would be. Adding
+// or removing fields requires a change here.
+const spacerField = {
+  name: 'Blank "field" to space things out',
+  currentValue: '',
+  render: () => <span />,
+};
+
+const AllFilters = ({ filters }: { filters: Field[] }) => {
+  // Yes...this is gross. I'm sorry.
+  filters.splice(3, 0, spacerField);
+  return (
+    <div key="filterGrid" className="slds-grid slds-wrap slds-gutters">
+      {filters.map(filter => (
+        <div key={filter.name} className="slds-col slds-size_3-of-12">
+          {filter.render()}
+        </div>
+      ))}
+    </div>
+  );
+};
 
 const select = (appState: AppState) => ({
   perfUIStatus: selectPerfUIStatus(appState),


### PR DESCRIPTION
3 unrelated commits.

One is a hack to clean up the UI and keep some related fields together on the same line. There are better ways but this UI will be replaced in the not too distant future and the better ways would involve more code to delete later.

The second deletes the last references to a feature that was obsoleted a month ago.

The last cleans up the URL handling to ensure that links can be passed around reliably.
