### PR TITLE
Planrepos autopopulate

### DIFF
--- a/metaci/build/models.py
+++ b/metaci/build/models.py
@@ -173,9 +173,9 @@ class Build(models.Model):
         super().save(*args, **kwargs)
 
     def _populate_planrepo(self):
-        if self.plan and self.repo and not self.planrepo:
+        if self.plan_id and self.repo_id and not self.planrepo:
             PlanRepository = apps.get_model("plan.PlanRepository")
-            self.planrepo = PlanRepository.objects.get_or_create(
+            self.planrepo, created = PlanRepository.objects.get_or_create(
                 plan=self.plan, repo=self.repo
             )
 

--- a/metaci/build/models.py
+++ b/metaci/build/models.py
@@ -166,18 +166,20 @@ class Build(models.Model):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._populate_planrepo()
+        self._try_populate_planrepo()
 
     def save(self, *args, **kwargs):
-        self._populate_planrepo()
+        self._try_populate_planrepo()
         super().save(*args, **kwargs)
 
-    def _populate_planrepo(self):
+    def _try_populate_planrepo(self):
         if self.plan_id and self.repo_id and not self.planrepo:
             PlanRepository = apps.get_model("plan.PlanRepository")
-            self.planrepo, created = PlanRepository.objects.get_or_create(
+            matching_repo = PlanRepository.objects.filter(
                 plan=self.plan, repo=self.repo
             )
+            if matching_repo.exists():
+                self.planrepo = matching_repo[0]
 
     def __str__(self):
         return '{}: {} - {}'.format(self.id, self.repo, self.commit)

--- a/metaci/build/models.py
+++ b/metaci/build/models.py
@@ -164,6 +164,21 @@ class Build(models.Model):
             ('search_builds', 'Search Builds'),
         )
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._populate_planrepo()
+
+    def save(self, *args, **kwargs):
+        self._populate_planrepo()
+        super().save(*args, **kwargs)
+
+    def _populate_planrepo(self):
+        if self.plan and self.repo and not self.planrepo:
+            PlanRepository = apps.get_model("plan.PlanRepository")
+            self.planrepo = PlanRepository.objects.get_or_create(
+                plan=self.plan, repo=self.repo
+            )
+
     def __str__(self):
         return '{}: {} - {}'.format(self.id, self.repo, self.commit)
 

--- a/metaci/build/test_models.py
+++ b/metaci/build/test_models.py
@@ -12,8 +12,7 @@ from metaci.conftest import (
 # Create your tests here.
 class BuildTestCase(TestCase):
     def test_empty_build_init(self):
-        build = Build()
-        self.assertTrue(build)
+        Build()
 
     def test_scheduled_build_init(self):
         repo = RepositoryFactory()

--- a/metaci/build/test_models.py
+++ b/metaci/build/test_models.py
@@ -20,6 +20,9 @@ class BuildTestCase(TestCase):
         branch = BranchFactory(name="branch", repo=repo)
         schedule = PlanScheduleFactory(branch=branch)
         plan = PlanFactory()
+
+        planrepo = PlanRepositoryFactory(plan=plan, repo=repo)
+
         build = Build(
             repo=branch.repo,
             plan=plan,
@@ -28,15 +31,8 @@ class BuildTestCase(TestCase):
             schedule=schedule,
             build_type="scheduled",
         )
-        self.assertTrue(build.planrepo)
+        self.assertEqual(build.planrepo, planrepo)
         build.save()
-
-    def test_planrepo_create_on_build_init(self):
-        repo = RepositoryFactory()
-        plan = PlanFactory()
-
-        build = Build(repo=repo, plan=plan)
-        self.assertTrue(build.planrepo)
 
     def test_planrepo_find_on_build_init(self):
         repo = RepositoryFactory()

--- a/metaci/build/test_models.py
+++ b/metaci/build/test_models.py
@@ -1,0 +1,47 @@
+from django.test import TestCase
+from metaci.build.models import Build
+from metaci.conftest import (
+    RepositoryFactory,
+    BranchFactory,
+    PlanFactory,
+    PlanRepositoryFactory,
+    PlanScheduleFactory,
+)
+
+
+# Create your tests here.
+class BuildTestCase(TestCase):
+    def test_empty_build_init(self):
+        build = Build()
+        self.assertTrue(build)
+
+    def test_scheduled_build_init(self):
+        repo = RepositoryFactory()
+        branch = BranchFactory(name="branch", repo=repo)
+        schedule = PlanScheduleFactory(branch=branch)
+        plan = PlanFactory()
+        build = Build(
+            repo=branch.repo,
+            plan=plan,
+            branch=branch,
+            commit="shashasha",
+            schedule=schedule,
+            build_type="scheduled",
+        )
+        self.assertTrue(build.planrepo)
+        build.save()
+
+    def test_planrepo_create_on_build_init(self):
+        repo = RepositoryFactory()
+        plan = PlanFactory()
+
+        build = Build(repo=repo, plan=plan)
+        self.assertTrue(build.planrepo)
+
+    def test_planrepo_find_on_build_init(self):
+        repo = RepositoryFactory()
+        plan = PlanFactory()
+        planrepo = PlanRepositoryFactory(plan=plan, repo=repo)
+
+        build = Build(repo=repo, plan=plan)
+        self.assertEqual(build.planrepo, planrepo)

--- a/metaci/conftest.py
+++ b/metaci/conftest.py
@@ -6,7 +6,7 @@ import random
 import datetime
 
 
-from metaci.plan.models import Plan, PlanRepository
+from metaci.plan.models import Plan, PlanRepository, PlanSchedule
 from metaci.testresults.models import (
     TestResult,
     TestMethod,
@@ -190,3 +190,11 @@ class UserFactory(factory.django.DjangoModelFactory):
 class StaffSuperuserFactory(UserFactory):
     is_staff = True
     is_superuser = True
+
+
+class PlanScheduleFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = PlanSchedule
+
+    branch = factory.SubFactory(BranchFactory)
+    plan = factory.SubFactory(PlanFactory)


### PR DESCRIPTION
I noticed that scheduled planrepos are not showing up in my review UI.

This turns out to be because they are not getting PlanRepos.

This turns out to be because the old PlanSchedule code that I revived doesn't set the PlanRepo.

This is probably because PlanSchedules predate PlanRepos.

Rather than just set the PlanRepo in the PlanSchedule code, I thought it would be better to fix it at a lower level so that if anyone forgot in any context in the future, the \_\_init\_\_() or save() would infer them.

Of course there were no tests for Build \_\_init\_\_ or save() so I had to add a few of those too...
