### PR TITLE
Make it possible to store Robot Framework screenshots as non-public S3 objects

### DIFF
--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -86,7 +86,9 @@ AWS_ACCESS_KEY_ID = env("DJANGO_AWS_ACCESS_KEY_ID")
 AWS_SECRET_ACCESS_KEY = env("DJANGO_AWS_SECRET_ACCESS_KEY")
 AWS_STORAGE_BUCKET_NAME = env("DJANGO_AWS_STORAGE_BUCKET_NAME")
 AWS_AUTO_CREATE_BUCKET = True
-AWS_QUERYSTRING_AUTH = False
+AWS_BUCKET_ACL = "private"
+AWS_DEFAULT_ACL = None
+
 # AWS_S3_CALLING_FORMAT = OrdinaryCallingFormat()
 
 # AWS cache settings, don't change unless you know what you're doing:


### PR DESCRIPTION
This changes the code which imports robot test result XML to convert screenshot URLs into an intermediate representation like asset://1234 (using the id of the TestResultAsset in the database) instead of directly into a public S3 URL. And it changes the view which renders those results to convert the intermediate URL into an S3 URL that includes time-limited query string authorization.

This is meant for use with the new S3 buckets we're moving to. Existing test results still keep their old screenshot URLs, which will stop working once the old S3 buckets are deleted.