### PR TITLE
Make it possible to configure multiple comma-separated github webhook secrets

### DIFF
--- a/app.json
+++ b/app.json
@@ -52,7 +52,7 @@
       "value": ""
     },
     "GITHUB_WEBHOOK_SECRET": {
-      "description": "The url for handling Github webhooks.  Ex: https://<app-name>.herokuapp.com/webhook/github",
+      "description": "The secret for validating Github webhooks.",
       "generator": "secret"
     },
     "HIREFIRE_TOKEN": {

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -321,7 +321,7 @@ FROM_EMAIL = "test@mailinator.com"
 # Github credentials
 GITHUB_USERNAME = env("GITHUB_USERNAME", default=None)
 GITHUB_PASSWORD = env("GITHUB_PASSWORD", default=None)
-GITHUB_WEBHOOK_SECRET = None
+GITHUB_WEBHOOK_SECRETS = []
 
 # Salesforce OAuth Connected App credentials
 CONNECTED_APP_CLIENT_ID = None

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -113,7 +113,7 @@ HIREFIRE_TOKEN = env("HIREFIRE_TOKEN", default="localtest")
 SITE_URL = env("SITE_URL", default="http://localhost:8000")
 
 # Github credentials
-GITHUB_WEBHOOK_SECRET = env("GITHUB_WEBHOOK_SECRET")
+GITHUB_WEBHOOK_SECRETS = env("GITHUB_WEBHOOK_SECRET").split(",")
 
 # Salesforce OAuth Connected App credentials
 CONNECTED_APP_CLIENT_ID = env("CONNECTED_APP_CLIENT_ID")

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -269,7 +269,7 @@ SITE_URL = env("SITE_URL")
 FROM_EMAIL = env("FROM_EMAIL")
 
 # Github credentials
-GITHUB_WEBHOOK_SECRET = env("GITHUB_WEBHOOK_SECRET")
+GITHUB_WEBHOOK_SECRETS = env("GITHUB_WEBHOOK_SECRET").split(",")
 
 # Salesforce OAuth Connected App credentials
 CONNECTED_APP_CLIENT_ID = env("CONNECTED_APP_CLIENT_ID")

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -7,7 +7,6 @@ Test settings
 
 from .common import *  # noqa
 
-
 # DEBUG
 # ------------------------------------------------------------------------------
 # Turn debug off so tests run faster
@@ -15,7 +14,7 @@ DEBUG = False
 TEMPLATES[0]["OPTIONS"]["debug"] = False
 
 # Allow requests with Host: testserver
-ALLOWED_HOSTS = ['testserver']
+ALLOWED_HOSTS = ["testserver"]
 
 # SECRET CONFIGURATION
 # ------------------------------------------------------------------------------
@@ -69,7 +68,7 @@ TEMPLATES[0]["OPTIONS"]["loaders"] = [
 
 GITHUB_USERNAME = "TestUser"
 GITHUB_PASSWORD = "TestUserPass123"
-GITHUB_WEBHOOK_SECRET = "a secret"
+GITHUB_WEBHOOK_SECRETS = ["a secret"]
 
 # Salesforce OAuth Connected App credentials
 CONNECTED_APP_CLIENT_ID = "1234567890"


### PR DESCRIPTION
This way we can rotate the secret with zero downtime.