### PR TITLE
Import Robot setup/teardown screenshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ node_modules/
 .sass-cache
 
 # virtual environments
+/env
 .env
 .envrc
 local_setup.sh

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -204,39 +204,3 @@ Developing with SLDS
 MetaCI uses https://github.com/SalesforceFoundation/django-slds which imports version 2.1.2 of the Salesforce Lightning Design System.
 
 You can find a CSS and component reference archived here: https://archive-2_1_2.lightningdesignsystem.com/
-
-Setting up MetaCI with CumulusCI-Test
--------------------------------------
-
-To connect your local MetaCI to the CumulustCI-Test repository you will need to perform the following:
-- Login to the Django Admin page (`localhost:8000/admin/login`)
-- Scroll down and click on the "Repositories" object
-- In the top right click the "Add Repository +" button
-- Enter the following:
-    - Name: CumulusCI-Test
-    - Owner: SFDO-Tooling
-    - Url: https://github.com/SFDO-Tooling/CumulusCI-Test
-- Click 'Save'
-- Note: You'll want to ensure that you have the github variables set in your corresponding env.example file.
-
-In order to run a build against the CumulusCI-Test repository you will also need to create an `org` to associate with the new CumulusCI-Test repository.
-
-- Navigate to the Django Admin page
-- Under the 'CumulusCI' section click on 'Orgs'
-- In the top right click the "Add Org +" button
-- Enter the following to setup a dev org:
-    - Name: dev
-    - Json: {"config_file":"orgs/dev.json","scratch":true}
-    - Scratch (checkbox): checked/true
-    - Repo (picklis): SFDO-Tooling/CumulusCI-Test
-- Click the 'SAVE' button
-
-Finally, you'll want to ensure that the "Dev Org" plan is associated with the CumulusCI-Repository:
-
-- Navigate to the Django Admin page
-- Under 'Plan' click on 'Plans'
-- Click on 'Dev Org'
-- Scroll down to the bottom to the 'Plan Repositories' section:
-    - Click 'Add another Plan repository
-    - Select the 'SFDO-Tooling/CumuluCI-Test repository
-    - Click the 'SAVE' button

--- a/metaci/build/tests/test_models.py
+++ b/metaci/build/tests/test_models.py
@@ -1,17 +1,18 @@
+from unittest.mock import Mock
+
+import pytest
 from cumulusci.core.config import OrgConfig
+
 from metaci.build.models import Build
 from metaci.conftest import (
-    RepositoryFactory,
     BranchFactory,
     BuildFactory,
     PlanFactory,
     PlanRepositoryFactory,
     PlanScheduleFactory,
+    RepositoryFactory,
     ScratchOrgInstanceFactory,
 )
-from unittest.mock import Mock
-import pytest
-import unittest
 
 
 @pytest.mark.django_db

--- a/metaci/db/management/commands/populate_db.py
+++ b/metaci/db/management/commands/populate_db.py
@@ -1,59 +1,71 @@
-from django.core.management.base import BaseCommand
-
-from django.db import transaction
-
-from guardian.shortcuts import assign_perm
+import random
 
 import factory.random
+from django.contrib.auth.models import Group
+from django.core.management.base import BaseCommand
+from django.db import transaction
+from guardian.shortcuts import assign_perm
 
 from metaci import conftest as fact
-from metaci.users.models import User
-from metaci.testresults.models import TestResult
-from django.contrib.auth.models import Group
-
 from metaci.build.models import BuildFlow
-
-import random
+from metaci.cumulusci.models import Org
+from metaci.plan.models import Plan, PlanRepository
+from metaci.repository.models import Repository
+from metaci.testresults.models import TestResult
+from metaci.users.models import User
 
 
 class Command(BaseCommand):
     help = "Populates a testing DB with sample data"
 
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--results", action="store_true", help="Create fake builds and test results"
+        )
+
     def handle(self, *args, **options):
-        if self.check_non_destructive():
-            print("Populating test data")
-            # reset_db.Command().handle(*args, **options)
-            # migrate.Command().handle(*args, **options)
+        if options["results"]:
+            if self.check_non_destructive():
+                print("Populating test data")
+                # reset_db.Command().handle(*args, **options)
+                # migrate.Command().handle(*args, **options)
 
-            self.create_objs()
-        else:
-            print(
+                self.create_builds_with_test_results()
+            else:
+                print(
+                    """
+                This does not seem to be an empty or test database!
+                Please clear the database before continuing!
+                One way of clearing the database is:
+
+                python manage.py reset_db -c && python manage.py migrate && python manage.py createsuperuser --username clark --email kent@krypton.com
+
+                You can add a --noinput to that if you're sure you know what you're doing.
                 """
-            This does not seem to be an empty or test database!
-            Please clear the database before continuing!
-            One way of clearing the database is:
-
-            python manage.py reset_db -c && python manage.py migrate && python manage.py createsuperuser --username clark --email kent@krypton.com
-
-            You can add a --noinput to that if you're sure you know what you're doing.
-            """
-            )
+                )
+        else:
+            self.create_test_repo()
 
     def check_non_destructive(self):
         return User.objects.count() < 3 and TestResult.objects.count() < 10
 
-    def create_objs(self):
+    def create_builds_with_test_results(self):
         with transaction.atomic():
             factory.random.reseed_random("TOtaLLY RaNdOM")
             random.seed("RaNDOM!! TOtaLLY")
             fact.UserFactory()
             fact.UserFactory()
+            existing_plans = Plan.objects.all()
             PublicPlanRepositories = [
-                fact.PlanRepositoryFactory(repo__name_prefix="PublicRepo_")
+                fact.PlanRepositoryFactory(
+                    repo__name_prefix="PublicRepo_", plan=random.choice(existing_plans)
+                )
                 for i in range(6)
             ]
             PrivatePlanRepositories = [
-                fact.PlanRepositoryFactory(repo__name_prefix="PrivateRepo_")
+                fact.PlanRepositoryFactory(
+                    repo__name_prefix="PrivateRepo_", plan=random.choice(existing_plans)
+                )
                 for i in range(6)
             ]
             for repo in PublicPlanRepositories:
@@ -86,3 +98,24 @@ class Command(BaseCommand):
         for bf in BuildFlow.objects.all():
             bf.tests_total = bf.test_results.count()
             bf.save()
+
+    def create_test_repo(self):
+        with transaction.atomic():
+            repo = Repository(
+                owner="SFDO-Tooling",
+                name="CumulusCI-Test",
+                github_id=24913646,
+                url="https://github.com/SalesforceFoundation/CumulusCI-Test",
+            )
+            repo.save()
+            org = Org(
+                name="dev",
+                repo=repo,
+                json='{"config_file":"orgs/dev.json", "scratch":true}',
+                scratch=True,
+            )
+            org.save()
+            # enable each existing plan for the repo
+            for plan in Plan.objects.all():
+                planrepo = PlanRepository(plan=plan, repo=repo)
+                planrepo.save()

--- a/metaci/testresults/importer.py
+++ b/metaci/testresults/importer.py
@@ -151,6 +151,7 @@ def import_robot_test_results(build_flow, path):
         )
         asset.save()
 
+    suite_screenshots = {}
     for result in parse_robot_output(path):
         class_and_method = "{}.{}".format(result["suite"]["name"], result["name"])
 
@@ -162,6 +163,24 @@ def import_robot_test_results(build_flow, path):
                 test_type="Robot",
             )
             classes[result["suite"]["name"]] = testclass
+
+        # Attach suite screenshots to buildflow
+        dirname = os.path.dirname(path)
+        for screenshot in result["suite"]["screenshots"]:
+            if screenshot in suite_screenshots:
+                continue
+            screenshot_path = screenshot
+            if dirname:
+                screenshot_path = "{}/{}".format(dirname, screenshot)
+            with open(screenshot_path, "rb") as f:
+                asset = BuildFlowAsset(
+                    build_flow=build_flow,
+                    asset=ContentFile(f.read(), screenshot),
+                    category="robot-screenshot",
+                )
+                asset.save()
+                suite_screenshots[screenshot] = asset.id
+            os.remove(screenshot_path)
 
         method = methods.get(class_and_method, None)
         if not method:
@@ -180,8 +199,8 @@ def import_robot_test_results(build_flow, path):
         )
         testresult.save()
 
-        if result["screenshots"]:
-            dirname = os.path.dirname(path)
+        # attach test case screenshots to test result
+        if result["screenshots"] or suite_screenshots:
             for screenshot in result["screenshots"]:
                 screenshot_path = screenshot
                 if dirname:
@@ -196,6 +215,11 @@ def import_robot_test_results(build_flow, path):
                         '"{}"'.format(screenshot), '"asset://{}"'.format(asset.id)
                     )
                 os.remove(screenshot_path)
+            # replace references to suite screenshots with BuildFlowAsset ids
+            for screenshot, asset_id in suite_screenshots.items():
+                testresult.robot_xml = testresult.robot_xml.replace(
+                    '"{}"'.format(screenshot), '"buildflowasset://{}"'.format(asset_id)
+                )
             testresult.save()
 
 
@@ -219,13 +243,16 @@ def get_robot_tests(root, elem, parents=[]):
 
     if not has_children:
         suite_file = elem.attrib["source"].replace(os.getcwd(), "")
+        setup = elem.find("kw[@type='setup']")
+        teardown = elem.find("kw[@type='teardown']")
         suite = {
             "file": suite_file,
             "elem": elem,
             "name": "/".join([suite.attrib["name"] for suite in parents]),
-            "setup": elem.find("kw[@type='setup']"),
+            "setup": setup,
             "status": elem.find("status"),
-            "teardown": elem.find("kw[@type='teardown']"),
+            "teardown": teardown,
+            "screenshots": find_screenshots(setup) + find_screenshots(teardown),
         }
         for test in elem.iter("test"):
             status = test.find("status")
@@ -241,11 +268,7 @@ def get_robot_tests(root, elem, parents=[]):
             delta = end - start
 
             # Process screenshots
-            for msg in test.findall(".//msg[@html='yes']"):
-                txt = "".join([text for text in msg.itertext()])
-                for screenshot in re.findall(r'href="([\w.-]+)">', txt):
-                    test_info["screenshots"].append(screenshot)
-
+            test_info["screenshots"] = find_screenshots(test)
             test_info["duration"] = float(
                 "{}.{}".format(delta.seconds, delta.microseconds)
             )
@@ -253,6 +276,15 @@ def get_robot_tests(root, elem, parents=[]):
             tests.append(test_info)
 
     return tests
+
+
+def find_screenshots(root):
+    screenshots = []
+    for msg in root.findall(".//msg[@html='yes']"):
+        txt = "".join([text for text in msg.itertext()])
+        for screenshot in re.findall(r'href="([\w.-]+)">', txt):
+            screenshots.append(screenshot)
+    return screenshots
 
 
 def render_robot_test_xml(root, test):


### PR DESCRIPTION
This adjusts the existing code for importing Robot Framework results to handle screenshots from setup/teardown. (Fixes #469)

These are stored as a BuildFlowAsset since they aren't related to a specific TestResult.

Unrelatedly I also adjusted the populate_db script to default to setting up the CumulusCI-Test repository (the old script for adding fake builds and test results is still available via the --results option)