### PR TITLE
Default date range on page load

### DIFF
--- a/metaci/api/views/testmethod_perf.py
+++ b/metaci/api/views/testmethod_perf.py
@@ -14,12 +14,16 @@ from metaci.repository.models import Repository, Branch
 from metaci.plan.models import Plan
 
 from django.db import connection
+from datetime import datetime, timedelta
+
+thirty_days_ago = datetime.now() - timedelta(days=30)
 
 
 class DEFAULTS:
     page_size = 50
     max_page_size = 100
     branch = "master"
+    daterange_after = thirty_days_ago.isoformat("T").split("T")[0]
 
 
 def set_timeout(timeout):

--- a/src/js/components/perfPages/perfPage.js
+++ b/src/js/components/perfPages/perfPage.js
@@ -65,7 +65,7 @@ export const UnwrappedPerfPage = ({
     throw new Error(message);
   }
 
-  // Fetch the data: both UI configuration and also actual data results
+  // Fetch the UI data
   useEffect(() => {
     /* Special case for getting repo name from URL
      * path into query params with other filters
@@ -73,9 +73,15 @@ export const UnwrappedPerfPage = ({
     const pathParts = window.location.pathname.split('/');
     const repo = pathParts[pathParts.length - 2];
     queryparams.set({ repo });
-    doPerfRESTFetch({ ...queryparams.getAll() });
     doPerfREST_UI_Fetch();
   }, []);
+
+  // Fetch the real data
+  useEffect(() => {
+    if (uiAvailable) {
+      doPerfRESTFetch({ ...queryparams.getAll() });
+    }
+  }, [uiAvailable]);
 
   let results;
   if (


### PR DESCRIPTION
testmethod_perf.py changed to add a default date range so that we wouldn't try to provide results to the beginning of time by default.

perfPage.js changed to fetch the UI properties and defaults from the server before fetching the data. This is very slightly slower, but it manages an architectural convention that the client doesn't know much about the details of the schema, data model or defaults.
