### PR TITLE
Feature/better error handling

### DIFF
--- a/src/js/components/error.js
+++ b/src/js/components/error.js
@@ -41,7 +41,12 @@ class ErrorBoundary extends React.Component<
                 <br />
               </Trans>
               <p>
-                The error was &ldquo;{get(this.state, 'error.message')}&rdquo;
+                {get(this.state, 'error.message') && (
+                  <>
+                    The error was &ldquo;{get(this.state, 'error.message')}
+                    &rdquo;
+                  </>
+                )}
               </p>
             </>
           }

--- a/src/js/components/error.js
+++ b/src/js/components/error.js
@@ -1,5 +1,5 @@
 // @flow
-
+import get from 'lodash/get';
 import * as React from 'react';
 import { Trans } from 'react-i18next';
 import Illustration from '@salesforce/design-system-react/components/illustration';
@@ -9,7 +9,10 @@ import { logError } from 'utils/logging';
 
 type Props = { children: React.Node };
 
-class ErrorBoundary extends React.Component<Props, { hasError: boolean }> {
+class ErrorBoundary extends React.Component<
+  Props,
+  { hasError: boolean, error?: any, info?: any },
+> {
   constructor(props: Props) {
     super(props);
     this.state = { hasError: false };
@@ -17,7 +20,7 @@ class ErrorBoundary extends React.Component<Props, { hasError: boolean }> {
 
   /* istanbul ignore next */
   componentDidCatch(error: Error, info: {}) {
-    this.setState({ hasError: true });
+    this.setState({ hasError: true, error, info });
     logError(error, info);
   }
 
@@ -37,6 +40,9 @@ class ErrorBoundary extends React.Component<Props, { hasError: boolean }> {
                 scratch. Sorry about that.
                 <br />
               </Trans>
+              <p>
+                The error was &ldquo;{get(this.state, 'error.message')}&rdquo;
+              </p>
             </>
           }
         />

--- a/src/js/components/perfPages/perfDataTable.js
+++ b/src/js/components/perfPages/perfDataTable.js
@@ -25,6 +25,13 @@ const PerfDataTable = ({
   perfState,
   queryparams,
 }: Props) => {
+  if (perfState && perfState.status === 'ERROR') {
+    const message =
+      get(perfState, 'reason.reason.detail') ||
+      get(perfState, 'reason.error') ||
+      '';
+    throw new Error(message);
+  }
   /*
    * Extract the page from the server-generated URL and ensure it is
    * browser URL before fetching it.

--- a/src/js/components/perfPages/perfPage.js
+++ b/src/js/components/perfPages/perfPage.js
@@ -16,11 +16,16 @@ import { QueryParamHelpers, addIds } from './perfTableUtils';
 
 import ErrorBoundary from 'components/error';
 import type { AppState } from 'store';
-import type { PerfDataState, LoadingStatus } from 'store/perfdata/reducer';
+import type {
+  PerfDataState,
+  PerfData_UI_State,
+  LoadingStatus,
+} from 'store/perfdata/reducer';
 import { perfRESTFetch, perfREST_UI_Fetch } from 'store/perfdata/actions';
 import type { TestMethodPerfUI } from 'api/testmethod_perf_UI_JSON_schema';
 import {
   selectPerfState,
+  selectPerfUIState,
   selectPerfUIStatus,
   selectTestMethodPerfUI,
 } from 'store/perfdata/selectors';
@@ -34,6 +39,7 @@ const gradient = 'linear-gradient(to top, rgba(221, 219, 218, 0) 0, #1B5F9E)';
 // TODO: Stronger typing in these
 type ReduxProps = {|
   perfState: PerfDataState,
+  perfUIState: PerfData_UI_State,
   perfUIStatus: LoadingStatus,
   testMethodPerfUI: TestMethodPerfUI,
   doPerfRESTFetch: ({}) => null,
@@ -49,6 +55,7 @@ export const UnwrappedPerfPage = ({
   doPerfRESTFetch,
   doPerfREST_UI_Fetch,
   perfState,
+  perfUIState,
   testMethodPerfUI,
   perfUIStatus,
 }: ReduxProps & RouterProps & SelfProps) => {
@@ -62,7 +69,9 @@ export const UnwrappedPerfPage = ({
 
   if (perfUIStatus === 'ERROR') {
     const message =
-      get(perfState, 'reason.reason') || get(perfState, 'reason.error') || '';
+      get(perfUIState, 'reason.reason') ||
+      get(perfUIState, 'reason.error') ||
+      '';
     throw new Error(message);
   }
 
@@ -161,6 +170,7 @@ const select = (appState: AppState) => ({
   perfState: selectPerfState(appState),
   testMethodPerfUI: selectTestMethodPerfUI(appState),
   perfUIStatus: selectPerfUIStatus(appState),
+  perfUIState: selectPerfUIState(appState),
 });
 
 const actions = {

--- a/src/js/components/perfPages/perfPage.js
+++ b/src/js/components/perfPages/perfPage.js
@@ -14,6 +14,7 @@ import PerfTableOptionsUI from './perfTableOptionsUI';
 import PerfDataTable from './perfDataTable';
 import { QueryParamHelpers, addIds } from './perfTableUtils';
 
+import ErrorBoundary from 'components/error';
 import type { AppState } from 'store';
 import type { PerfDataState, LoadingStatus } from 'store/perfdata/reducer';
 import { perfRESTFetch, perfREST_UI_Fetch } from 'store/perfdata/actions';
@@ -59,7 +60,7 @@ export const UnwrappedPerfPage = ({
     throw new Error('Store error');
   }
 
-  if (perfUIStatus === 'ERROR' || (perfState && perfState.status === 'ERROR')) {
+  if (perfUIStatus === 'ERROR') {
     const message =
       get(perfState, 'reason.reason') || get(perfState, 'reason.error') || '';
     throw new Error(message);
@@ -104,14 +105,16 @@ export const UnwrappedPerfPage = ({
         queryparams={queryparams}
         key="thePerfAccordian"
       />
-      <div style={{ position: 'relative' }}>
-        <PerfDataTable
-          fetchServerData={fetchServerData}
-          perfState={perfState}
-          queryparams={queryparams}
-          items={results}
-        />
-      </div>{' '}
+      <ErrorBoundary>
+        <div style={{ position: 'relative' }}>
+          <PerfDataTable
+            fetchServerData={fetchServerData}
+            perfState={perfState}
+            queryparams={queryparams}
+            items={results}
+          />
+        </div>{' '}
+      </ErrorBoundary>
       <DebugIcon />
     </div>
   );

--- a/src/js/store/perfdata/reducer.js
+++ b/src/js/store/perfdata/reducer.js
@@ -38,6 +38,11 @@ export type UIDataAvailable = {
   uidata: UIData,
 };
 
+export type UIDataError = {
+  status: 'ERROR',
+  uidata: UIData,
+};
+
 export type PerfDataState = PerfDataAvailable | PerfDataLoading | PerfDataError;
 
 export const perfDataReducer = (
@@ -64,7 +69,7 @@ export const perfDataReducer = (
   return state;
 };
 
-export type PerfData_UI_State = UIDataLoading | UIDataAvailable;
+export type PerfData_UI_State = UIDataLoading | UIDataAvailable | UIDataError;
 
 export const perfDataUIReducer = (
   state: PerfData_UI_State = { status: 'LOADING', uidata: null },
@@ -75,6 +80,8 @@ export const perfDataUIReducer = (
       return { status: 'LOADING', uidata: action.payload };
     case 'UI_DATA_AVAILABLE':
       return { status: 'AVAILABLE', uidata: action.payload };
+    case 'UI_DATA_ERROR':
+      return { status: 'ERROR', uidata: action.payload };
   }
   return state;
 };

--- a/src/js/store/perfdata/selectors.js
+++ b/src/js/store/perfdata/selectors.js
@@ -1,7 +1,11 @@
 // @flow
 
 import type { AppState } from 'store';
-import type { PerfDataState, LoadingStatus } from 'store/perfdata/reducer';
+import type {
+  PerfDataState,
+  PerfData_UI_State,
+  LoadingStatus,
+} from 'store/perfdata/reducer';
 import type {
   TestMethodPerfUI,
   FilterDefinition,
@@ -9,6 +13,9 @@ import type {
 
 export const selectPerfState = (appState: AppState): PerfDataState =>
   appState.perfData;
+
+export const selectPerfUIState = (appState: AppState): PerfData_UI_State =>
+  appState.perfDataUI;
 
 export const selectPerfUIStatus = (appState: AppState): LoadingStatus =>
   appState.perfDataUI ? appState.perfDataUI.status : 'LOADING';

--- a/src/js/store/perfdata/selectors.js
+++ b/src/js/store/perfdata/selectors.js
@@ -21,7 +21,7 @@ export const selectPerfUIStatus = (appState: AppState): LoadingStatus =>
   appState.perfDataUI ? appState.perfDataUI.status : 'LOADING';
 
 export const selectPerfDataAPIUrl = (appState: AppState): string =>
-  appState.perfData.status === 'AVAILABLE' ? appState.perfData.url : '';
+  (appState.perfData && appState.perfData.url) || '';
 
 // TODO: Improve strong typing on these:
 export const selectTestMethodPerfUI = (


### PR DESCRIPTION
A few changes:

1. Previously the "error boundary" was the whole page so a failure to load data would also overwrite the UI parts at the top of the page. Now the data table at the bottom has its own error boundary.

2. Previously UI errors and data errors would both trigger a single exception which would obliterate the whole page. Now the errors are recognized and caught in different places.

