### PR TITLE
Calculate durations properly

### DIFF
--- a/metaci/testresults/tests/robot_with_nested_suites.xml
+++ b/metaci/testresults/tests/robot_with_nested_suites.xml
@@ -17,7 +17,7 @@ automatically log into the target Salesforce org.</doc>
 </arguments>
 <status status="PASS" starttime="20191023 09:38:43.701" endtime="20191023 09:38:43.701"></status>
 </kw>
-<status status="PASS" starttime="20191023 09:38:43.699" endtime="20191023 09:38:43.701" critical="yes"></status>
+<status status="PASS" starttime="20191023 09:38:43.500" endtime="20191023 09:38:43.75" critical="yes"></status>
 </test>
 <test id="s1-s1-s1-t2" name="Test Login Url">
 <kw name="Login Url" library="cumulusci.robotframework.CumulusCI">

--- a/metaci/testresults/tests/robot_with_setup_teardown.xml
+++ b/metaci/testresults/tests/robot_with_setup_teardown.xml
@@ -1,89 +1,216 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <robot rpa="false">
-    <suite id="s1" name="Api" source="">
-        <test id="s1-t1" name="FakeTestResult2">
-            <kw name="Sleep" library="BuiltIn" type="setup">
-                <doc>Pauses the test executed for the given time.</doc>
-                <arguments>
-                    <arg>6</arg>
-                </arguments>
-                <status status="PASS" starttime="20191021 01:00:00.000" endtime="20191021 01:00:06.00"></status>
-            </kw>
-            <kw name="Create Contact">
-                <assign>
-                    <var>&amp;{contact}</var>
-                </assign>
-                <kw name="Generate Random String" library="String">
-                    <doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
-                    <assign>
-                        <var>${first_name}</var>
-                    </assign>
-                    <msg timestamp="20191021 15:29:11.360" level="INFO">${first_name} = 9xPGOPDZ</msg>
-                    <status status="PASS" starttime="20191021 15:29:11.360" endtime="20191021 15:29:11.360"></status>
-                </kw>
-                <kw name="Generate Random String" library="String">
-                    <doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
-                    <assign>
-                        <var>${last_name}</var>
-                    </assign>
-                    <msg timestamp="20191021 15:29:11.361" level="INFO">${last_name} = 08V1Y8CO</msg>
-                    <status status="PASS" starttime="20191021 15:29:11.360" endtime="20191021 15:29:11.361"></status>
-                </kw>
-                <kw name="Salesforce Insert" library="cumulusci.robotframework.Salesforce">
-                    <doc>Inserts a Salesforce object setting fields using kwargs and returns the id</doc>
-                    <arguments>
-                        <arg>Contact</arg>
-                        <arg>FirstName=${first_name}</arg>
-                        <arg>LastName=${last_name}</arg>
-                    </arguments>
-                    <assign>
-                        <var>${contact_id}</var>
-                    </assign>
-                    <msg timestamp="20191021 15:29:11.361" level="INFO">Inserting Contact with values {'FirstName': '9xPGOPDZ', 'LastName': '08V1Y8CO'}</msg>
-                    <msg timestamp="20191021 15:29:12.330" level="INFO">Storing Contact 0034F00000SYtgTQAT to session records</msg>
-                    <msg timestamp="20191021 15:29:12.331" level="INFO">${contact_id} = 0034F00000SYtgTQAT</msg>
-                    <status status="PASS" starttime="REMOVED_FOR_CLARITY" endtime="REMOVED_FOR_CLARITY"></status>
-                </kw>
-                <kw name="Salesforce Get" library="cumulusci.robotframework.Salesforce">
-                    <doc>Gets a Salesforce object by id and returns the dict result</doc>
-                    <arguments>
-                        <arg>Contact</arg>
-                        <arg>${contact_id}</arg>
-                    </arguments>
-                    <assign>
-                        <var>&amp;{contact}</var>
-                    </assign>
-                    <msg timestamp="REMOVED_FOR_CLARITY" level="INFO">Getting Contact with Id 0034F00000SYtgTQAT</msg>
-                    <msg timestamp="REMOVED_FOR_CLARITY" level="INFO">&amp;{contact} = { attributes={'type': 'Contact', 'url': '/services/data/v46.0/sobjects/Contact/0034F00000SYtgTQAT'} | Id=0034F00000SYtgTQAT | IsDeleted=False | MasterRecordId=None | AccountId=None | LastName=08V1Y8CO...</msg>
-                    <status status="PASS" starttime="REMOVED_FOR_CLARITY" endtime="REMOVED_FOR_CLARITY"></status>
-                </kw>
-                <msg timestamp="REMOVED_FOR_CLARITY" level="INFO">&amp;{contact} = { attributes={'type': 'Contact', 'url': '/services/data/v46.0/sobjects/Contact/0034F00000SYtgTQAT'} | Id=0034F00000SYtgTQAT | IsDeleted=False | MasterRecordId=None | AccountId=None | LastName=08V1Y8CO...</msg>
-                <status status="PASS" starttime="20191021 01:00:07.000" endtime="20191021 01:00:20.000"></status>
-            </kw>
-            <tags>
-                <tag>api</tag>
-                <tag>Runme</tag>
-            </tags>
-            <kw name="Do Some Cleanup" library="cumulusci.robotframework.Salesforce" type="teardown">
-                <doc>Cleanup the stuff.</doc>
-                <status status="PASS" starttime="20191021 01:00:20.001" endtime="20191021 01:00:21.000"></status>
-            </kw>
-            <status status="PASS" starttime="20191021 01:00:00.000" endtime="20191021 01:00:21.001" critical="yes"></status>
-        </test>
-        <status status="PASS" starttime="20191021 01:00:00.000" endtime="20191021 01:00:21.002"></status>
-    </suite>
-    <statistics>
-        <total>
-            <stat pass="1" fail="0">Critical Tests</stat>
-            <stat pass="1" fail="0">All Tests</stat>
-        </total>
-        <tag>
-            <stat pass="1" fail="0">api</stat>
-            <stat pass="1" fail="0">Runme</stat>
-        </tag>
-        <suite>
-            <stat pass="1" fail="0" id="s1" name="Api">Api</stat>
-        </suite>
-    </statistics>
-    <errors></errors>
+<suite id="s1" name="Api" source="">
+<test id="s1-t1" name="FakeTestResult2">
+<kw name="Sleep" library="BuiltIn" type="setup">
+<doc>Pauses the test executed for the given time.</doc>
+<arguments>
+<arg>6</arg>
+</arguments>
+<status status="PASS" starttime="20191021 01:00:00.000" endtime="20191021 01:00:06.00"></status>
+</kw>
+<kw name="Create Contact">
+<assign>
+<var>&amp;{contact}</var>
+</assign>
+<kw name="Generate Random String" library="String">
+<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
+<assign>
+<var>${first_name}</var>
+</assign>
+<msg timestamp="20191021 15:29:11.360" level="INFO">${first_name} = 9xPGOPDZ</msg>
+<status status="PASS" starttime="20191021 15:29:11.360" endtime="20191021 15:29:11.360"></status>
+</kw>
+<kw name="Generate Random String" library="String">
+<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
+<assign>
+<var>${last_name}</var>
+</assign>
+<msg timestamp="20191021 15:29:11.361" level="INFO">${last_name} = 08V1Y8CO</msg>
+<status status="PASS" starttime="20191021 15:29:11.360" endtime="20191021 15:29:11.361"></status>
+</kw>
+<kw name="Salesforce Insert" library="cumulusci.robotframework.Salesforce">
+<doc>Inserts a Salesforce object setting fields using kwargs and returns the id</doc>
+<arguments>
+<arg>Contact</arg>
+<arg>FirstName=${first_name}</arg>
+<arg>LastName=${last_name}</arg>
+</arguments>
+<assign>
+<var>${contact_id}</var>
+</assign>
+<msg timestamp="20191021 15:29:11.361" level="INFO">Inserting Contact with values {'FirstName': '9xPGOPDZ', 'LastName': '08V1Y8CO'}</msg>
+<msg timestamp="20191021 15:29:12.330" level="INFO">Storing Contact 0034F00000SYtgTQAT to session records</msg>
+<msg timestamp="20191021 15:29:12.331" level="INFO">${contact_id} = 0034F00000SYtgTQAT</msg>
+<status status="PASS" starttime="REMOVED_FOR_CLARITY" endtime="REMOVED_FOR_CLARITY"></status>
+</kw>
+<kw name="Salesforce Get" library="cumulusci.robotframework.Salesforce">
+<doc>Gets a Salesforce object by id and returns the dict result</doc>
+<arguments>
+<arg>Contact</arg>
+<arg>${contact_id}</arg>
+</arguments>
+<assign>
+<var>&amp;{contact}</var>
+</assign>
+<msg timestamp="REMOVED_FOR_CLARITY" level="INFO">Getting Contact with Id 0034F00000SYtgTQAT</msg>
+<msg timestamp="REMOVED_FOR_CLARITY" level="INFO">&amp;{contact} = { attributes={'type': 'Contact', 'url': '/services/data/v46.0/sobjects/Contact/0034F00000SYtgTQAT'} | Id=0034F00000SYtgTQAT | IsDeleted=False | MasterRecordId=None | AccountId=None | LastName=08V1Y8CO...</msg>
+<status status="PASS" starttime="REMOVED_FOR_CLARITY" endtime="REMOVED_FOR_CLARITY"></status>
+</kw>
+<msg timestamp="REMOVED_FOR_CLARITY" level="INFO">&amp;{contact} = { attributes={'type': 'Contact', 'url': '/services/data/v46.0/sobjects/Contact/0034F00000SYtgTQAT'} | Id=0034F00000SYtgTQAT | IsDeleted=False | MasterRecordId=None | AccountId=None | LastName=08V1Y8CO...</msg>
+<status status="PASS" starttime="20191021 01:00:07.000" endtime="20191021 01:00:20.000"></status>
+</kw>
+<tags>
+<tag>api</tag>
+<tag>Runme</tag>
+</tags>
+<kw name="Do Some Cleanup" library="cumulusci.robotframework.Salesforce" type="teardown">
+<doc>Cleanup the stuff.</doc>
+<status status="PASS" starttime="20191021 01:00:20.001" endtime="20191021 01:00:21.000"></status>
+</kw>
+<status status="PASS" starttime="20191021 01:00:00.000" endtime="20191021 01:00:21.001" critical="yes"></status>
+</test>
+<test id="s1-t1" name="FakeTestResult_setup_no_teardown">
+<kw name="Sleep" library="BuiltIn" type="setup">
+<doc>Pauses the test executed for the given time.</doc>
+<arguments>
+<arg>6</arg>
+</arguments>
+<status status="PASS" starttime="20191021 01:00:00.000" endtime="20191021 01:00:06.00"></status>
+</kw>
+<kw name="Create Contact">
+<assign>
+<var>&amp;{contact}</var>
+</assign>
+<kw name="Generate Random String" library="String">
+<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
+<assign>
+<var>${first_name}</var>
+</assign>
+<msg timestamp="20191021 15:29:11.360" level="INFO">${first_name} = 9xPGOPDZ</msg>
+<status status="PASS" starttime="20191021 15:29:11.360" endtime="20191021 15:29:11.360"></status>
+</kw>
+<kw name="Generate Random String" library="String">
+<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
+<assign>
+<var>${last_name}</var>
+</assign>
+<msg timestamp="20191021 15:29:11.361" level="INFO">${last_name} = 08V1Y8CO</msg>
+<status status="PASS" starttime="20191021 15:29:11.360" endtime="20191021 15:29:11.361"></status>
+</kw>
+<kw name="Salesforce Insert" library="cumulusci.robotframework.Salesforce">
+<doc>Inserts a Salesforce object setting fields using kwargs and returns the id</doc>
+<arguments>
+<arg>Contact</arg>
+<arg>FirstName=${first_name}</arg>
+<arg>LastName=${last_name}</arg>
+</arguments>
+<assign>
+<var>${contact_id}</var>
+</assign>
+<msg timestamp="20191021 15:29:11.361" level="INFO">Inserting Contact with values {'FirstName': '9xPGOPDZ', 'LastName': '08V1Y8CO'}</msg>
+<msg timestamp="20191021 15:29:12.330" level="INFO">Storing Contact 0034F00000SYtgTQAT to session records</msg>
+<msg timestamp="20191021 15:29:12.331" level="INFO">${contact_id} = 0034F00000SYtgTQAT</msg>
+<status status="PASS" starttime="REMOVED_FOR_CLARITY" endtime="REMOVED_FOR_CLARITY"></status>
+</kw>
+<kw name="Salesforce Get" library="cumulusci.robotframework.Salesforce">
+<doc>Gets a Salesforce object by id and returns the dict result</doc>
+<arguments>
+<arg>Contact</arg>
+<arg>${contact_id}</arg>
+</arguments>
+<assign>
+<var>&amp;{contact}</var>
+</assign>
+<msg timestamp="REMOVED_FOR_CLARITY" level="INFO">Getting Contact with Id 0034F00000SYtgTQAT</msg>
+<msg timestamp="REMOVED_FOR_CLARITY" level="INFO">&amp;{contact} = { attributes={'type': 'Contact', 'url': '/services/data/v46.0/sobjects/Contact/0034F00000SYtgTQAT'} | Id=0034F00000SYtgTQAT | IsDeleted=False | MasterRecordId=None | AccountId=None | LastName=08V1Y8CO...</msg>
+<status status="PASS" starttime="REMOVED_FOR_CLARITY" endtime="REMOVED_FOR_CLARITY"></status>
+</kw>
+<msg timestamp="REMOVED_FOR_CLARITY" level="INFO">&amp;{contact} = { attributes={'type': 'Contact', 'url': '/services/data/v46.0/sobjects/Contact/0034F00000SYtgTQAT'} | Id=0034F00000SYtgTQAT | IsDeleted=False | MasterRecordId=None | AccountId=None | LastName=08V1Y8CO...</msg>
+<status status="PASS" starttime="20191021 01:00:07.000" endtime="20191021 01:00:20.000"></status>
+</kw>
+<tags>
+<tag>api</tag>
+<tag>Runme</tag>
+</tags>
+<status status="PASS" starttime="20191021 01:00:00.000" endtime="20191021 01:00:21.001" critical="yes"></status>
+</test>        
+<test id="s1-t1" name="FakeTestResult_teardown_no_setup">
+<kw name="Create Contact">
+<assign>
+<var>&amp;{contact}</var>
+</assign>
+<kw name="Generate Random String" library="String">
+<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
+<assign>
+<var>${first_name}</var>
+</assign>
+<msg timestamp="20191021 15:29:11.360" level="INFO">${first_name} = 9xPGOPDZ</msg>
+<status status="PASS" starttime="20191021 15:29:11.360" endtime="20191021 15:29:11.360"></status>
+</kw>
+<kw name="Generate Random String" library="String">
+<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
+<assign>
+<var>${last_name}</var>
+</assign>
+<msg timestamp="20191021 15:29:11.361" level="INFO">${last_name} = 08V1Y8CO</msg>
+<status status="PASS" starttime="20191021 15:29:11.360" endtime="20191021 15:29:11.361"></status>
+</kw>
+<kw name="Salesforce Insert" library="cumulusci.robotframework.Salesforce">
+<doc>Inserts a Salesforce object setting fields using kwargs and returns the id</doc>
+<arguments>
+<arg>Contact</arg>
+<arg>FirstName=${first_name}</arg>
+<arg>LastName=${last_name}</arg>
+</arguments>
+<assign>
+<var>${contact_id}</var>
+</assign>
+<msg timestamp="20191021 15:29:11.361" level="INFO">Inserting Contact with values {'FirstName': '9xPGOPDZ', 'LastName': '08V1Y8CO'}</msg>
+<msg timestamp="20191021 15:29:12.330" level="INFO">Storing Contact 0034F00000SYtgTQAT to session records</msg>
+<msg timestamp="20191021 15:29:12.331" level="INFO">${contact_id} = 0034F00000SYtgTQAT</msg>
+<status status="PASS" starttime="REMOVED_FOR_CLARITY" endtime="REMOVED_FOR_CLARITY"></status>
+</kw>
+<kw name="Salesforce Get" library="cumulusci.robotframework.Salesforce">
+<doc>Gets a Salesforce object by id and returns the dict result</doc>
+<arguments>
+<arg>Contact</arg>
+<arg>${contact_id}</arg>
+</arguments>
+<assign>
+<var>&amp;{contact}</var>
+</assign>
+<msg timestamp="REMOVED_FOR_CLARITY" level="INFO">Getting Contact with Id 0034F00000SYtgTQAT</msg>
+<msg timestamp="REMOVED_FOR_CLARITY" level="INFO">&amp;{contact} = { attributes={'type': 'Contact', 'url': '/services/data/v46.0/sobjects/Contact/0034F00000SYtgTQAT'} | Id=0034F00000SYtgTQAT | IsDeleted=False | MasterRecordId=None | AccountId=None | LastName=08V1Y8CO...</msg>
+<status status="PASS" starttime="REMOVED_FOR_CLARITY" endtime="REMOVED_FOR_CLARITY"></status>
+</kw>
+<msg timestamp="REMOVED_FOR_CLARITY" level="INFO">&amp;{contact} = { attributes={'type': 'Contact', 'url': '/services/data/v46.0/sobjects/Contact/0034F00000SYtgTQAT'} | Id=0034F00000SYtgTQAT | IsDeleted=False | MasterRecordId=None | AccountId=None | LastName=08V1Y8CO...</msg>
+<status status="PASS" starttime="20191021 01:00:07.000" endtime="20191021 01:00:20.000"></status>
+</kw>
+<tags>
+<tag>api</tag>
+<tag>Runme</tag>
+</tags>
+<kw name="Do Some Cleanup" library="cumulusci.robotframework.Salesforce" type="teardown">
+<doc>Cleanup the stuff.</doc>
+<status status="PASS" starttime="20191021 01:00:20.001" endtime="20191021 01:00:21.000"></status>
+</kw>
+<status status="PASS" starttime="20191021 01:00:00.000" endtime="20191021 01:00:21.001" critical="yes"></status>
+</test>        
+<status status="PASS" starttime="20191021 01:00:00.000" endtime="20191021 01:00:21.002"></status>
+</suite>
+<statistics>
+<total>
+<stat pass="1" fail="0">Critical Tests</stat>
+<stat pass="1" fail="0">All Tests</stat>
+</total>
+<tag>
+<stat pass="1" fail="0">api</stat>
+<stat pass="1" fail="0">Runme</stat>
+</tag>
+<suite>
+<stat pass="1" fail="0" id="s1" name="Api">Api</stat>
+</suite>
+</statistics>
+<errors></errors>
 </robot>

--- a/metaci/testresults/tests/test_robot_importer.py
+++ b/metaci/testresults/tests/test_robot_importer.py
@@ -29,6 +29,8 @@ class RobotImporterTestCase(TestCase):
         buildflow = BuildFlowFactory()
         path = PurePath(__file__).parent / "robot_with_setup_teardown.xml"
         robot_importer.import_robot_test_results(buildflow, path)
-        # TODO:
-        # res = 14.002
-        # assert models.TestResult.objects.filter(method__name="FakeTestResult2")[0].duration == res
+        res = 14.002
+        assert (
+            models.TestResult.objects.filter(method__name="FakeTestResult2")[0].duration
+            == res
+        )

--- a/metaci/testresults/tests/test_robot_importer.py
+++ b/metaci/testresults/tests/test_robot_importer.py
@@ -9,14 +9,15 @@ from metaci.testresults import models, robot_importer
 
 @pytest.mark.django_db
 class RobotImporterTestCase(TestCase):
-    def setUp(self):
-        pass
-
     def test_nested_suites(self):
         buildflow = BuildFlowFactory()
         path = PurePath(__file__).parent / "robot_with_nested_suites.xml"
         robot_importer.import_robot_test_results(buildflow, path)
         assert models.TestResult.objects.all(), "Test results should have been created"
+        test_result = models.TestResult.objects.get(method__name__contains="AAAAA")
+        assert test_result.duration == 0.25
+        assert test_result.method.name == "AAAAA Test Set Login Url"
+        assert test_result.method.testclass.name == "Nested/Cumulusci/Base"
 
     def test_basic_parsing(self):
         buildflow = BuildFlowFactory()
@@ -25,12 +26,22 @@ class RobotImporterTestCase(TestCase):
         test_results = models.TestResult.objects.filter(method__name="FakeTestResult")
         assert test_results[0].duration == 71.008
 
-    def test_duration_calcuations(self):
+    def test_duration_calculations(self):
         buildflow = BuildFlowFactory()
         path = PurePath(__file__).parent / "robot_with_setup_teardown.xml"
         robot_importer.import_robot_test_results(buildflow, path)
-        res = 14.002
-        assert (
-            models.TestResult.objects.filter(method__name="FakeTestResult2")[0].duration
-            == res
-        )
+        correct = 14.002
+        duration = models.TestResult.objects.get(
+            method__name="FakeTestResult2"
+        ).duration
+        assert duration == correct
+        correct = 15.001
+        duration = models.TestResult.objects.get(
+            method__name="FakeTestResult_setup_no_teardown"
+        ).duration
+        assert duration == correct
+        correct = 20.002
+        duration = models.TestResult.objects.get(
+            method__name="FakeTestResult_teardown_no_setup"
+        ).duration
+        assert duration == correct


### PR DESCRIPTION
Fixed 3 bugs:

 1. Use of a defaulted mutable in a function signature caused errors when the function is used multiple times in a single process.

 2. The code for setting test_info["duration"] was wrong because 10 microseconds would be rendered to essentially the same thing as 100000 microseconds.

https://github.com/SFDO-Tooling/MetaCI/compare/feature/calculate-durations-properly?expand=1#diff-6f1d244dba8bbd99d9457d42f1869c97L145

 3. Durations included setup and teardown time. Now they don't.

https://github.com/SFDO-Tooling/MetaCI/compare/feature/calculate-durations-properly?expand=1#diff-6f1d244dba8bbd99d9457d42f1869c97R160

Also a few minor readability refactorings.
