### PR TITLE
📦 fixes

### DIFF
--- a/metaci/build/management/commands/run_build.py
+++ b/metaci/build/management/commands/run_build.py
@@ -63,6 +63,9 @@ class Command(BaseCommand):
 
             assert status, "Could not lock org"
 
-        dyno = os.environ["DYNO"]
-        print(f"Running build {build.pk} in {dyno}")
+        dyno = os.environ.get("DYNO")
+        if dyno:
+            print(f"Running build {build.pk} in {dyno}")
+        else:
+            print(f"Running build {build.pk}")
         run_build(build.pk)

--- a/metaci/build/models.py
+++ b/metaci/build/models.py
@@ -10,11 +10,10 @@ import zipfile
 from glob import iglob
 from io import BytesIO
 
-from cumulusci.core.config import FAILED_TO_CREATE_SCRATCH_ORG, FlowConfig
+from cumulusci.core.config import FAILED_TO_CREATE_SCRATCH_ORG
 from cumulusci.core.exceptions import (
     ApexTestException,
     BrowserTestFailure,
-    FlowNotFoundError,
     RobotTestFailure,
     ScratchOrgException,
 )
@@ -625,10 +624,7 @@ class BuildFlow(models.Model):
         # the repo
         sys.path.append(project_config.repo_root)
 
-        flow = getattr(project_config, "flows__{}".format(self.flow))
-        if not flow:
-            raise FlowNotFoundError("Flow not found: {}".format(self.flow))
-        flow_config = FlowConfig(flow)
+        flow_config = project_config.get_flow(self.flow)
 
         callbacks = None
         if settings.METACI_FLOW_CALLBACK_ENABLED:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -41,7 +41,7 @@ django-rq-scheduler==1.1.3
 
 # CumulusCI
 cumulusci==3.1.0
-requests==2.22.0
+requests[security]==2.22.0
 
 # Salesforce Lightning Design System for Django
 django-slds-crispyforms==0.1.0  # pyup: ignore # there are releases with no package


### PR DESCRIPTION
This fixes 3 things:
1. Get the flow_config using the preferred API project_config.get_flow(), which now also takes care of attaching a reference from the flow config to the project config (which CCI now uses to know which project the flow came from)
2. Make the run_build command work even when the DYNO env var isn't set (i.e. locally, where I was using it as a handy way to run builds without a separate process being involved so it was easier to use the debugger)
3. Make sure requests is installed with the setuptools extra that includes pyOpenSSL. pyOpenSSL isn't supposed to actually be needed and in theory it was already there, but it is (due to carelessness in the code I added to cumulusci to deactivate it! I'll fix that later) and it wasn't (due to pip requirements ordering weirdness?)