### PR TITLE
Specify the test Django settings in a higher-precedence way

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,7 @@
 [pytest]
-DJANGO_SETTINGS_MODULE=config.settings.test
+# Use test settings, in a way that takes precedence
+# over the DJANGO_SETTINGS_MODULE environment variable
+addopts = --ds=config.settings.test
+
 python_files = test_*.py
 norecursedirs = node_modules dist src


### PR DESCRIPTION
@boakley I figured out a way to specify the Django settings module for tests that will take precedence over the environment variable.