### PR TITLE
Install Snowfakery optionally

### DIFF
--- a/bin/post_compile
+++ b/bin/post_compile
@@ -1,0 +1,6 @@
+echo SFDO_METACI_DEPLOY=${SFDO_METACI_DEPLOY}
+if [[ -z "${SFDO_METACI_DEPLOY}" ]]; then
+    echo Installing from sfdo-metaci.txt
+    pip3 install -r requirements/sfdo-metaci.txt > /dev/null 2>&1 || echo Pip install failed. Error suppressed for security reasons
+fi
+echo "Ran post_compile hook"

--- a/requirements/sfdo-metaci.txt
+++ b/requirements/sfdo-metaci.txt
@@ -1,0 +1,1 @@
+git+https://${GITHUB_USERNAME}:${GITHUB_TOKEN}@github.com/SalesforceFoundation/Snowfakery.git@master


### PR DESCRIPTION
Install Snowfakery only if the SFDO_METACI_DEPLOY environment variable is set.

Supply username and password with environment variables.

Suppress output for security reasons.
