### PR TITLE
Deal with wrong pip version and other minor stuff

### DIFF
--- a/bin/post_compile
+++ b/bin/post_compile
@@ -1,10 +1,11 @@
 echo SFDO_METACI_DEPLOY=${SFDO_METACI_DEPLOY}
+pip install --upgrade pip    # Upgrade pip to get embeddable env vars feature
 pip --version
-if [[ -z "${SFDO_METACI_DEPLOY}" ]]; then
+if [ -n "${SFDO_METACI_DEPLOY}" ]; then
     echo Installing from sfdo-metaci.txt
-    pip3 install -r requirements/sfdo-metaci.txt > /dev/null 2>&1 || echo Pip install failed. Error suppressed for security reasons
+    pip3 install -r requirements/sfdo-metaci.txt > /dev/null  # Pip is obscuring the password now
 else
     echo Not installing from sfdo-metaci.txt
 fi
-python -m snowfakery || echo "Warning: Snowfakery is not installed. If you don't use it, that is not a problem."
+python -m snowfakery.cli --version || echo "Warning: Snowfakery is not installed. If you don't use it, that is not a problem."
 echo "Ran hook from bin/post_compile"


### PR DESCRIPTION
Pip on metaci has an old version. I'm not thrilled about upgrading it mid-deploy but I'm open to better suggestions. I need the new version for environment variable stuff.

I added a --version command to snowfakery to make it easier to use it in this context (and because it is generally useful).

After I changed GITHUB_TOKEN to GITHUB_PASSWORD, pip started scrubbing the password, so I took out the code that I had from before to do it myself.
