### PR TITLE
Move pip upgrade from post_compile to pre_compile

### DIFF
--- a/bin/post_compile
+++ b/bin/post_compile
@@ -1,6 +1,4 @@
 echo SFDO_METACI_DEPLOY=${SFDO_METACI_DEPLOY}
-pip install --upgrade pip    # Upgrade pip to get embeddable env vars feature
-pip --version
 if [ -n "${SFDO_METACI_DEPLOY}" ]; then
     echo Installing from sfdo-metaci.txt
     pip3 install -r requirements/sfdo-metaci.txt > /dev/null  # Pip is obscuring the password now

--- a/bin/pre_compile
+++ b/bin/pre_compile
@@ -1,0 +1,2 @@
+pip install --upgrade pip    # Upgrade pip to get embeddable env vars feature
+pip --version


### PR DESCRIPTION
 Move pip upgrade from post_compile to pre_compile so it is available earlier in the process.