### PR TITLE
Dependency fixes

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -78,12 +78,8 @@ PyJWT==1.7.1
 # Django Defender
 django-defender==0.6.2
 
-# Django Postgres Stats
-django-postgres-stats==1.0.0
-
 # SFDO Template Helpers for authorization middleware and other helpers
--e git+https://github.com/SFDO-Tooling/sfdo-template-helpers.git@v0.6.0#egg=sfdo_template_helpers
+https://github.com/SFDO-Tooling/sfdo-template-helpers/archive/v0.9.0.tar.gz
 
 # Let Javascript refer to Django URLs by name
 django-js-reverse==0.9.1
-


### PR DESCRIPTION
- Use our own Percentile aggregate instead of the one from django-postgres-stats so that we don't transitively require psycopg2 (we already require psycopg2-binary, which is easier to install since it's prebuilt as a binary wheel)
- Fix the percentile used for the NearMin aggregate (should be 0.05 instead of 0.5)
- Update to the latest sfdo-template-helpers, and install it from the source tarball instead of a git clone for better performance and to work around a pip bug that broke things when reinstalling the git clone.