### PR TITLE
Update repo build link title to add space

### DIFF
--- a/metaci/repository/templates/repository/repo_list.html
+++ b/metaci/repository/templates/repository/repo_list.html
@@ -27,7 +27,7 @@
           <td>
           {% for build in column %}
             {% if build.get_status == 'queued' or build.get_status == 'waiting' or build.get_status == 'running' %}
-              <a href="{{ build.get_absolute_url }}" title="Started: {{ build.get_time_start|naturaltime }}{{ build.commit }}">
+              <a href="{{ build.get_absolute_url }}" title="Started: {{ build.get_time_start|naturaltime }} Commit: {{ build.commit }}">
                 <div class="slds-media__figure"> 
                   {% autoescape off %}
                   <svg class="slds-button__icon slds-theme--default" aria-hidden="true">


### PR DESCRIPTION
This PR adds a space to the title of links to running builds on the
repo list. Before:

```
Started: 41&nbsp;minutes agof6599f5b5b3ce6767f170376796f809f633370a8
```

After:
```
Started: 41&nbsp;minutes ago Commit: f6599f5b5b3ce6767f170376796f809f633370a8
```


----

#