### PR TITLE
Fix a couple test result importer bugs

### DIFF
--- a/metaci/testresults/importer.py
+++ b/metaci/testresults/importer.py
@@ -64,7 +64,7 @@ def import_test_results(build_flow, results, test_type):
             method, created = TestMethod.objects.get_or_create(
                 testclass=testclass, name=result["Method"]
             )
-            methods[result["Method"]] = method
+            methods[class_and_method] = method
 
         duration = None
         if (

--- a/metaci/testresults/robot_importer.py
+++ b/metaci/testresults/robot_importer.py
@@ -168,7 +168,7 @@ def parse_test(test, suite, root):
 
     test_info = {
         "suite": suite,
-        "name": test.attrib["name"],
+        "name": test.attrib.get("name") or "<no name>",
         "elem": test,
         "status": "Pass" if status.attrib["status"] == "PASS" else "Fail",
         "screenshots": [],


### PR DESCRIPTION
- Handle tests with no name in the robot test importer (fixes #1097). In this case we set the name to `<no name>` because name is a required non-blank field in the TestMethod model.
- Use the correct key for the `methods` mapping that's used as a cache of TestMethod objects in the Apex test importer