### PR TITLE
Exclude build log fields from fulltext indexing

### DIFF
--- a/metaci/build/apps.py
+++ b/metaci/build/apps.py
@@ -5,11 +5,12 @@ from watson import search as watson
 
 
 class BuildConfig(AppConfig):
-    name = 'metaci.build'
+    name = "metaci.build"
 
     def ready(self):
-        import metaci.build.handlers
-        Build = self.get_model('Build')
-        BuildFlow = self.get_model('BuildFlow')
-        watson.register(Build)
-        watson.register(BuildFlow)
+        import metaci.build.handlers  # noqa; side effect import
+
+        Build = self.get_model("Build")
+        BuildFlow = self.get_model("BuildFlow")
+        watson.register(Build, exclude=["log"])
+        watson.register(BuildFlow, exclude=["log"])


### PR DESCRIPTION
Removing the build logs from the fields that get indexed to cut down on db size and memory use.

I'll need to rebuild the index using the buildwatson management command after deploying this.