### PR TITLE
handle github status events with no branch

### DIFF
--- a/metaci/repository/views.py
+++ b/metaci/repository/views.py
@@ -185,7 +185,8 @@ def get_repository(event):
 
 
 def get_branch_name_from_payload(event):
-    if "branches" in event:
+    branches = event.get("branches")
+    if branches:
         branch_name = event["branches"][0]["name"]
         return branch_name
 


### PR DESCRIPTION
Fixes an error if we receive a status event from github with no branch specified