### PR TITLE
Hide "Robot Results" Tab

### DIFF
--- a/metaci/repository/templates/repository/repo_branches.html
+++ b/metaci/repository/templates/repository/repo_branches.html
@@ -19,13 +19,23 @@
 
 <div class="slds-tabs--default">
   <ul class="slds-tabs--default__nav" role="tablist">
-    <li class="slds-tabs--default__item" title="Builds" role="presentation"><a class="slds-tabs--default__link" href="{{ repo.get_absolute_url }}" role="tab" tabindex="0" aria-selected="true" aria-controls="tab-default-1" id="tab-default-1__item">Latest Builds</a></li>
-    <li class="slds-tabs--default__item slds-active" title="Branches" role="presentation"><a class="slds-tabs--default__link" href="{{ repo.get_absolute_url }}/branches" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-default-2" id="tab-default-2__item">Branches</a></li>
-    <li class="slds-tabs--default__item" title="Plans" role="presentation"><a class="slds-tabs--default__link" href="{{ repo.get_absolute_url }}/plans" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-default-3" id="tab-default-3__item">Plans</a></li>
-    <li class="slds-tabs--default__item" title="Orgs" role="presentation"><a class="slds-tabs--default__link" href="{{ repo.get_absolute_url }}/orgs" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-default-4" id="tab-default-4__item">Orgs</a></li>
-    <li class="slds-tabs--default__item" title="Perf" role="presentation"><a class="slds-tabs--default__link" href="{{ repo.get_absolute_url }}/perf" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-default-5" id="tab-default-5__item">Perf (Beta)</a></li>
-    <li class="slds-tabs--default__item" title="Robot Results" role="presentation"><a class="slds-tabs--default__link" href="{{ repo.get_absolute_url }}/results" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-default-6" id="tab-default-6__item">Robot Results</a></li>
-<!-- <li class="slds-tabs--default__item" title="Tests" role="presentation"><a class="slds-tabs--default__link" href="{{ repo.get_absolute_url }}/tests" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-default-6" id="tab-default-6__item">Tests</a></li> -->
+    <li class="slds-tabs--default__item" title="Builds" role="presentation"><a class="slds-tabs--default__link"
+        href="{{ repo.get_absolute_url }}" role="tab" tabindex="0" aria-selected="true" aria-controls="tab-default-1"
+        id="tab-default-1__item">Latest Builds</a></li>
+    <li class="slds-tabs--default__item slds-active" title="Branches" role="presentation"><a
+        class="slds-tabs--default__link" href="{{ repo.get_absolute_url }}/branches" role="tab" tabindex="-1"
+        aria-selected="false" aria-controls="tab-default-2" id="tab-default-2__item">Branches</a></li>
+    <li class="slds-tabs--default__item" title="Plans" role="presentation"><a class="slds-tabs--default__link"
+        href="{{ repo.get_absolute_url }}/plans" role="tab" tabindex="-1" aria-selected="false"
+        aria-controls="tab-default-3" id="tab-default-3__item">Plans</a></li>
+    <li class="slds-tabs--default__item" title="Orgs" role="presentation"><a class="slds-tabs--default__link"
+        href="{{ repo.get_absolute_url }}/orgs" role="tab" tabindex="-1" aria-selected="false"
+        aria-controls="tab-default-4" id="tab-default-4__item">Orgs</a></li>
+    <li class="slds-tabs--default__item" title="Perf" role="presentation"><a class="slds-tabs--default__link"
+        href="{{ repo.get_absolute_url }}/perf" role="tab" tabindex="-1" aria-selected="false"
+        aria-controls="tab-default-5" id="tab-default-5__item">Perf (Beta)</a></li>
+    <!-- <li class="slds-tabs--default__item" title="Robot Results" role="presentation"><a class="slds-tabs--default__link" href="{{ repo.get_absolute_url }}/results" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-default-6" id="tab-default-6__item">Robot Results</a></li> -->
+    <!-- <li class="slds-tabs--default__item" title="Tests" role="presentation"><a class="slds-tabs--default__link" href="{{ repo.get_absolute_url }}/tests" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-default-6" id="tab-default-6__item">Tests</a></li> -->
   </ul>
   <div id="tab-default-2" class="slds-tabs--default__content slds-show" role="tabpanel" aria-labelledby="tab-default-2__item">
 

--- a/metaci/repository/templates/repository/repo_detail.html
+++ b/metaci/repository/templates/repository/repo_detail.html
@@ -19,12 +19,22 @@
 
 <div class="slds-tabs--default">
   <ul class="slds-tabs--default__nav" role="tablist">
-    <li class="slds-tabs--default__item slds-active" title="Builds" role="presentation"><a class="slds-tabs--default__link" href="{{ repo.get_absolute_url }}" role="tab" tabindex="0" aria-selected="true" aria-controls="tab-default-1" id="tab-default-1__item">Latest Builds</a></li>
-    <li class="slds-tabs--default__item" title="Branches" role="presentation"><a class="slds-tabs--default__link" href="{{ repo.get_absolute_url }}/branches" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-default-2" id="tab-default-2__item">Branches</a></li>
-    <li class="slds-tabs--default__item" title="Plans" role="presentation"><a class="slds-tabs--default__link" href="{{ repo.get_absolute_url }}/plans" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-default-3" id="tab-default-3__item">Plans</a></li>
-    <li class="slds-tabs--default__item" title="Orgs" role="presentation"><a class="slds-tabs--default__link" href="{{ repo.get_absolute_url }}/orgs" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-default-4" id="tab-default-4__item">Orgs</a></li>
-    <li class="slds-tabs--default__item" title="Perf" role="presentation"><a class="slds-tabs--default__link" href="{{ repo.get_absolute_url }}/perf" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-default-5" id="tab-default-5__item">Perf (Beta)</a></li>
-    <li class="slds-tabs--default__item" title="Robot Results" role="presentation"><a class="slds-tabs--default__link" href="{{ repo.get_absolute_url }}/results" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-default-6" id="tab-default-6__item">Robot Results</a></li>
+    <li class="slds-tabs--default__item slds-active" title="Builds" role="presentation"><a
+        class="slds-tabs--default__link" href="{{ repo.get_absolute_url }}" role="tab" tabindex="0" aria-selected="true"
+        aria-controls="tab-default-1" id="tab-default-1__item">Latest Builds</a></li>
+    <li class="slds-tabs--default__item" title="Branches" role="presentation"><a class="slds-tabs--default__link"
+        href="{{ repo.get_absolute_url }}/branches" role="tab" tabindex="-1" aria-selected="false"
+        aria-controls="tab-default-2" id="tab-default-2__item">Branches</a></li>
+    <li class="slds-tabs--default__item" title="Plans" role="presentation"><a class="slds-tabs--default__link"
+        href="{{ repo.get_absolute_url }}/plans" role="tab" tabindex="-1" aria-selected="false"
+        aria-controls="tab-default-3" id="tab-default-3__item">Plans</a></li>
+    <li class="slds-tabs--default__item" title="Orgs" role="presentation"><a class="slds-tabs--default__link"
+        href="{{ repo.get_absolute_url }}/orgs" role="tab" tabindex="-1" aria-selected="false"
+        aria-controls="tab-default-4" id="tab-default-4__item">Orgs</a></li>
+    <li class="slds-tabs--default__item" title="Perf" role="presentation"><a class="slds-tabs--default__link"
+        href="{{ repo.get_absolute_url }}/perf" role="tab" tabindex="-1" aria-selected="false"
+        aria-controls="tab-default-5" id="tab-default-5__item">Perf (Beta)</a></li>
+    <!-- <li class="slds-tabs--default__item" title="Robot Results" role="presentation"><a class="slds-tabs--default__link" href="{{ repo.get_absolute_url }}/results" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-default-6" id="tab-default-6__item">Robot Results</a></li> -->
     <!-- <li class="slds-tabs--default__item" title="Tests" role="presentation"><a class="slds-tabs--default__link" href="{{ repo.get_absolute_url }}/tests" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-default-5" id="tab-default-5__item">Tests</a></li> -->
   </ul>
   <div id="tab-default-1" class="slds-tabs--default__content slds-show" role="tabpanel" aria-labelledby="tab-default-1__item">

--- a/metaci/repository/templates/repository/repo_orgs.html
+++ b/metaci/repository/templates/repository/repo_orgs.html
@@ -19,12 +19,22 @@
 
 <div class="slds-tabs--default">
   <ul class="slds-tabs--default__nav" role="tablist">
-    <li class="slds-tabs--default__item" title="Builds" role="presentation"><a class="slds-tabs--default__link" href="{{ repo.get_absolute_url }}" role="tab" tabindex="0" aria-selected="true" aria-controls="tab-default-1" id="tab-default-1__item">Latest Builds</a></li>
-    <li class="slds-tabs--default__item" title="Branches" role="presentation"><a class="slds-tabs--default__link" href="{{ repo.get_absolute_url }}/branches" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-default-2" id="tab-default-2__item">Branches</a></li>
-    <li class="slds-tabs--default__item" title="Plans" role="presentation"><a class="slds-tabs--default__link" href="{{ repo.get_absolute_url }}/plans" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-default-3" id="tab-default-3__item">Plans</a></li>
-    <li class="slds-tabs--default__item slds-active" title="Orgs" role="presentation"><a class="slds-tabs--default__link" href="{{ repo.get_absolute_url }}/orgs" role="tab" tabindex="-1" aria-selected="true" aria-controls="tab-default-4" id="tab-default-4__item">Orgs</a></li>
-    <li class="slds-tabs--default__item" title="Perf" role="presentation"><a class="slds-tabs--default__link" href="{{ repo.get_absolute_url }}/perf" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-default-5" id="tab-default-5__item">Perf (Beta)</a></li>
-    <li class="slds-tabs--default__item" title="Robot Results" role="presentation"><a class="slds-tabs--default__link" href="{{ repo.get_absolute_url }}/results" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-default-6" id="tab-default-6__item">Robot Results</a></li>
+    <li class="slds-tabs--default__item" title="Builds" role="presentation"><a class="slds-tabs--default__link"
+        href="{{ repo.get_absolute_url }}" role="tab" tabindex="0" aria-selected="true" aria-controls="tab-default-1"
+        id="tab-default-1__item">Latest Builds</a></li>
+    <li class="slds-tabs--default__item" title="Branches" role="presentation"><a class="slds-tabs--default__link"
+        href="{{ repo.get_absolute_url }}/branches" role="tab" tabindex="-1" aria-selected="false"
+        aria-controls="tab-default-2" id="tab-default-2__item">Branches</a></li>
+    <li class="slds-tabs--default__item" title="Plans" role="presentation"><a class="slds-tabs--default__link"
+        href="{{ repo.get_absolute_url }}/plans" role="tab" tabindex="-1" aria-selected="false"
+        aria-controls="tab-default-3" id="tab-default-3__item">Plans</a></li>
+    <li class="slds-tabs--default__item slds-active" title="Orgs" role="presentation"><a
+        class="slds-tabs--default__link" href="{{ repo.get_absolute_url }}/orgs" role="tab" tabindex="-1"
+        aria-selected="true" aria-controls="tab-default-4" id="tab-default-4__item">Orgs</a></li>
+    <li class="slds-tabs--default__item" title="Perf" role="presentation"><a class="slds-tabs--default__link"
+        href="{{ repo.get_absolute_url }}/perf" role="tab" tabindex="-1" aria-selected="false"
+        aria-controls="tab-default-5" id="tab-default-5__item">Perf (Beta)</a></li>
+    <!-- <li class="slds-tabs--default__item" title="Robot Results" role="presentation"><a class="slds-tabs--default__link" href="{{ repo.get_absolute_url }}/results" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-default-6" id="tab-default-6__item">Robot Results</a></li> -->
     <!-- <li class="slds-tabs--default__item" title="Tests" role="presentation"><a class="slds-tabs--default__link" href="{{ repo.get_absolute_url }}/tests" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-default-5" id="tab-default-5__item">Tests</a></li> -->
   </ul>
   <div id="tab-default-4" class="slds-tabs--default__content slds-show" role="tabpanel" aria-labelledby="tab-default-4__item">

--- a/metaci/repository/templates/repository/repo_perf.html
+++ b/metaci/repository/templates/repository/repo_perf.html
@@ -21,13 +21,23 @@
 
 <div class="slds-tabs--default">
   <ul class="slds-tabs--default__nav" role="tablist">
-    <li class="slds-tabs--default__item" title="Builds" role="presentation"><a class="slds-tabs--default__link" href="{{ repo.get_absolute_url }}" role="tab" tabindex="0" aria-selected="true" aria-controls="tab-default-1" id="tab-default-1__item">Latest Builds</a></li>
-    <li class="slds-tabs--default__item" title="Branches" role="presentation"><a class="slds-tabs--default__link" href="{{ repo.get_absolute_url }}/branches" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-default-2" id="tab-default-2__item">Branches</a></li>
-    <li class="slds-tabs--default__item" title="Plans" role="presentation"><a class="slds-tabs--default__link" href="{{ repo.get_absolute_url }}/plans" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-default-3" id="tab-default-3__item">Plans</a></li>
-    <li class="slds-tabs--default__item" title="Orgs" role="presentation"><a class="slds-tabs--default__link" href="{{ repo.get_absolute_url }}/orgs" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-default-4" id="tab-default-4__item">Orgs</a></li>
-    <li class="slds-tabs--default__item {% if tab == 'perf' %}slds-active {% endif %}" title="Perf" role="presentation"><a class="slds-tabs--default__link" href="{{ repo.get_absolute_url }}/perf" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-default-5" id="tab-default-5__item">Perf (Beta)</a></li>
-    <li class="slds-tabs--default__item" title="Robot Results" role="presentation"><a class="slds-tabs--default__link" href="{{ repo.get_absolute_url }}/results" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-default-6" id="tab-default-6__item">Robot Results</a></li>
-<!--    <li class="slds-tabs--default__item {% if tab == 'tests' %}slds-active {% endif %}" title="Tests" role="presentation"><a class="slds-tabs--default__link" href="{{ repo.get_absolute_url }}/tests?include_fields=repo&include_fields=duration&page_size=10" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-default-5" id="tab-default-5__item">Tests</a></li> -->
+    <li class="slds-tabs--default__item" title="Builds" role="presentation"><a class="slds-tabs--default__link"
+        href="{{ repo.get_absolute_url }}" role="tab" tabindex="0" aria-selected="true" aria-controls="tab-default-1"
+        id="tab-default-1__item">Latest Builds</a></li>
+    <li class="slds-tabs--default__item" title="Branches" role="presentation"><a class="slds-tabs--default__link"
+        href="{{ repo.get_absolute_url }}/branches" role="tab" tabindex="-1" aria-selected="false"
+        aria-controls="tab-default-2" id="tab-default-2__item">Branches</a></li>
+    <li class="slds-tabs--default__item" title="Plans" role="presentation"><a class="slds-tabs--default__link"
+        href="{{ repo.get_absolute_url }}/plans" role="tab" tabindex="-1" aria-selected="false"
+        aria-controls="tab-default-3" id="tab-default-3__item">Plans</a></li>
+    <li class="slds-tabs--default__item" title="Orgs" role="presentation"><a class="slds-tabs--default__link"
+        href="{{ repo.get_absolute_url }}/orgs" role="tab" tabindex="-1" aria-selected="false"
+        aria-controls="tab-default-4" id="tab-default-4__item">Orgs</a></li>
+    <li class="slds-tabs--default__item {% if tab == 'perf' %}slds-active {% endif %}" title="Perf" role="presentation">
+      <a class="slds-tabs--default__link" href="{{ repo.get_absolute_url }}/perf" role="tab" tabindex="-1"
+        aria-selected="false" aria-controls="tab-default-5" id="tab-default-5__item">Perf (Beta)</a></li>
+    <!-- <li class="slds-tabs--default__item" title="Robot Results" role="presentation"><a class="slds-tabs--default__link" href="{{ repo.get_absolute_url }}/results" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-default-6" id="tab-default-6__item">Robot Results</a></li> -->
+    <!-- <li class="slds-tabs--default__item {% if tab == 'tests' %}slds-active {% endif %}" title="Tests" role="presentation"><a class="slds-tabs--default__link" href="{{ repo.get_absolute_url }}/tests?include_fields=repo&include_fields=duration&page_size=10" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-default-5" id="tab-default-5__item">Tests</a></li> -->
   </ul>
 </div>
 

--- a/metaci/repository/templates/repository/repo_plans.html
+++ b/metaci/repository/templates/repository/repo_plans.html
@@ -19,20 +19,25 @@
 
 <div class="slds-tabs--default">
   <ul class="slds-tabs--default__nav" role="tablist">
-    <li class="slds-tabs--default__item" title="Builds" role="presentation"><a class="slds-tabs--default__link" href="{{ repo.get_absolute_url }}"
-        role="tab" tabindex="0" aria-selected="true" aria-controls="tab-default-1" id="tab-default-1__item">Latest
+    <li class="slds-tabs--default__item" title="Builds" role="presentation"><a class="slds-tabs--default__link"
+        href="{{ repo.get_absolute_url }}" role="tab" tabindex="0" aria-selected="true" aria-controls="tab-default-1"
+        id="tab-default-1__item">Latest
         Builds</a></li>
-    <li class="slds-tabs--default__item" title="Branches" role="presentation"><a class="slds-tabs--default__link" href="{{ repo.get_absolute_url }}/branches"
-        role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-default-2" id="tab-default-2__item">Branches</a></li>
-    <li class="slds-tabs--default__item slds-active" title="Plans" role="presentation"><a class="slds-tabs--default__link"
-        href="{{ repo.get_absolute_url }}/plans" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-default-3"
-        id="tab-default-3__item">Plans</a></li>
-    <li class="slds-tabs--default__item" title="Orgs" role="presentation"><a class="slds-tabs--default__link" href="{{ repo.get_absolute_url }}/orgs"
-        role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-default-4" id="tab-default-4__item">Orgs</a></li>
-    <li class="slds-tabs--default__item" title="Perf" role="presentation"><a class="slds-tabs--default__link" href="{{ repo.get_absolute_url }}/perf" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-default-5" id="tab-default-5__item">Perf (Beta)</a></li>
-    <li class="slds-tabs--default__item" title="Robot Results" role="presentation"><a class="slds-tabs--default__link" href="{{ repo.get_absolute_url }}/results" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-default-6" id="tab-default-6__item">Robot Results</a></li>
+    <li class="slds-tabs--default__item" title="Branches" role="presentation"><a class="slds-tabs--default__link"
+        href="{{ repo.get_absolute_url }}/branches" role="tab" tabindex="-1" aria-selected="false"
+        aria-controls="tab-default-2" id="tab-default-2__item">Branches</a></li>
+    <li class="slds-tabs--default__item slds-active" title="Plans" role="presentation"><a
+        class="slds-tabs--default__link" href="{{ repo.get_absolute_url }}/plans" role="tab" tabindex="-1"
+        aria-selected="false" aria-controls="tab-default-3" id="tab-default-3__item">Plans</a></li>
+    <li class="slds-tabs--default__item" title="Orgs" role="presentation"><a class="slds-tabs--default__link"
+        href="{{ repo.get_absolute_url }}/orgs" role="tab" tabindex="-1" aria-selected="false"
+        aria-controls="tab-default-4" id="tab-default-4__item">Orgs</a></li>
+    <li class="slds-tabs--default__item" title="Perf" role="presentation"><a class="slds-tabs--default__link"
+        href="{{ repo.get_absolute_url }}/perf" role="tab" tabindex="-1" aria-selected="false"
+        aria-controls="tab-default-5" id="tab-default-5__item">Perf (Beta)</a></li>
+    <!-- <li class="slds-tabs--default__item" title="Robot Results" role="presentation"><a class="slds-tabs--default__link" href="{{ repo.get_absolute_url }}/results" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-default-6" id="tab-default-6__item">Robot Results</a></li> -->
     <!-- <li class="slds-tabs--default__item" title="Tests" role="presentation"><a class="slds-tabs--default__link" href="{{ repo.get_absolute_url }}/tests" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-default-5" id="tab-default-5__item">Tests</a></li> -->
-      </ul>
+  </ul>
   <div id="tab-default-3" class="slds-tabs--default__content slds-show" role="tabpanel" aria-labelledby="tab-default-3__item">
 
     <table class="slds-table slds-table--bordered slds-table--cell-buffer">


### PR DESCRIPTION
* Hide the "Robot Results" tab on the following templates:
     * `repo_branches.html`
     * `repo_detail.html`
     * `repo_orgs.html`
     * `repo_perf.html`
     * `repo_plans.html`

* View still available via its [original url](https://github.com/SFDO-Tooling/MetaCI/blob/fe7231b4f34f352677bb166bcb6154f00f0a399a/metaci/repository/urls.py#L38).