### PR TITLE
Add "Queued" Column for Builds

### DIFF
--- a/metaci/build/models.py
+++ b/metaci/build/models.py
@@ -262,6 +262,10 @@ class Build(models.Model):
     def get_error_message(self):
         return self.get_build_attr("error_message")
 
+    def get_commit(self):
+        """Return the first 6 characters of the commit sha, followed by an elipsis"""
+        return f"{self.commit[:6]}..."
+
     def get_qa_comment(self):
         return self.get_build_attr("qa_comment")
 

--- a/metaci/build/templates/build/build_list.html
+++ b/metaci/build/templates/build/build_list.html
@@ -30,10 +30,10 @@
         <div class="slds-truncate" title="">Queued</div>
       </th>
       <th scope="col">
-        <div class="slds-truncate" title="">Start Date</div>
+        <div class="slds-truncate" title="">Start Time</div>
       </th>
       <th scope="col">
-        <div class="slds-truncate" title="">End Date</div>
+        <div class="slds-truncate" title="">End Time</div>
       </th>
     </tr>
   </thead>

--- a/metaci/build/templates/build/build_list.html
+++ b/metaci/build/templates/build/build_list.html
@@ -27,7 +27,7 @@
         <div class="slds-truncate" title="">Branch/Tag</div>
       </th>
       <th scope="col">
-        <div class="slds-truncate" title="">Commit</div>
+        <div class="slds-truncate" title="">Queued</div>
       </th>
       <th scope="col">
         <div class="slds-truncate" title="">Start Date</div>
@@ -59,13 +59,13 @@
       <td data-label="Branch">
         <div class="slds-truncate" title="{{ build.branch.name }}">{{ build.branch.name }}</div>
       </td>
-      <td data-label="Commit">
-        <div class="slds-truncate" title="{{ build.commit }}">{{ build.commit }}</div>
+      <td data-label="Queued">
+        <div class="slds-truncate" title="{{ build.get_time_queue }}">{{ build.get_time_queue }}</div>
       </td>
-      <td data-label="Start Date">
+      <td data-label="Start Time">
         <div class="slds-truncate" title="{{ build.get_time_start }}">{{ build.get_time_start }}</div>
       </td>
-      <td data-label="End Date">
+      <td data-label="End Time">
         <div class="slds-truncate" title="{{ build.get_time_end }}">{{ build.get_time_end }}</div>
       </td>
     </tr>

--- a/metaci/build/tests/test_models.py
+++ b/metaci/build/tests/test_models.py
@@ -136,6 +136,12 @@ class TestBuild:
         build = BuildFactory()
         assert build.worker_id == "faker.1"
 
+    def test_get_commit(self):
+        build = BuildFactory()
+        commit_sha = build.commit
+        truncated_commit = build.get_commit()
+        assert f"{commit_sha[:6]}..." == truncated_commit
+
 
 @pytest.mark.django_db
 class TestBuildFlow:

--- a/metaci/cumulusci/templates/cumulusci/org_detail.html
+++ b/metaci/cumulusci/templates/cumulusci/org_detail.html
@@ -87,10 +87,10 @@
             <div class="slds-truncate" title="">Commit</div>
           </th>
           <th scope="col">
-            <div class="slds-truncate" title="">Start Date</div>
+            <div class="slds-truncate" title="">Start Time</div>
           </th>
           <th scope="col">
-            <div class="slds-truncate" title="">End Date</div>
+            <div class="slds-truncate" title="">End Time</div>
           </th>
         </tr>
       </thead>
@@ -124,10 +124,10 @@
           <td data-label="Commit">
             <div class="slds-truncate" title="{{ build.commit }}">{{ build.commit }}</div>
           </td>
-          <td data-label="Start Date">
+          <td data-label="Start Time">
             <div class="slds-truncate" title="{{ build.get_time_start }}">{{ build.get_time_start }}</div>
           </td>
-          <td data-label="End Date">
+          <td data-label="End Time">
             <div class="slds-truncate" title="{{ build.get_time_end }}">{{ build.get_time_end }}</div>
           </td>
         </tr>

--- a/metaci/cumulusci/templates/cumulusci/org_instance_detail.html
+++ b/metaci/cumulusci/templates/cumulusci/org_instance_detail.html
@@ -80,10 +80,10 @@
             <div class="slds-truncate" title="">Commit</div>
           </th>
           <th scope="col">
-            <div class="slds-truncate" title="">Start Date</div>
+            <div class="slds-truncate" title="">Start Time</div>
           </th>
           <th scope="col">
-            <div class="slds-truncate" title="">End Date</div>
+            <div class="slds-truncate" title="">End Time</div>
           </th>
         </tr>
       </thead>
@@ -109,10 +109,10 @@
           <td data-label="Commit">
             <div class="slds-truncate" title="{{ build.commit }}">{{ build.commit }}</div>
           </td>
-          <td data-label="Start Date">
+          <td data-label="Start Time">
             <div class="slds-truncate" title="{{ build.get_time_start }}">{{ build.get_time_start }}</div>
           </td>
-          <td data-label="End Date">
+          <td data-label="End Time">
             <div class="slds-truncate" title="{{ build.get_time_end }}">{{ build.get_time_end }}</div>
           </td>
         </tr>

--- a/metaci/fixtures/factories.py
+++ b/metaci/fixtures/factories.py
@@ -1,5 +1,6 @@
 import datetime
 import numbers
+import random
 
 import factory
 import factory.fuzzy
@@ -113,6 +114,7 @@ class BuildFactory(factory.django.DjangoModelFactory):
         lambda build: BranchFactory(repo=build.planrepo.repo)
     )
     status = factory.fuzzy.FuzzyChoice(BUILD_STATUS_NAMES)
+    commit = str(random.getrandbits(128))
 
 
 class BuildFlowFactory(factory.django.DjangoModelFactory):

--- a/metaci/plan/templates/plan/detail.html
+++ b/metaci/plan/templates/plan/detail.html
@@ -113,10 +113,10 @@
         <div class="slds-truncate" title="">Queued</div>
       </th>
       <th scope="col">
-        <div class="slds-truncate" title="">Start Date</div>
+        <div class="slds-truncate" title="">Start Time</div>
       </th>
       <th scope="col">
-        <div class="slds-truncate" title="">End Date</div>
+        <div class="slds-truncate" title="">End Time</div>
       </th>
     </tr>
   </thead>
@@ -143,7 +143,7 @@
       <td data-label="Queued">
         <div class="slds-truncate" title="{{ build.get_time_queue }}">{{ build.get_time_queue }}</div>
       </td>
-      <td data-label="Start Date">
+      <td data-label="Start Time">
         <div class="slds-truncate" title="{{ build.get_time_start }}">{{ build.get_time_start }}</div>
       </td>
       <td data-label="End Date">

--- a/metaci/plan/templates/plan/detail.html
+++ b/metaci/plan/templates/plan/detail.html
@@ -110,6 +110,9 @@
         <div class="slds-truncate" title="">Branch/Tag</div>
       </th>
       <th scope="col">
+        <div class="slds-truncate" title="">Queued</div>
+      </th>
+      <th scope="col">
         <div class="slds-truncate" title="">Start Date</div>
       </th>
       <th scope="col">
@@ -132,10 +135,13 @@
         <div class="slds-truncate" title="{{ build.repo }}">{{ build.repo }}</div>
       </td>
       <td data-label="Commit">
-        <div class="slds-truncate" title="{{ build.commit }}">{{ build.commit }}</div>
+        <div class="slds-truncate" title="{{ build.get_commit }}">{{ build.get_commit }}</div>
       </td>
       <td data-label="Branch">
         <div class="slds-truncate" title="{{ build.branch.name }}">{{ build.branch.name }}</div>
+      </td>
+      <td data-label="Queued">
+        <div class="slds-truncate" title="{{ build.get_time_queue }}">{{ build.get_time_queue }}</div>
       </td>
       <td data-label="Start Date">
         <div class="slds-truncate" title="{{ build.get_time_start }}">{{ build.get_time_start }}</div>

--- a/metaci/plan/templates/plan/plan_repo_detail.html
+++ b/metaci/plan/templates/plan/plan_repo_detail.html
@@ -86,6 +86,9 @@
         <div class="slds-truncate" title="">Branch/Tag</div>
       </th>
       <th scope="col">
+        <div class="slds-truncate" title="">Queued</div>
+      </th>
+      <th scope="col">
         <div class="slds-truncate" title="">Start Date</div>
       </th>
       <th scope="col">
@@ -105,10 +108,13 @@
           title="{{ build.get_status }}">{{ build.get_status }}</div>
       </td>
       <td data-label="Commit">
-        <div class="slds-truncate" title="{{ build.commit }}">{{ build.commit }}</div>
+        <div class="slds-truncate" title="{{ build.get_commit }}">{{ build.get_commit }}</div>
       </td>
       <td data-label="Branch">
         <div class="slds-truncate" title="{{ build.branch.name }}">{{ build.branch.name }}</div>
+      </td>
+      <td data-label="Queued">
+        <div class="slds-truncate" title="{{ build.get_time_queue }}">{{ build.get_time_queue }}</div>
       </td>
       <td data-label="Start Date">
         <div class="slds-truncate" title="{{ build.get_time_start }}">{{ build.get_time_start }}</div>

--- a/metaci/plan/templates/plan/plan_repo_detail.html
+++ b/metaci/plan/templates/plan/plan_repo_detail.html
@@ -89,10 +89,10 @@
         <div class="slds-truncate" title="">Queued</div>
       </th>
       <th scope="col">
-        <div class="slds-truncate" title="">Start Date</div>
+        <div class="slds-truncate" title="">Start Time</div>
       </th>
       <th scope="col">
-        <div class="slds-truncate" title="">End Date</div>
+        <div class="slds-truncate" title="">End Time</div>
       </th>
     </tr>
   </thead>
@@ -116,10 +116,10 @@
       <td data-label="Queued">
         <div class="slds-truncate" title="{{ build.get_time_queue }}">{{ build.get_time_queue }}</div>
       </td>
-      <td data-label="Start Date">
+      <td data-label="Start Time">
         <div class="slds-truncate" title="{{ build.get_time_start }}">{{ build.get_time_start }}</div>
       </td>
-      <td data-label="End Date">
+      <td data-label="End Time">
         <div class="slds-truncate" title="{{ build.get_time_end }}">{{ build.get_time_end }}</div>
       </td>
     </tr>

--- a/metaci/repository/templates/repository/branch_detail.html
+++ b/metaci/repository/templates/repository/branch_detail.html
@@ -32,10 +32,10 @@
         <div class="slds-truncate" title="">Commit</div>
       </th>
       <th scope="col">
-        <div class="slds-truncate" title="">Start Date</div>
+        <div class="slds-truncate" title="">Start Time</div>
       </th>
       <th scope="col">
-        <div class="slds-truncate" title="">End Date</div>
+        <div class="slds-truncate" title="">End Time</div>
       </th>
     </tr>
   </thead>
@@ -58,10 +58,10 @@
       <td data-label="Commit">
         <div class="slds-truncate" title="{{ build.commit }}">{{ build.commit }}</div>
       </td>
-      <td data-label="Start Date">
+      <td data-label="Start Time">
         <div class="slds-truncate" title="{{ build.get_time_start }}">{{ build.get_time_start }}</div>
       </td>
-      <td data-label="End Date">
+      <td data-label="End Time">
         <div class="slds-truncate" title="{{ build.get_time_end }}">{{ build.get_time_end }}</div>
       </td>
     </tr>

--- a/metaci/repository/templates/repository/commit_detail.html
+++ b/metaci/repository/templates/repository/commit_detail.html
@@ -32,10 +32,10 @@
         <div class="slds-truncate" title="">Branch/Tag</div>
       </th>
       <th scope="col">
-        <div class="slds-truncate" title="">Start Date</div>
+        <div class="slds-truncate" title="">Start Time</div>
       </th>
       <th scope="col">
-        <div class="slds-truncate" title="">End Date</div>
+        <div class="slds-truncate" title="">End Time</div>
       </th>
     </tr>
   </thead>
@@ -58,10 +58,10 @@
       <td data-label="Branch">
         <div class="slds-truncate" title="{{ build.branch.name }}">{{ build.branch.name }}</div>
       </td>
-      <td data-label="Start Date">
+      <td data-label="Start Time">
         <div class="slds-truncate" title="{{ build.get_time_start }}">{{ build.get_time_start }}</div>
       </td>
-      <td data-label="End Date">
+      <td data-label="End Time">
         <div class="slds-truncate" title="{{ build.get_time_end }}">{{ build.get_time_end }}</div>
       </td>
     </tr>

--- a/metaci/repository/templates/repository/repo_detail.html
+++ b/metaci/repository/templates/repository/repo_detail.html
@@ -48,6 +48,9 @@
             <div class="slds-truncate" title="">Commit</div>
           </th>
           <th scope="col">
+            <div class="slds-truncate" title="">Queued</div>
+          </th>
+          <th scope="col">
             <div class="slds-truncate" title="">Start Date</div>
           </th>
           <th scope="col">
@@ -71,7 +74,10 @@
             <div class="slds-truncate" title="{{ build.branch.name }}">{{ build.branch.name }}</div>
           </td>
           <td data-label="Commit">
-            <div class="slds-truncate" title="{{ build.commit }}">{{ build.commit }}</div>
+            <div class="slds-truncate" title="{{ build.get_commit }}">{{ build.get_commit }}</div>
+          </td>
+          <td data-label="Queued">
+            <div class="slds-truncate" title="{{ build.get_time_queue }}">{{ build.get_time_queue }}</div>
           </td>
           <td data-label="Start Date">
             <div class="slds-truncate" title="{{ build.get_time_start }}">{{ build.get_time_start }}</div>

--- a/metaci/repository/templates/repository/repo_detail.html
+++ b/metaci/repository/templates/repository/repo_detail.html
@@ -51,10 +51,10 @@
             <div class="slds-truncate" title="">Queued</div>
           </th>
           <th scope="col">
-            <div class="slds-truncate" title="">Start Date</div>
+            <div class="slds-truncate" title="">Start Time</div>
           </th>
           <th scope="col">
-            <div class="slds-truncate" title="">End Date</div>
+            <div class="slds-truncate" title="">End Time</div>
           </th>
         </tr>
       </thead>
@@ -79,10 +79,10 @@
           <td data-label="Queued">
             <div class="slds-truncate" title="{{ build.get_time_queue }}">{{ build.get_time_queue }}</div>
           </td>
-          <td data-label="Start Date">
+          <td data-label="Start Time">
             <div class="slds-truncate" title="{{ build.get_time_start }}">{{ build.get_time_start }}</div>
           </td>
-          <td data-label="End Date">
+          <td data-label="End Time">
             <div class="slds-truncate" title="{{ build.get_time_end }}">{{ build.get_time_end }}</div>
           </td>
         </tr>

--- a/metaci/testresults/templates/testresults/build_flow_compare_to.html
+++ b/metaci/testresults/templates/testresults/build_flow_compare_to.html
@@ -82,7 +82,7 @@
             <th>Plan</th>
             <th>Branch</th>
             <th>Status</th>
-            <th>Start Date</th>
+            <th>Start Time</th>
         </tr>
     </thead>
     <tbody>


### PR DESCRIPTION
* We now show a "Queued" column for builds which displays the date/time at which the build was placed in the queue.
These changes apply to the following templates:
     * `build/templates/build_list.html`
     * `build/templates/detail_rebuilds.html`
     * `plan/templates/detail.html`
     * `plan/templates/plan_repo_detail.html`
     * `repository/templates/repo_detail.html`

* Note: The "Commit" column has been removed from `build/templates/build_list.html` as it seemed the least useful and I wanted to reduce clutter with the addition of the new date/time field.

* The `build` model now has a `get_commit` method which returns a truncated version of the commit SHA. This will help reduce clutter when displaying commits in build info tables. The full commit SHA is still visible on the `build/detail_layout.html` template.

* `BuildFactory` has been updated to generate a commit(ish) string for test builds.