### PR TITLE
Further improvements: plan repo view

### DIFF
--- a/metaci/plan/templates/plan/plan_repo_detail.html
+++ b/metaci/plan/templates/plan/plan_repo_detail.html
@@ -1,16 +1,32 @@
 {% extends 'layout_full.html' %}
 
-{% block layout_header_text %}Latest Builds for {{ plan.name }}: {{ repo.name }}{% endblock %}
+{% block layout_header_text %}
+<ul class="slds-list_horizontal">
+  <li>
+    <a href="{{ plan.get_absolute_url }}">
+    <div class="slds-page-header__row">
+      <div class="slds-text-body_regular">
+        Plan
+      </div>
+    </div>
+    {{ plan.name }}
+    </a>
+  </li>
+  <li class="slds-p-left_large">
+    <a href="{{ repo.get_absolute_url }}">
+    <div class="slds-page-header__row">
+      <div class="slds-text-body_regular">
+        Repository
+      </div>
+    </div>
+    {{ repo.name }}
+    </a>
+  </li>
+</ul>
+{% endblock %}
 
 {% block layout_header_details %}
 <ul class="slds-grid slds-page-header__detail-row">
-
-  <li class="slds-page-header__detail-block">
-    <p class="slds-text-title slds-truncate slds-m-bottom--xx-small" title="Repository">Repository</p>
-    <p class="slds-text-body--regular slds-truncate" title="{{ repo.name }}">
-      <a href="{{repo.get_absolute_url}}">{{ repo.name }}</a>
-    </p>
-  </li>
   <li class="slds-page-header__detail-block">
     <p class="slds-text-title slds-truncate slds-m-bottom--xx-small" title="Role">Role</p>
     <p class="slds-text-body--regular slds-truncate" title="{{ plan.role }}">
@@ -64,9 +80,11 @@
 {% block layout_body %}
 {% if plan.description %}
 <div class="slds-box">
-  <h3 class="slds-heading slds-heading--large">Description</h3>
+  <h3 class="slds-heading slds-heading--large">Plan Description</h3>
   <p>{{ plan.description }}</p>
 </div>
 {% endif %}
+
+<div class="slds-text-heading_medium slds-m-top_large">Latest Builds</div>
 {% include "build/build_table.html" %}
 {% endblock %}


### PR DESCRIPTION
* `plan_repo_detail.html` received the following improvements:
    * Fixed header record names to match new format
    * Made both record names link to their respective detail pages
    * Removed the repository detail info (and link) from the bar with the other plan info (this link is now available by clicking on the name of the repository).
    * Added "Plan" to "Plan Description"
    * Added a "Latest Builds" Header to denote these are the latest builds for the plan/repo combination

![Screen Shot 2020-11-25 at 6 58 09 PM](https://user-images.githubusercontent.com/6100538/100303195-d6a5a080-2f50-11eb-9ff2-0815716bc4cc.png)
