### PR TITLE
f strings!

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -246,7 +246,7 @@ ROOT_URLCONF = "config.urls"
 
 # Location of root django.contrib.admin URL, use {% url 'admin:index' %}
 ADMIN_URL = env("DJANGO_ADMIN_URL", default="admin")
-ADMIN_URL_ROUTE = r"^{}/".format(ADMIN_URL)
+ADMIN_URL_ROUTE = rf"^{ADMIN_URL}/"
 
 # Forward-compatible alias for use with IP-checking middleware
 ADMIN_AREA_PREFIX = ADMIN_URL

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -97,7 +97,7 @@ INSTALLED_APPS += ("django_extensions",)
 
 # URL that handles the media served from MEDIA_ROOT, used for managing
 # stored files.
-# MEDIA_URL = 'https://s3.amazonaws.com/{}/'.format(AWS_STORAGE_BUCKET_NAME)
+# MEDIA_URL = f'https://s3.amazonaws.com/{AWS_STORAGE_BUCKET_NAME}/'
 # DEFAULT_FILE_STORAGE = 'config.settings.storage_backends.MediaStorage'
 
 # TESTING

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -106,7 +106,7 @@ AWS_DEFAULT_ACL = None
 
 # URL that handles the media served from MEDIA_ROOT, used for managing
 # stored files.
-MEDIA_URL = "https://s3.amazonaws.com/{}/".format(AWS_STORAGE_BUCKET_NAME)
+MEDIA_URL = f"https://s3.amazonaws.com/{AWS_STORGAE_BUCKET_NAME}/"
 DEFAULT_FILE_STORAGE = "config.settings.storage_backends.MediaStorage"
 
 # Static Assets
@@ -168,7 +168,7 @@ DATABASES["default"] = env.db("DATABASE_URL")
 # ------------------------------------------------------------------------------
 
 REDIS_MAX_CONNECTIONS = env.int("REDIS_MAX_CONNECTIONS", default=2)
-REDIS_LOCATION = "{0}/{1}".format(env("REDIS_URL", default="redis://127.0.0.1:6379"), 0)
+REDIS_LOCATION = f"{env("REDUS_URL", default="redis://127.0.0.1:6379")}/0"
 # Heroku URL does not pass the DB number, so we parse it in
 CACHES = {
     "default": {

--- a/metaci/build/management/commands/metaci_scheduled_jobs.py
+++ b/metaci/build/management/commands/metaci_scheduled_jobs.py
@@ -21,14 +21,13 @@ class Command(BaseCommand):
         if created:
             self.stdout.write(
                 self.style.SUCCESS(
-                    "Created job check_waiting_builds with id {}".format(job.id)
+                    f"Created job check_waiting_builds with id {job.id}"
                 )
             )
         else:
             self.stdout.write(
                 self.style.SUCCESS(
-                    "Scheduled job check_waiting_builds with id {} already exists and is {}.".format(
-                        job.id, "enabled" if job.enabled else "disabled"
-                    )
+                    f"Scheduled job check_waiting_builds with id {job.id} "
+                    + f"already exists and is {'enabled' if job.enabled else 'disabled'}."
                 )
             )

--- a/metaci/build/models.py
+++ b/metaci/build/models.py
@@ -232,7 +232,7 @@ class Build(models.Model):
                 self.planrepo = matching_repo[0]
 
     def __str__(self):
-        return "{}: {} - {}".format(self.id, self.repo, self.commit)
+        return f"{self.id}: {self.repo} - {self.commit}"
 
     def get_log_html(self):
         if self.log:
@@ -242,7 +242,7 @@ class Build(models.Model):
         return reverse("build_detail", kwargs={"build_id": str(self.id)})
 
     def get_external_url(self):
-        url = "{}{}".format(settings.SITE_URL, self.get_absolute_url())
+        url = f"{settings.SITE_URL}{self.get_absolute_url()}"
         return url
 
     def get_build(self):
@@ -311,9 +311,7 @@ class Build(models.Model):
 
         if self.schedule:
             self.logger.info(
-                "Build triggered by {} schedule #{}".format(
-                    self.schedule.schedule, self.schedule.id
-                )
+                f"Build triggered by {self.schedule.schedule} schedule #{self.schedule.id}"
             )
 
         try:
@@ -358,7 +356,7 @@ class Build(models.Model):
             flows = [flow.strip() for flow in self.plan.flows.split(",")]
             for flow in flows:
                 self.logger = init_logger(self)
-                self.logger.info("Running flow: {}".format(flow))
+                self.logger.info(f"Running flow: {flow}")
                 self.save()
 
                 build_flow = BuildFlow(
@@ -370,14 +368,10 @@ class Build(models.Model):
                 if build_flow.status != "success":
                     self.logger = init_logger(self)
                     self.logger.error(
-                        "Build flow {} completed with status {}".format(
-                            flow, build_flow.status
-                        )
+                        f"Build flow {flow} completed with status {build_flow.status}"
                     )
                     self.logger.error(
-                        "    {}: {}".format(
-                            build_flow.exception, build_flow.error_message
-                        )
+                        f"    {build_flow.exception}: {build_flow.error_message}"
                     )
                     set_build_info(
                         build,
@@ -394,7 +388,7 @@ class Build(models.Model):
                 else:
                     self.logger = init_logger(self)
                     self.logger.info(
-                        "Build flow {} completed successfully".format(flow)
+                        f"Build flow {flow} completed successfully"
                     )
                     self.flush_log()
                     self.save()
@@ -449,13 +443,13 @@ class Build(models.Model):
         zip_content = BytesIO()
         self.repo.github_api.archive("zipball", zip_content, ref=self.commit)
         build_dir = tempfile.mkdtemp()
-        self.logger.info("-- Extracting zip to temp dir {}".format(build_dir))
+        self.logger.info(f"-- Extracting zip to temp dir {build_dir}")
         self.save()
         zip_file = zipfile.ZipFile(zip_content)
         zip_file.extractall(build_dir)
         # assume the zipfile has a single child dir with the repo
         build_dir = os.path.join(build_dir, os.listdir(build_dir)[0])
-        self.logger.info("-- Commit extracted to build dir: {}".format(build_dir))
+        self.logger.info(f"-- Commit extracted to build dir: {build_dir}")
         self.save()
 
         if self.plan.sfdx_config:
@@ -493,7 +487,7 @@ class Build(models.Model):
                     self.logger.warning(str(e))
                     self.logger.info(
                         "Retrying create scratch org "
-                        + "(retry {} of {})".format(attempt, retries)
+                        + f"(retry {attempt} of {retries})"
                     )
                     attempt += 1
                     continue
@@ -566,7 +560,7 @@ class Build(models.Model):
 
     def delete_build_dir(self):
         if hasattr(self, "build_dir"):
-            self.logger.info("Deleting build dir {}".format(self.build_dir))
+            self.logger.info(f"Deleting build dir {self.build_dir}")
             shutil.rmtree(self.build_dir)
             self.save()
 
@@ -599,14 +593,11 @@ class BuildFlow(models.Model):
     asset_hash = models.CharField(max_length=64, unique=True, default=generate_hash)
 
     def __str__(self):
-        return "{}: {} - {} - {}".format(
-            self.build.id, self.build.repo, self.build.commit, self.flow
-        )
-
+        return f"{self.build.id}: {self.build.repo} - {self.build.commit} - {self.flow}"
     def get_absolute_url(self):
         return reverse(
             "build_detail", kwargs={"build_id": str(self.build.id)}
-        ) + "#flow-{}".format(self.flow)
+        ) + f"#flow-{self.flow}"
 
     def get_log_html(self):
         if self.log:
@@ -708,7 +699,7 @@ class BuildFlow(models.Model):
     def load_test_results(self):
         has_results = False
 
-        root_dir_robot_path = "{}/output.xml".format(self.root_dir)
+        root_dir_robot_path = f"{self.root_dir}/output.xml"
         # Load robotframework's output.xml if found
         if os.path.isfile("output.xml"):
             has_results = True
@@ -731,9 +722,7 @@ class BuildFlow(models.Model):
                 results.extend(self.load_junit(filename))
             if not results:
                 self.logger.warning(
-                    "No results found at JUnit path {}".format(
-                        self.build.plan.junit_path
-                    )
+                    f"No results found at JUnit path {self.build.plan.junit_path}"
                 )
         if results:
             has_results = True
@@ -886,7 +875,7 @@ class FlowTask(models.Model):
     objects = FlowTaskManager()
 
     def __str__(self):
-        return "{}: {} - {}".format(self.build_flow_id, self.stepnum, self.path)
+        return f"{self.build_flow_id}: {self.stepnum} - {self.path}"
 
     class Meta:
         ordering = ["-build_flow", "stepnum"]

--- a/metaci/build/tasks.py
+++ b/metaci/build/tasks.py
@@ -124,7 +124,7 @@ def check_queued_build(build_id):
     try:
         org = build.org or Org.objects.get(name=build.plan.org, repo=build.repo)
     except Org.DoesNotExist:
-        message = "Could not find org configuration for org {}".format(build.plan.org)
+        message = f"Could not find org configuration for org {build.plan.org}"
         build.log = message
         build.set_status("error")
         build.save()
@@ -144,7 +144,7 @@ def check_queued_build(build_id):
         res_run = start_build(build)
         return (
             "DevHub has scratch org capacity, running the build "
-            + "as task {}".format(res_run.id)
+            + f"as task {res_run.id}"
         )
     else:
         # For persistent orgs, use the cache to lock the org
@@ -153,20 +153,16 @@ def check_queued_build(build_id):
         if status is True:
             # Lock successful, run the build
             res_run = start_build(build, org.lock_id)
-            return "Got a lock on the org, running as task {}".format(res_run.id)
+            return f"Got a lock on the org, running as task {res_run.id}"
         else:
             # Failed to get lock, queue next check
             build.task_id_check = None
             build.set_status("waiting")
-            build.log = "Waiting on build #{} to complete".format(
-                cache.get(org.lock_id)
-            )
+            build.log = f"Waiting on build #{cache.get(org.lock_id)} to complete"
             build.save()
             return (
                 "Failed to get lock on org. "
-                + "{} has the org locked. Queueing next check.".format(
-                    cache.get(org.lock_id)
-                )
+                + f"{cache.get(org.lock_id)} has the org locked. Queueing next check."
             )
 
 
@@ -184,7 +180,7 @@ def check_waiting_builds():
         build.save()
 
     if builds:
-        return "Checked waiting builds: {}".format(builds)
+        return f"Checked waiting builds: {builds}"
     else:
         return "No queued builds to check"
 
@@ -215,7 +211,7 @@ def delete_scratch_orgs():
     if not count:
         return "No orgs found to delete"
 
-    return "Scheduled deletion attempts for {} orgs".format(count)
+    return f"Scheduled deletion attempts for {count} orgs"
 
 
 @django_rq.job("short")
@@ -226,12 +222,10 @@ def delete_scratch_org(org_instance_id):
     try:
         org = ScratchOrgInstance.objects.get(id=org_instance_id)
     except ScratchOrgInstance.DoesNotExist:
-        return "Failed: could not find ScratchOrgInstance with id {}".format(
-            org_instance_id
-        )
+        return f"Failed: could not find ScratchOrgInstance with id {org_instance_id}"
 
     org.delete_org()
     if org.deleted:
-        return "Deleted org instance #{}".format(org.id)
+        return f"Deleted org instance #{org.id}"
     else:
-        return "Failed to delete org instance #{}".format(org.id)
+        return f"Failed to delete org instance #{ord.id}"

--- a/metaci/build/utils.py
+++ b/metaci/build/utils.py
@@ -62,7 +62,7 @@ def format_log(log):
     conv = Ansi2HTMLConverter(dark_bg=False, scheme="solarized", markup_lines=True)
     headers = conv.produce_headers()
     content = conv.convert(log, full=False)
-    content = '<pre class="ansi2html-content">{}</pre>'.format(content)
+    content = f'<pre class="ansi2html-content">{content}</pre>'
     return headers + content
 
 
@@ -85,5 +85,5 @@ def run_command(command, env=None, cwd=None):
     p.stdout.close()
     p.wait()
     if p.returncode:
-        message = "Return code: {}\nstderr: {}".format(p.returncode, p.stderr)
+        message = f"Return code: {p.returncode}\nstderr: {p.stderr}"
         raise CommandException(message)

--- a/metaci/build/views.py
+++ b/metaci/build/views.py
@@ -159,13 +159,11 @@ def build_rebuild(request, build_id):
     if not build.log:
         build.log = ""
 
-    build.log += "\n=== Build restarted at {} by {} ===\n".format(
-        timezone.now(), request.user.username
-    )
+    build.log += f"\n=== Build restarted at {timezone.now()} by {request.user.username} ===\n"
     build.current_rebuild = rebuild
     build.save()
 
-    return HttpResponseRedirect("/builds/{}".format(build.id))
+    return HttpResponseRedirect(f"/builds/{build.id}")
 
 
 @permission_required("build.search_builds")

--- a/metaci/cumulusci/keychain.py
+++ b/metaci/cumulusci/keychain.py
@@ -19,7 +19,7 @@ class MetaCIProjectKeychain(BaseProjectKeychain):
     def _load_keychain_services(self):
         for key, value in settings.__dict__["_wrapped"].__dict__.items():
             if key.startswith("CUMULUSCI_SERVICE_"):
-                print(f"%%% DEBUG %%%: {key[len('CUMULUSCI_SERVICE_' :)]}")
+                print(f"%%% DEBUG %%%: {key[len('CUMULUSCI_SERVICE_') :]}")
                 self.services[key[len("CUMULUSCI_SERVICE_") :]] = ServiceConfig(
                     json.loads(value)
                 )

--- a/metaci/cumulusci/keychain.py
+++ b/metaci/cumulusci/keychain.py
@@ -19,7 +19,7 @@ class MetaCIProjectKeychain(BaseProjectKeychain):
     def _load_keychain_services(self):
         for key, value in settings.__dict__["_wrapped"].__dict__.items():
             if key.startswith("CUMULUSCI_SERVICE_"):
-                print("%%% DEBUG %%%: {}".format(key[len("CUMULUSCI_SERVICE_") :]))
+                print(f"%%% DEBUG %%%: {key[len('CUMULUSCI_SERVICE_' :)]}")
                 self.services[key[len("CUMULUSCI_SERVICE_") :]] = ServiceConfig(
                     json.loads(value)
                 )

--- a/metaci/cumulusci/models.py
+++ b/metaci/cumulusci/models.py
@@ -63,7 +63,7 @@ class Org(models.Model):
         ordering = ["name", "repo__owner", "repo__name"]
 
     def __str__(self):
-        return "{}: {}".format(self.repo.name, self.name)
+        return f"{self.repo.name}: {self.name}"
 
     def get_absolute_url(self):
         return reverse("org_detail", kwargs={"org_id": self.id})
@@ -76,7 +76,7 @@ class Org(models.Model):
     @property
     def lock_id(self):
         if not self.scratch:
-            return "metaci-org-lock-{}".format(self.id)
+            return f"metaci-org-lock-{self.id}"
 
     @property
     def is_locked(self):
@@ -140,7 +140,7 @@ class ScratchOrgInstance(models.Model):
             return self.username
         if self.sf_org_id:
             return self.sf_org_id
-        return "{}: {}".format(self.org, self.id)
+        return f"{self.org}: {self.id}"
 
     def get_absolute_url(self):
         return reverse(
@@ -188,9 +188,7 @@ class ScratchOrgInstance(models.Model):
             sf = sf_session(sfjwt)
             # query ActiveScratchOrg via OrgId
             asos = sf.query(
-                "SELECT ID FROM ActiveScratchOrg WHERE ScratchOrg='{}'".format(
-                    self.sf_org_id
-                )
+                f"SELECT ID FROM ActiveScratchOrg WHERE ScratchOrg='{self.sf_org_id}'"
             )
             if asos["totalSize"] > 0:
                 aso = asos["records"][0]["Id"]

--- a/metaci/cumulusci/tasks.py
+++ b/metaci/cumulusci/tasks.py
@@ -18,4 +18,4 @@ def prune_orgs():
     count = pruneing_qs.update(
         deleted=True, time_deleted=timezone.now(), delete_error="Org is expired."
     )
-    return "pruned {} orgs".format(count)
+    return f"pruned {count} orgs"

--- a/metaci/cumulusci/views.py
+++ b/metaci/cumulusci/views.py
@@ -95,7 +95,7 @@ def org_login(request, org_id, instance_id=None):
         return HttpResponseRedirect(
             urljoin(
                 str(session["instance_url"]),
-                "secur/frontdoor.jsp?sid={}".format(session["access_token"]),
+                f"secur/frontdoor.jsp?sid={session['access_token']}",
             )
         )
 

--- a/metaci/notification/tasks.py
+++ b/metaci/notification/tasks.py
@@ -76,7 +76,7 @@ def queue_build_notifications(build_id):
     for user_id in users:
         send_notification_message.delay(build_id, user_id)
 
-    return "Enqueued send of {} notification messages".format(len(users))
+    return f"Enqueued send of {len(users)} notification messages"
 
 
 @django_rq.job("short", timeout=60)
@@ -97,12 +97,8 @@ def send_notification_message(build_id, user_id):
 
     context = {"build": build, "log_lines": log_lines}
 
-    subject = "[{}] Build #{} of {} {} - {}".format(
-        build.repo.name,
-        build.id,
-        build.branch.name,
-        build.plan.name,
-        build.get_status().upper(),
+    subject = (
+        f"[{build.repo.name}] Build #{build.id} of {build.branch.name} {build.plan.name} - {build.get_status().upper()}"
     )
     message = template_txt.render(context)
     html_message = template_html.render(context)

--- a/metaci/plan/management/commands/compressplans.py
+++ b/metaci/plan/management/commands/compressplans.py
@@ -67,10 +67,7 @@ class Command(BaseCommand):
                 for build in plan2.builds.select_for_update():
                     self.stdout.write(
                         self.style.WARNING(
-                            "Overwriting Plan ({} --> {}) for Build {}".format(
-                                build.plan, plan1, build
-                            )
-                        )
+                            f"Overwriting Plan ({build.plan} --> {plan1}) for Build {build}"                        )
                     )
                     build.plan = plan1
                     if not options["dry_run"]:
@@ -82,7 +79,7 @@ class Command(BaseCommand):
                 except PlanRepository.DoesNotExist:
                     self.stdout.write(
                         self.style.WARNING(
-                            "Linking Repository {} to Plan {}".format(repo, plan1)
+                            f"Linking Repository {repo} to Plan {plan1}"
                         )
                     )
                     if not options["dry_run"]:
@@ -90,12 +87,12 @@ class Command(BaseCommand):
             # delete/deactivate plan
             invalid_plans.add(plan2.pk)
             if options["delete"]:
-                self.stdout.write(self.style.WARNING("Deleting Plan {}".format(plan2)))
+                self.stdout.write(self.style.WARNING(f"Deleting Plan {plan2}"))
                 if not options["dry_run"]:
                     plan2.delete()
             else:
                 self.stdout.write(
-                    self.style.WARNING("Deactivating Plan {}".format(plan2))
+                    self.style.WARNING(f"Deactivating Plan {plan2}")
                 )
                 plan2.active = False
                 if not options["dry_run"]:

--- a/metaci/plan/models.py
+++ b/metaci/plan/models.py
@@ -52,7 +52,7 @@ def validate_yaml_field(value):
     try:
         yaml.safe_load(value)
     except yaml.YAMLError as err:
-        raise ValidationError("Error parsing additional YAML: {}".format(err))
+        raise ValidationError(f"Error parsing additional YAML: {err}")
 
 
 class PlanQuerySet(models.QuerySet):
@@ -231,7 +231,7 @@ class PlanRepository(models.Model):
         )
 
     def __str__(self):
-        return "[{}] {}".format(self.repo, self.plan)
+        return f"[{self.repo}] {self.plan}"
 
     def get_absolute_url(self):
         return reverse(

--- a/metaci/plan/tasks.py
+++ b/metaci/plan/tasks.py
@@ -14,19 +14,17 @@ def run_scheduled(schedule):
     schedules = PlanSchedule.objects.filter(schedule=schedule)
 
     log = []
-    log.append("Found {} {} schedules to run".format(schedules.count(), schedule))
+    log.append(f"Found {schedules.count()} {schedule} schedules to run")
 
     for sched in schedules:
         try:
             build = sched.run()
             log.append(
-                "Created build #{} from Plan {} on branch {}".format(
-                    build.id, sched.plan, sched.branch
-                )
+                f"Created build #{build.id} from Plan {sched.plan} on branch {sched.branch}"
             )
 
         except Exception as e:
-            log.append("Schedule {} failed with error:\n{}".format(sched, str(e)))
+            log.append(f"Schedule {sched} failed with error:\n{str(e)}")
 
     return "\n".join(log)
 

--- a/metaci/release/migrations/0003_populate_releases.py
+++ b/metaci/release/migrations/0003_populate_releases.py
@@ -47,7 +47,7 @@ def populate_build_release(apps, schema_editor):
                 repo=build.repo, git_tag=build.branch.name.replace("tag: ", "")
             )
         except ObjectDoesNotExist:
-            logger.error("Couldn't find Release for build #{}".format(build.id))
+            logger.error(f"Couldn't find Release for build #{build.id}")
             continue
         build.release = rel
         if build.plan.role == "release":

--- a/metaci/release/models.py
+++ b/metaci/release/models.py
@@ -91,7 +91,7 @@ class Release(StatusModel):
         unique_together = ("repo", "git_tag")
 
     def __str__(self):
-        return "{}: {}".format(self.repo, self.version_name)
+        return f"{self.repo}: {self.version_name}"
 
     def update_from_github(self):
         update_release_from_github(self)

--- a/metaci/release/utils.py
+++ b/metaci/release/utils.py
@@ -22,12 +22,10 @@ def update_release_from_github(release, repo_api=None):
     if not release.git_tag:
         logger.info("Cannot update release, no git_tag specified")
         return
-    ref = repo_api.ref("tags/{}".format(release.git_tag))
+    ref = repo_api.ref(f"tags/{release.git_tag}")
     if not ref:
         logger.info(
-            "Cannot update release, ref tags/{} not found in Github".format(
-                release.git_tag
-            )
+            f"Cannot update release, ref tags/{release.git_tag} not found in Github"
         )
         return
     gh_release = repo_api.release_by_tag_name(release.git_tag)

--- a/metaci/repository/models.py
+++ b/metaci/repository/models.py
@@ -48,7 +48,7 @@ class Repository(models.Model):
         return reverse("repo_detail", kwargs={"owner": self.owner, "name": self.name})
 
     def __str__(self):
-        return "{}/{}".format(self.owner, self.name)
+        return f"{self.owner}/{self.name}"
 
     @property
     def github_api(self):

--- a/metaci/repository/utils.py
+++ b/metaci/repository/utils.py
@@ -16,15 +16,13 @@ def create_status(build):
         description = "The build is running"
     if build.get_status() == "qa":
         state = "pending"
-        description = "{} is testing".format(build.user)
+        description = f"{build.user} is testing"
     if build.get_status() == "success":
         state = "success"
         if build.commit_status:
             description = build.commit_status
         elif build.plan.role == "qa":
-            description = "{} approved. See details for QA comments".format(
-                build.qa_user
-            )
+            description = f"{build.qa_user} approved. See details for QA comments"
         else:
             description = "The build was successful"
     elif build.get_status() == "error":
@@ -33,9 +31,7 @@ def create_status(build):
     elif build.get_status() == "fail":
         state = "failure"
         if build.plan.role == "qa":
-            description = "{} rejected. See details for QA comments".format(
-                build.qa_user
-            )
+            description = f"{build.qa_user} rejected. See details for QA comments"
         else:
             description = "Tests failed"
 

--- a/metaci/testresults/models.py
+++ b/metaci/testresults/models.py
@@ -75,7 +75,7 @@ class TestResultManager(models.Manager):
                     results[cls][method] = {}
 
                 for limit in result.get_limit_types():
-                    test_limit = "test_{}_used".format(limit)
+                    test_limit = f"test_{limit}_used"
 
                     if test_limit not in results[cls][method]:
                         results[cls][method][test_limit] = OrderedDict()

--- a/metaci/testresults/robot_importer.py
+++ b/metaci/testresults/robot_importer.py
@@ -42,7 +42,7 @@ def import_robot_test_results(build_flow, path):
 
     suite_screenshots = {}
     for result in parse_robot_output(path):
-        class_and_method = "{}.{}".format(result["suite"]["name"], result["name"])
+        class_and_method = f"{result['suite']['name']}.{result['name']}"
 
         testclass = classes.get(result["suite"]["name"], None)
         if not testclass:
@@ -60,7 +60,7 @@ def import_robot_test_results(build_flow, path):
                 continue
             screenshot_path = screenshot
             if dirname:
-                screenshot_path = "{}/{}".format(dirname, screenshot)
+                screenshot_path = f"{dirname}/{screenshot}"
             with open(screenshot_path, "rb") as f:
                 asset = BuildFlowAsset(
                     build_flow=build_flow,
@@ -97,7 +97,7 @@ def import_robot_test_results(build_flow, path):
             for screenshot in result["screenshots"]:
                 screenshot_path = screenshot
                 if dirname:
-                    screenshot_path = "{}/{}".format(dirname, screenshot)
+                    screenshot_path = f"{dirname}/{screenshot}"
                 with open(screenshot_path, "rb") as f:
                     asset = TestResultAsset(
                         result=testresult, asset=ContentFile(f.read(), screenshot)

--- a/metaci/testresults/views.py
+++ b/metaci/testresults/views.py
@@ -133,15 +133,15 @@ def test_result_detail(request, result_id):
             }
         )
         for stat in stats:
-            used = getattr(result, "{}_used".format(stat), None)
+            used = getattr(result, f"{stat}_used", None)
             if not used:
                 continue
             test_stats.append(
                 {
                     "limit": STATS_MAP[stat],
                     "used": used,
-                    "allowed": getattr(result, "{}_allowed".format(stat), None),
-                    "percent": getattr(result, "{}_percent".format(stat), None),
+                    "allowed": getattr(result, f"{stat}_allowed", None),
+                    "percent": getattr(result, f"{stat}_percent", None),
                 }
             )
         data["test_stats"] = test_stats

--- a/metaci/users/tests/factories.py
+++ b/metaci/users/tests/factories.py
@@ -2,8 +2,8 @@ import factory
 
 
 class UserFactory(factory.django.DjangoModelFactory):
-    username = factory.Sequence(lambda n: "user-{0}".format(n))
-    email = factory.Sequence(lambda n: "user-{0}@example.com".format(n))
+    username = factory.Sequence(lambda n: f"user-{n}")
+    email = factory.Sequence(lambda n: f"user-{n}@example.com")
     password = factory.PostGenerationMethodCall("set_password", "password")
 
     class Meta:

--- a/metaci/views.py
+++ b/metaci/views.py
@@ -16,17 +16,11 @@ class AboutView(TemplateView):
     def get_context_data(self, **kwargs):
         context = super(AboutView, self).get_context_data(**kwargs)
 
-        # django
-        context["DJANGO_VERSION"] = "{}.{}.{}".format(
-            django.VERSION[0],  # major
-            django.VERSION[1],  # minor
-            django.VERSION[2],  # micro
-        )
+        # django (major.minor.micro)
+        context["DJANGO_VERSION"] = f"{django.VERSION[0]}.{django.VERSION[1]}.{django.VERSION[2]}"
 
         # python
-        context["PYTHON_VERSION"] = "{}.{}.{}".format(
-            sys.version_info.major, sys.version_info.minor, sys.version_info.micro
-        )
+        context["PYTHON_VERSION"] = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
 
         # Salesforce DX
         out = subprocess.check_output(["sfdx", "--version"])


### PR DESCRIPTION
All but 6 references to `str.format()` now use f strings. One of these references I believe should remain (under `metaci/release.py` in `METACI_CHANGE_CASE_URL_TEMPLATE`). The other references are questionable.

For example, there are several in `robot_importer.py` that use an odd double quote syntax like: `'"{}"'.format(screenshot)`. I'm not sure if the double quotes are there for a reason, or if this was just a mistake that is working by chance.