### PR TITLE
fix AWS_STORAGE_BUCKET_NAME

### DIFF
--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -106,7 +106,7 @@ AWS_DEFAULT_ACL = None
 
 # URL that handles the media served from MEDIA_ROOT, used for managing
 # stored files.
-MEDIA_URL = f"https://s3.amazonaws.com/{AWS_STORGAE_BUCKET_NAME}/"
+MEDIA_URL = f"https://s3.amazonaws.com/{AWS_STORAGE_BUCKET_NAME}/"
 DEFAULT_FILE_STORAGE = "config.settings.storage_backends.MediaStorage"
 
 # Static Assets


### PR DESCRIPTION
I ran locally with the production settings. It complains about the SITE_URL, but that is to be expected.  I didn't see any f strings after that line in the config file, so going to assume this should work now 🤞 