### PR TITLE
use whitenoise in development, and load it after the security middleware

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -37,6 +37,7 @@ def url_prefix_list(val: str) -> List[str]:
 
 # APP CONFIGURATION
 # ------------------------------------------------------------------------------
+WHITENOISE_APPS = ("whitenoise.runserver_nostatic",)
 DJANGO_APPS = (
     # Default Django apps:
     "django.contrib.auth",
@@ -83,7 +84,7 @@ LOCAL_APPS = (
 )
 
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#installed-apps
-INSTALLED_APPS = DJANGO_APPS + THIRD_PARTY_APPS + LOCAL_APPS
+INSTALLED_APPS = WHITENOISE_APPS + DJANGO_APPS + THIRD_PARTY_APPS + LOCAL_APPS
 
 ALLOWED_HOSTS = [
     "127.0.0.1",
@@ -99,6 +100,7 @@ ALLOWED_HOSTS = [
 MIDDLEWARE = (
     "log_request_id.middleware.RequestIDMiddleware",
     "django.middleware.security.SecurityMiddleware",
+    "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -234,6 +234,8 @@ STATICFILES_FINDERS = (
     "django.contrib.staticfiles.finders.AppDirectoriesFinder",
 )
 
+WHITENOISE_ALLOW_ALL_ORIGINS = False
+
 # MEDIA CONFIGURATION
 # ------------------------------------------------------------------------------
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#media-root

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -36,8 +36,6 @@ INSTALLED_APPS += ("defender",)
 
 # Use Whitenoise to serve static files
 # See: https://whitenoise.readthedocs.io/
-WHITENOISE_MIDDLEWARE = ("whitenoise.middleware.WhiteNoiseMiddleware",)
-MIDDLEWARE = WHITENOISE_MIDDLEWARE + MIDDLEWARE
 RAVEN_MIDDLEWARE = (
     "raven.contrib.django.raven_compat.middleware.SentryResponseErrorIdMiddleware",
 )


### PR DESCRIPTION
We use `whitenoise` to serve static assets in production. This enables the "whitenoise.runserver_nostatic" app so that we also do so in development for consistency (http://whitenoise.evans.io/en/stable/django.html#using-whitenoise-in-development), and moves its middleware to follow SecurityMiddleware so that HSTS headers are also set for static URLs (http://whitenoise.evans.io/en/stable/django.html#enable-whitenoise).

I also turned off whitenoise's setting to add the Access-Control-Allow-Origin: * response header, which we don't need because we're not using a CDN.