### PR TITLE
Remove reference to metaci cli

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,11 +54,9 @@ You can also fork the CumulusCI-Test repository and use that as a demo since it 
 Getting Started
 ---------------
 MetaCI can be run locally or configured for use on Heroku.
-For local setup see `running`_
+For local setup see :ref: `running`.
 
-You can also reference the following session recordings showing live demos of how to configure `CumulusCI` and `MetaCI` for projects:
-https://www.youtube.com/watch?v=CgvYKDqb6Ng
-https://www.youtube.com/watch?v=TN-e785MqBA
+You can also reference `this session <https://www.youtube.com/watch?v=TN-e785MqBA>`_ from TrailheadDX '18 showing a live demo of how to configure `CumulusCI` and `MetaCI` for projects.
 
 Or, if you feel like deploying manually and configuring through the Admin interface:
 

--- a/README.rst
+++ b/README.rst
@@ -56,13 +56,9 @@ Getting Started
 MetaCI can be run locally or configured for use on Heroku.
 For local setup see `running <https://github.com/SFDO-Tooling/MetaCI/blob/main/docs/running.rst>`_.
 
-You can also reference `this session <https://www.youtube.com/watch?v=TN-e785MqBA>`_ from TrailheadDX '18 showing a live demo of how to configure `CumulusCI` and `MetaCI` for projects.
-
-Or, if you feel like deploying manually and configuring through the Admin interface:
-
-.. image:: https://www.herokucdn.com/deploy/button.svg
-   :target: https://heroku.com/deploy
-
+We're currently working on improving our documentation for deploying MetaCI on Heroku.
+If you have questions about production setup, please reach out to the SFDO Release Engineering Team,
+or post a question on the `CumulusCI Trailblazer Community Group <https://trailblazers.salesforce.com/_ui/core/chatter/groups/GroupProfilePage?g=0F9300000009M9Z>`_.
 RQ Worker
 ^^^^^^^^^
 

--- a/README.rst
+++ b/README.rst
@@ -53,11 +53,8 @@ You can also fork the CumulusCI-Test repository and use that as a demo since it 
 
 Getting Started
 ---------------
-
-The recommended way to deploy and configure `MetaCI` is via the `MetaCI-CLI` project which can access your local CumulusCI project configurations including repo info and org configs to quickly get you up and running with `MetaCI`.
-
-Full documentation on launching and configuring `MetaCI` on Heroku using the `MetaCI-CLI`:
-http://metaci-cli.readthedocs.io/
+MetaCI can be run locally or configured for use on Heroku.
+For local setup see `running`_
 
 You can also reference the following session recordings showing live demos of how to configure `CumulusCI` and `MetaCI` for projects:
 https://www.youtube.com/watch?v=CgvYKDqb6Ng

--- a/README.rst
+++ b/README.rst
@@ -65,20 +65,6 @@ Or, if you feel like deploying manually and configuring through the Admin interf
 .. image:: https://www.herokucdn.com/deploy/button.svg
    :target: https://heroku.com/deploy
 
-Basic Commands
---------------
-
-Create Your Initial Admin Account
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-* To create a **normal user account**, just go to Sign Up and fill out the form. Once you submit it, you'll see a "Verify Your E-mail Address" page. Go to your console to see a simulated email verification message. Copy the link into your browser. Now the user's email should be verified and ready to go.
-
-* To create an **superuser account**, use this command::
-
-    $ python manage.py createsuperuser
-
-For convenience, you can keep your normal user logged in on Chrome and your superuser logged in on Firefox (or similar), so that you can see how the site behaves for both kinds of users.
-
 RQ Worker
 ^^^^^^^^^
 

--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ You can also fork the CumulusCI-Test repository and use that as a demo since it 
 Getting Started
 ---------------
 MetaCI can be run locally or configured for use on Heroku.
-For local setup see :ref: `running`.
+For local setup see `running <https://github.com/SFDO-Tooling/MetaCI/blob/main/docs/running.rst>`_.
 
 You can also reference `this session <https://www.youtube.com/watch?v=TN-e785MqBA>`_ from TrailheadDX '18 showing a live demo of how to configure `CumulusCI` and `MetaCI` for projects.
 


### PR DESCRIPTION
* This removes the references to MetaCI cli in readme.rst. 

Outstanding item:
* I've replaced the mention of the cli with a note that MetaCI can be run locally or deployed into a production environment on Heroku. For local development we can link to `running.rst`. We have the "deploy to heroku" button, but do we have anything to point people to for setup on Heroku or is this a gap in our docs?