### PR TITLE
Remove reliance on github API in tests

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -302,9 +302,6 @@ AUTH_USER_MODEL = "users.User"
 LOGIN_REDIRECT_URL = "users:redirect"
 LOGIN_URL = "account_login"
 
-# SLUGLIFIER
-AUTOSLUG_SLUGIFY_FUNCTION = "slugify.slugify"
-
 # django-rq
 REDIS_URL = env("REDIS_URL", default="redis://localhost:6379")
 REDIS_URL += "/0"

--- a/metaci/repository/tests/test_model.py
+++ b/metaci/repository/tests/test_model.py
@@ -1,5 +1,6 @@
 from unittest import mock
 
+import github3.exceptions
 import pytest
 
 from metaci.fixtures.factories import BranchFactory
@@ -15,10 +16,22 @@ def test_branch_is_tag():
 
 
 @pytest.mark.django_db
-def test_branch_get_github_api():
+def test_branch_get_github_api__exception():
     branch = BranchFactory()
+    mock_gh = mock.Mock()
+    branch.repo.get_github_api = mock_gh
+
+    def raise_error(*args, **kwargs):
+        raise github3.exceptions.NotFoundError(mock.Mock())
+
+    mock_gh.return_value.branch = raise_error
+
     assert branch.get_github_api() is None
 
+
+@pytest.mark.django_db
+def test_branch_get_github_api__normal():
+    branch = BranchFactory()
     mock_gh = mock.Mock()
     mock_gh.return_value.branch.return_value = mock_branch_api = object()
     branch.repo.get_github_api = mock_gh

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -30,9 +30,6 @@ Pillow==8.1.0
 # For user registration, either via email or social
 django-allauth==0.44.0
 
-# Unicode slugification
-awesome-slugify==1.6.5
-
 # Redis support
 django-redis==4.12.1
 redis==3.5.3


### PR DESCRIPTION
Previously it was hanging for me perhaps because of github/SSO complaints.

I could PROBABLY make repro steps for the hanging situation if it is likely that someone would look into it.
