### PR TITLE
🛢 Make sure the SocialApp has the expect name so we don't create a duplicate

### DIFF
--- a/metaci/users/migrations/0004_github_socialapp.py
+++ b/metaci/users/migrations/0004_github_socialapp.py
@@ -12,7 +12,7 @@ def update_github_socialapp(apps, schema_editor):
         app = SocialApp.objects.get(provider="github")
     except SocialApp.DoesNotExist:
         app = SocialApp(provider="github")
-    app.name = "github"
+    app.name = "GitHub"
     app.client_id = "-"
     app.secret = ""
     app.save()


### PR DESCRIPTION
A small fix for the migration to update the github SocialApp, based on my testing in staging. It needs to have the name that we'll look for when someone logs in.