### PR TITLE
Adjust cache configuration to work with Redis 6

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -317,9 +317,25 @@ AUTH_USER_MODEL = "users.User"
 LOGIN_REDIRECT_URL = "users:redirect"
 LOGIN_URL = "account_login"
 
-# django-rq
+# Redis configuration
 REDIS_URL = env("REDIS_URL", default="redis://localhost:6379")
-REDIS_URL += "/0"
+REDIS_LOCATION = f"{REDIS_URL}/0"
+REDIS_MAX_CONNECTIONS = env.int("REDIS_MAX_CONNECTIONS", default=2)
+CACHES = {
+    "default": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": REDIS_LOCATION,
+        "OPTIONS": {
+            "CONNECTION_POOL_CLASS": "redis.BlockingConnectionPool",
+            "CONNECTION_POOL_KWARGS": {
+                "max_connections": REDIS_MAX_CONNECTIONS,
+                "timeout": 20,
+            },
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+            "IGNORE_EXCEPTIONS": True,
+        },
+    }
+}
 RQ_QUEUES = {
     "default": {
         "USE_REDIS_CACHE": "default",

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -41,26 +41,6 @@ EMAIL_BACKEND = env(
 )
 
 
-# CACHING
-# ------------------------------------------------------------------------------
-REDIS_MAX_CONNECTIONS = env.int("REDIS_MAX_CONNECTIONS", default=2)
-CACHES = {
-    "default": {
-        "BACKEND": "django_redis.cache.RedisCache",
-        "LOCATION": REDIS_URL,
-        "OPTIONS": {
-            "CONNECTION_POOL_CLASS": "redis.BlockingConnectionPool",
-            "CONNECTION_POOL_KWARGS": {
-                "max_connections": REDIS_MAX_CONNECTIONS,
-                "timeout": 20,
-            },
-            "CLIENT_CLASS": "django_redis.client.DefaultClient",
-            "IGNORE_EXCEPTIONS": True,  # mimics memcache behavior.
-            # http://niwinz.github.io/django-redis/latest/#_memcached_exceptions_behavior
-        },
-    }
-}
-
 # django-debug-toolbar
 # ------------------------------------------------------------------------------
 MIDDLEWARE += ("debug_toolbar.middleware.DebugToolbarMiddleware",)

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -35,25 +35,6 @@ EMAIL_PORT = 1025
 # for unit testing purposes
 EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
 
-# CACHING
-# ------------------------------------------------------------------------------
-# Speed advantages of in-memory caching without having to run Memcached
-CACHES = {
-    "default": {
-        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
-        "LOCATION": "",
-    }
-}
-
-# Use Redis for RQ queues instead of cache which uses LocMemCache
-RQ_QUEUES = {
-    "default": {"URL": REDIS_URL, "DEFAULT_TIMEOUT": 7200, "AUTOCOMMIT": False},
-    "high": {"URL": REDIS_URL, "DEFAULT_TIMEOUT": 7200, "AUTOCOMMIT": False},
-    "medium": {"URL": REDIS_URL, "DEFAULT_TIMEOUT": 7200, "AUTOCOMMIT": False},
-    "short": {"URL": REDIS_URL, "DEFAULT_TIMEOUT": 500, "AUTOCOMMIT": False},
-    "robot": {"URL": REDIS_URL, "DEFAULT_TIMEOUT": 7200, "AUTOCOMMIT": False},
-}
-
 
 # PASSWORD HASHING
 # ------------------------------------------------------------------------------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     - "5432:5432/tcp"
     restart: always
   redis:
-    image: "redis:5"
+    image: "redis:6"
     ports:
       - "6379:6379"
   web:


### PR DESCRIPTION
Tell django-redis not to worry about a self-signed certificate when connecting with TLS, since that's what Heroku Redis 6 gives us

I also took the opportunity to consolidate the cache configuration into base.py