### PR TITLE
Feature/robot 4

### DIFF
--- a/metaci/testresults/robot_importer.py
+++ b/metaci/testresults/robot_importer.py
@@ -241,7 +241,7 @@ def find_screenshots(root):
     if root is None:
         return []
     screenshots = []
-    for msg in root.findall(".//msg[@html='yes']"):
+    for msg in root.findall(".//msg[@html='true']"):
         txt = "".join([text for text in msg.itertext()])
         for screenshot in re.findall(r'href="([\w.-]+)">', txt):
             screenshots.append(screenshot)

--- a/metaci/testresults/robot_importer.py
+++ b/metaci/testresults/robot_importer.py
@@ -199,7 +199,10 @@ def parse_test(test, suite, root):
         "suite": suite,
         "name": test.attrib.get("name") or "<no name>",
         "elem": test,
-        "status": "Pass" if status.attrib["status"] == "PASS" else "Fail",
+        # Note: robot status should always be PASS, FAIL, or SKIP, so
+        # it's a simple transformation to become one of the values from
+        # OUTCOME_CHOICES in testresults/choices.py
+        "status": status.attrib["status"].capitalize(),
         "screenshots": [],
         "message": status.text,
         "failing_keyword": keyword,

--- a/metaci/testresults/robot_importer.py
+++ b/metaci/testresults/robot_importer.py
@@ -180,7 +180,6 @@ def parse_test(test, suite, root):
     zero = timedelta(seconds=0)
     setup_time = _robot_duration(setup.find("status")) if setup else zero
     teardown_time = _robot_duration(teardown.find("status")) if teardown else zero
-    tags = test.find("tags")
 
     # I'm not 100% convinced this is what we want. It's great in the
     # normal case, but it's possible for a test to have multiple failing
@@ -195,9 +194,7 @@ def parse_test(test, suite, root):
             if library:
                 keyword = f"{library}.{keyword}"
 
-    robot_tags = ",".join(
-        sorted([tag.text for tag in tags.iterfind("tag")]) if tags else []
-    )
+    robot_tags = ",".join(sorted([tag.text for tag in test.iterfind("tag")]))
     test_info = {
         "suite": suite,
         "name": test.attrib.get("name") or "<no name>",

--- a/metaci/testresults/robot_importer.py
+++ b/metaci/testresults/robot_importer.py
@@ -146,8 +146,8 @@ def get_robot_tests(root, elem, parents=()):
 
     if not has_children_suites:
         suite_file = elem.attrib["source"].replace(os.getcwd(), "")
-        setup = elem.find("kw[@type='setup']")
-        teardown = elem.find("kw[@type='teardown']")
+        setup = elem.find("kw[@type='SETUP']")
+        teardown = elem.find("kw[@type='TEARDOWN']")
         suite = {
             "file": suite_file,
             "elem": elem,
@@ -175,8 +175,8 @@ def _robot_duration(status_element):
 
 def parse_test(test, suite, root):
     status = test.find("status")
-    setup = test.find("kw[@type='setup']")
-    teardown = test.find("kw[@type='teardown']")
+    setup = test.find("kw[@type='SETUP']")
+    teardown = test.find("kw[@type='TEARDOWN']")
     zero = timedelta(seconds=0)
     setup_time = _robot_duration(setup.find("status")) if setup else zero
     teardown_time = _robot_duration(teardown.find("status")) if teardown else zero

--- a/metaci/testresults/tests/output_with_elapsed_times.xml
+++ b/metaci/testresults/tests/output_with_elapsed_times.xml
@@ -1,117 +1,91 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<robot generator="Robot 3.2.2 (Python 3.9.1 on darwin)" generated="20210301 14:20:18.962" rpa="false">
+<robot generator="Rebot 4.0.1 (Python 3.8.9 on darwin)" generated="20210511 15:19:11.175" rpa="false" schemaversion="2">
 <suite id="s1" name="Performance" source="/Users/pprescod/code/CumulusCI/cumulusci/robotframework/tests/salesforce/performance.robot">
 <test id="s1-t1" name="Test Elapsed Time For Last Record">
 <kw name="Salesforce Insert" library="cumulusci.robotframework.Salesforce">
-<doc>Creates a new Salesforce object and returns the Id.</doc>
-<arguments>
+<var>${contact_id}</var>
 <arg>Contact</arg>
 <arg>FirstName=Dummy1</arg>
 <arg>LastName=Dummy2</arg>
 <arg>EmailBouncedDate=2030-01-01T00:00:00</arg>
-</arguments>
-<assign>
-<var>${contact_id}</var>
-</assign>
+<doc>Creates a new Salesforce object and returns the Id.</doc>
 <msg timestamp="20210301 14:20:19.553" level="INFO">Inserting Contact with values {'FirstName': 'Dummy1', 'LastName': 'Dummy2', 'EmailBouncedDate': '2030-01-01T00:00:00'}</msg>
 <msg timestamp="20210301 14:20:21.136" level="INFO">Storing Contact 003R000001aWPbLIAW to session records</msg>
 <msg timestamp="20210301 14:20:21.138" level="INFO">${contact_id} = 003R000001aWPbLIAW</msg>
-<msg timestamp="20210301 14:20:21.138" level="INFO" />
-<status status="PASS" starttime="20210301 14:20:19.553" endtime="20210301 14:20:21.138"></status>
+<msg timestamp="20210301 14:20:21.138" level="INFO"/>
+<status status="PASS" starttime="20210301 14:20:19.553" endtime="20210301 14:20:21.138"/>
 </kw>
 <kw name="Elapsed Time For Last Record" library="cumulusci.robotframework.Salesforce">
-<doc>For records representing jobs or processes, compare the record's start-time to its end-time to see how long a process took.</doc>
-<arguments>
+<var>${Elapsed}</var>
 <arg>obj_name=Contact</arg>
 <arg>where=Id='${contact_id}'</arg>
 <arg>start_field=CreatedDate</arg>
 <arg>end_field=EmailBouncedDate</arg>
 <arg>order_by=EmailBouncedDate</arg>
-</arguments>
-<assign>
-<var>${Elapsed}</var>
-</assign>
+<doc>For records representing jobs or processes, compare the record's start-time to its end-time to see how long a process took.</doc>
 <msg timestamp="20210301 14:20:21.154" level="INFO">Running SOQL Query: SELECT CreatedDate, EmailBouncedDate FROM Contact WHERE Id='003R000001aWPbLIAW' ORDER BY EmailBouncedDate DESC NULLS LAST LIMIT 1</msg>
 <msg timestamp="20210301 14:20:21.583" level="INFO">${Elapsed} = 278818780.0</msg>
-<status status="PASS" starttime="20210301 14:20:21.153" endtime="20210301 14:20:21.583"></status>
+<status status="PASS" starttime="20210301 14:20:21.153" endtime="20210301 14:20:21.583"/>
 </kw>
 <kw name="Should Be True" library="BuiltIn">
-<doc>Fails if the given condition is not true.</doc>
-<arguments>
 <arg>${Elapsed} &gt;= 100_000</arg>
-</arguments>
-<status status="PASS" starttime="20210301 14:20:21.583" endtime="20210301 14:20:21.584"></status>
+<doc>Fails if the given condition is not true.</doc>
+<status status="PASS" starttime="20210301 14:20:21.583" endtime="20210301 14:20:21.584"/>
 </kw>
 <kw name="Salesforce Insert" library="cumulusci.robotframework.Salesforce">
-<doc>Creates a new Salesforce object and returns the Id.</doc>
-<arguments>
+<var>${contact2_id}</var>
 <arg>Contact</arg>
 <arg>FirstName=Dummy1</arg>
 <arg>LastName=Dummy2</arg>
 <arg>EmailBouncedDate=2029-01-01T00:00:00</arg>
-</arguments>
-<assign>
-<var>${contact2_id}</var>
-</assign>
+<doc>Creates a new Salesforce object and returns the Id.</doc>
 <msg timestamp="20210301 14:20:21.585" level="INFO">Inserting Contact with values {'FirstName': 'Dummy1', 'LastName': 'Dummy2', 'EmailBouncedDate': '2029-01-01T00:00:00'}</msg>
 <msg timestamp="20210301 14:20:22.128" level="INFO">Storing Contact 003R000001aWPbQIAW to session records</msg>
 <msg timestamp="20210301 14:20:22.131" level="INFO">${contact2_id} = 003R000001aWPbQIAW</msg>
-<status status="PASS" starttime="20210301 14:20:21.584" endtime="20210301 14:20:22.131"></status>
+<status status="PASS" starttime="20210301 14:20:21.584" endtime="20210301 14:20:22.131"/>
 </kw>
 <kw name="Elapsed Time For Last Record" library="cumulusci.robotframework.Salesforce">
-<doc>For records representing jobs or processes, compare the record's start-time to its end-time to see how long a process took.</doc>
-<arguments>
+<var>${Elapsed_latest}</var>
 <arg>obj_name=Contact</arg>
 <arg>start_field=CreatedDate</arg>
 <arg>end_field=EmailBouncedDate</arg>
 <arg>order_by=EmailBouncedDate</arg>
-</arguments>
-<assign>
-<var>${Elapsed_latest}</var>
-</assign>
+<doc>For records representing jobs or processes, compare the record's start-time to its end-time to see how long a process took.</doc>
 <msg timestamp="20210301 14:20:22.132" level="INFO">Running SOQL Query: SELECT CreatedDate, EmailBouncedDate FROM Contact ORDER BY EmailBouncedDate DESC NULLS LAST LIMIT 1</msg>
 <msg timestamp="20210301 14:20:22.920" level="INFO">${Elapsed_latest} = 278818780.0</msg>
-<status status="PASS" starttime="20210301 14:20:22.132" endtime="20210301 14:20:22.920"></status>
+<status status="PASS" starttime="20210301 14:20:22.132" endtime="20210301 14:20:22.920"/>
 </kw>
 <kw name="Should Be Equal" library="BuiltIn">
-<doc>Fails if the given objects are unequal.</doc>
-<arguments>
 <arg>${Elapsed}</arg>
 <arg>${Elapsed_latest}</arg>
-</arguments>
-<status status="PASS" starttime="20210301 14:20:22.921" endtime="20210301 14:20:22.921"></status>
+<doc>Fails if the given objects are unequal.</doc>
+<status status="PASS" starttime="20210301 14:20:22.921" endtime="20210301 14:20:22.921"/>
 </kw>
 <kw name="Set Test Elapsed Time" library="cumulusci.robotframework.Salesforce">
-<doc>This keyword captures a computed rather than measured elapsed time for performance tests.</doc>
-<arguments>
 <arg>${Elapsed}</arg>
-</arguments>
+<doc>This keyword captures a computed rather than measured elapsed time for performance tests.</doc>
 <msg timestamp="20210301 14:20:22.922" level="INFO">Set test message to:
 Elapsed time set by test : 278818780.0</msg>
 <msg timestamp="20210301 14:20:22.922" level="INFO">Set tag 'cci_metric_elapsed_time'.</msg>
 <msg timestamp="20210301 14:20:22.923" level="INFO">${cci_metric_elapsed_time} = 278818780.0</msg>
-<status status="PASS" starttime="20210301 14:20:22.921" endtime="20210301 14:20:22.923"></status>
+<status status="PASS" starttime="20210301 14:20:22.921" endtime="20210301 14:20:22.923"/>
 </kw>
-<kw name="Delete Session Records" library="cumulusci.robotframework.Salesforce" type="teardown">
+<kw name="Delete Session Records" library="cumulusci.robotframework.Salesforce" type="TEARDOWN">
 <doc>Deletes records that were created while running this test case.</doc>
 <msg timestamp="20210301 14:20:22.923" level="INFO">Deleting 2 records</msg>
 <msg timestamp="20210301 14:20:22.923" level="INFO">  Deleting Contact 003R000001aWPbQIAW</msg>
 <msg timestamp="20210301 14:20:22.924" level="INFO">Deleting Contact with Id 003R000001aWPbQIAW</msg>
 <msg timestamp="20210301 14:20:24.171" level="INFO">  Deleting Contact 003R000001aWPbLIAW</msg>
 <msg timestamp="20210301 14:20:24.171" level="INFO">Deleting Contact with Id 003R000001aWPbLIAW</msg>
-<status status="PASS" starttime="20210301 14:20:22.923" endtime="20210301 14:20:24.721"></status>
+<status status="PASS" starttime="20210301 14:20:22.923" endtime="20210301 14:20:24.721"/>
 </kw>
-<tags>
 <tag>api</tag>
 <tag>cci_metric_elapsed_time</tag>
 <tag>no-browser</tag>
-</tags>
-<status status="PASS" starttime="20210301 14:20:19.551" endtime="20210301 14:20:24.722" critical="yes">Elapsed time set by test : 278818780.0</status>
+<status status="PASS" starttime="20210301 14:20:19.551" endtime="20210301 14:20:24.722">Elapsed time set by test : 278818780.0</status>
 </test>
 <test id="s1-t2" name="Test Elapsed Time For Last Record - Failure No Record">
 <kw name="Run Keyword And Expect Error" library="BuiltIn">
-<doc>Runs the keyword and checks that the expected error occurred.</doc>
-<arguments>
 <arg>*Matching record not found*</arg>
 <arg>Elapsed Time For Last Record</arg>
 <arg>obj_name=AsyncApexJob</arg>
@@ -119,241 +93,199 @@ Elapsed time set by test : 278818780.0</msg>
 <arg>start_field=CreatedDate</arg>
 <arg>end_field=CompletedDate</arg>
 <arg>order_by=CompletedDate</arg>
-</arguments>
+<doc>Runs the keyword and checks that the expected error occurred.</doc>
 <kw name="Elapsed Time For Last Record" library="cumulusci.robotframework.Salesforce">
-<doc>For records representing jobs or processes, compare the record's start-time to its end-time to see how long a process took.</doc>
-<arguments>
 <arg>obj_name=AsyncApexJob</arg>
 <arg>where=ApexClass.Name='BlahBlah'</arg>
 <arg>start_field=CreatedDate</arg>
 <arg>end_field=CompletedDate</arg>
 <arg>order_by=CompletedDate</arg>
-</arguments>
+<doc>For records representing jobs or processes, compare the record's start-time to its end-time to see how long a process took.</doc>
 <msg timestamp="20210301 14:20:24.724" level="INFO">Running SOQL Query: SELECT CreatedDate, CompletedDate FROM AsyncApexJob WHERE ApexClass.Name='BlahBlah' ORDER BY CompletedDate DESC NULLS LAST LIMIT 1</msg>
 <msg timestamp="20210301 14:20:25.167" level="FAIL">Matching record not found: SELECT CreatedDate, CompletedDate FROM AsyncApexJob WHERE ApexClass.Name='BlahBlah' ORDER BY CompletedDate DESC NULLS LAST LIMIT 1</msg>
-<status status="FAIL" starttime="20210301 14:20:24.724" endtime="20210301 14:20:25.168"></status>
+<status status="FAIL" starttime="20210301 14:20:24.724" endtime="20210301 14:20:25.168"/>
 </kw>
-<status status="PASS" starttime="20210301 14:20:24.723" endtime="20210301 14:20:25.168"></status>
+<status status="PASS" starttime="20210301 14:20:24.723" endtime="20210301 14:20:25.168"/>
 </kw>
-<kw name="Delete Session Records" library="cumulusci.robotframework.Salesforce" type="teardown">
+<kw name="Delete Session Records" library="cumulusci.robotframework.Salesforce" type="TEARDOWN">
 <doc>Deletes records that were created while running this test case.</doc>
 <msg timestamp="20210301 14:20:25.169" level="INFO">Deleting 0 records</msg>
-<status status="PASS" starttime="20210301 14:20:25.169" endtime="20210301 14:20:25.169"></status>
+<status status="PASS" starttime="20210301 14:20:25.169" endtime="20210301 14:20:25.169"/>
 </kw>
-<tags>
 <tag>api</tag>
 <tag>no-browser</tag>
-</tags>
-<status status="PASS" starttime="20210301 14:20:24.723" endtime="20210301 14:20:25.169" critical="yes"></status>
+<status status="PASS" starttime="20210301 14:20:24.723" endtime="20210301 14:20:25.169"/>
 </test>
 <test id="s1-t3" name="Test Elapsed Time For Last Record - Failure Bad Fields">
 <kw name="Salesforce Insert" library="cumulusci.robotframework.Salesforce">
-<doc>Creates a new Salesforce object and returns the Id.</doc>
-<arguments>
+<var>${contact_id}</var>
 <arg>Contact</arg>
 <arg>LastName=Dummy2</arg>
 <arg>EmailBouncedDate=2030-01-01T00:00:00</arg>
-</arguments>
-<assign>
-<var>${contact_id}</var>
-</assign>
+<doc>Creates a new Salesforce object and returns the Id.</doc>
 <msg timestamp="20210301 14:20:25.172" level="INFO">Inserting Contact with values {'LastName': 'Dummy2', 'EmailBouncedDate': '2030-01-01T00:00:00'}</msg>
 <msg timestamp="20210301 14:20:25.754" level="INFO">Storing Contact 003R000001aWPbVIAW to session records</msg>
 <msg timestamp="20210301 14:20:25.756" level="INFO">${contact_id} = 003R000001aWPbVIAW</msg>
-<status status="PASS" starttime="20210301 14:20:25.172" endtime="20210301 14:20:25.756"></status>
+<status status="PASS" starttime="20210301 14:20:25.172" endtime="20210301 14:20:25.756"/>
 </kw>
 <kw name="Run Keyword And Expect Error" library="BuiltIn">
-<doc>Runs the keyword and checks that the expected error occurred.</doc>
-<arguments>
 <arg>*Date parse error*</arg>
 <arg>Elapsed Time For Last Record</arg>
 <arg>obj_name=Contact</arg>
 <arg>start_field=EmailBouncedDate</arg>
 <arg>end_field=LastName</arg>
 <arg>order_by=LastName</arg>
-</arguments>
+<doc>Runs the keyword and checks that the expected error occurred.</doc>
 <kw name="Elapsed Time For Last Record" library="cumulusci.robotframework.Salesforce">
-<doc>For records representing jobs or processes, compare the record's start-time to its end-time to see how long a process took.</doc>
-<arguments>
 <arg>obj_name=Contact</arg>
 <arg>start_field=EmailBouncedDate</arg>
 <arg>end_field=LastName</arg>
 <arg>order_by=LastName</arg>
-</arguments>
+<doc>For records representing jobs or processes, compare the record's start-time to its end-time to see how long a process took.</doc>
 <msg timestamp="20210301 14:20:25.758" level="INFO">Running SOQL Query: SELECT EmailBouncedDate, LastName FROM Contact ORDER BY LastName DESC NULLS LAST LIMIT 1</msg>
 <msg timestamp="20210301 14:20:26.192" level="FAIL">Date parse error: Parser must be a string or character stream, not NoneType in record {'attributes': {'type': 'Contact', 'url': '/services/data/v50.0/sobjects/Contact/003R000001aW2UUIA0'}, 'EmailBouncedDate': None, 'LastName': 'Zuniga'}</msg>
-<status status="FAIL" starttime="20210301 14:20:25.757" endtime="20210301 14:20:26.192"></status>
+<status status="FAIL" starttime="20210301 14:20:25.757" endtime="20210301 14:20:26.192"/>
 </kw>
-<status status="PASS" starttime="20210301 14:20:25.757" endtime="20210301 14:20:26.192"></status>
+<status status="PASS" starttime="20210301 14:20:25.757" endtime="20210301 14:20:26.192"/>
 </kw>
 <kw name="Run Keyword And Expect Error" library="BuiltIn">
-<doc>Runs the keyword and checks that the expected error occurred.</doc>
-<arguments>
 <arg>*Date parse error*</arg>
 <arg>Elapsed Time For Last Record</arg>
 <arg>obj_name=Contact</arg>
 <arg>start_field=EmailBouncedDate</arg>
 <arg>end_field=FirstName</arg>
 <arg>order_by=FirstName</arg>
-</arguments>
+<doc>Runs the keyword and checks that the expected error occurred.</doc>
 <kw name="Elapsed Time For Last Record" library="cumulusci.robotframework.Salesforce">
-<doc>For records representing jobs or processes, compare the record's start-time to its end-time to see how long a process took.</doc>
-<arguments>
 <arg>obj_name=Contact</arg>
 <arg>start_field=EmailBouncedDate</arg>
 <arg>end_field=FirstName</arg>
 <arg>order_by=FirstName</arg>
-</arguments>
+<doc>For records representing jobs or processes, compare the record's start-time to its end-time to see how long a process took.</doc>
 <msg timestamp="20210301 14:20:26.193" level="INFO">Running SOQL Query: SELECT EmailBouncedDate, FirstName FROM Contact ORDER BY FirstName DESC NULLS LAST LIMIT 1</msg>
 <msg timestamp="20210301 14:20:26.690" level="FAIL">Date parse error: Parser must be a string or character stream, not NoneType in record {'attributes': {'type': 'Contact', 'url': '/services/data/v50.0/sobjects/Contact/003R000001aW2TIIA0'}, 'EmailBouncedDate': None, 'FirstName': 'Zoe'}</msg>
-<status status="FAIL" starttime="20210301 14:20:26.193" endtime="20210301 14:20:26.690"></status>
+<status status="FAIL" starttime="20210301 14:20:26.193" endtime="20210301 14:20:26.690"/>
 </kw>
-<status status="PASS" starttime="20210301 14:20:26.193" endtime="20210301 14:20:26.691"></status>
+<status status="PASS" starttime="20210301 14:20:26.193" endtime="20210301 14:20:26.691"/>
 </kw>
-<kw name="Delete Session Records" library="cumulusci.robotframework.Salesforce" type="teardown">
+<kw name="Delete Session Records" library="cumulusci.robotframework.Salesforce" type="TEARDOWN">
 <doc>Deletes records that were created while running this test case.</doc>
 <msg timestamp="20210301 14:20:26.692" level="INFO">Deleting 1 records</msg>
 <msg timestamp="20210301 14:20:26.692" level="INFO">  Deleting Contact 003R000001aWPbVIAW</msg>
 <msg timestamp="20210301 14:20:26.692" level="INFO">Deleting Contact with Id 003R000001aWPbVIAW</msg>
-<status status="PASS" starttime="20210301 14:20:26.692" endtime="20210301 14:20:27.367"></status>
+<status status="PASS" starttime="20210301 14:20:26.692" endtime="20210301 14:20:27.367"/>
 </kw>
-<tags>
 <tag>api</tag>
 <tag>no-browser</tag>
-</tags>
-<status status="PASS" starttime="20210301 14:20:25.171" endtime="20210301 14:20:27.367" critical="yes"></status>
+<status status="PASS" starttime="20210301 14:20:25.171" endtime="20210301 14:20:27.367"/>
 </test>
 <test id="s1-t4" name="Test Perf Set Elapsed Time">
 <kw name="Set Test Elapsed Time" library="cumulusci.robotframework.Salesforce">
-<doc>This keyword captures a computed rather than measured elapsed time for performance tests.</doc>
-<arguments>
 <arg>11655.9</arg>
-</arguments>
+<doc>This keyword captures a computed rather than measured elapsed time for performance tests.</doc>
 <msg timestamp="20210301 14:20:27.370" level="INFO">Set test message to:
 Elapsed time set by test : 11655.9</msg>
 <msg timestamp="20210301 14:20:27.370" level="INFO">Set tag 'cci_metric_elapsed_time'.</msg>
 <msg timestamp="20210301 14:20:27.371" level="INFO">${cci_metric_elapsed_time} = 11655.9</msg>
-<status status="PASS" starttime="20210301 14:20:27.369" endtime="20210301 14:20:27.371"></status>
+<status status="PASS" starttime="20210301 14:20:27.369" endtime="20210301 14:20:27.371"/>
 </kw>
-<kw name="Delete Session Records" library="cumulusci.robotframework.Salesforce" type="teardown">
+<kw name="Delete Session Records" library="cumulusci.robotframework.Salesforce" type="TEARDOWN">
 <doc>Deletes records that were created while running this test case.</doc>
 <msg timestamp="20210301 14:20:27.372" level="INFO">Deleting 0 records</msg>
-<status status="PASS" starttime="20210301 14:20:27.371" endtime="20210301 14:20:27.372"></status>
+<status status="PASS" starttime="20210301 14:20:27.371" endtime="20210301 14:20:27.372"/>
 </kw>
-<tags>
 <tag>api</tag>
 <tag>cci_metric_elapsed_time</tag>
 <tag>no-browser</tag>
 <tag>perf</tag>
-</tags>
-<status status="PASS" starttime="20210301 14:20:27.369" endtime="20210301 14:20:27.372" critical="yes">Elapsed time set by test : 11655.9</status>
+<status status="PASS" starttime="20210301 14:20:27.369" endtime="20210301 14:20:27.372">Elapsed time set by test : 11655.9</status>
 </test>
 <test id="s1-t5" name="Test Perf Set Elapsed Time Twice">
 <kw name="Set Test Elapsed Time" library="cumulusci.robotframework.Salesforce">
-<doc>This keyword captures a computed rather than measured elapsed time for performance tests.</doc>
-<arguments>
 <arg>11655.9</arg>
-</arguments>
+<doc>This keyword captures a computed rather than measured elapsed time for performance tests.</doc>
 <msg timestamp="20210301 14:20:27.375" level="INFO">Set test message to:
 Elapsed time set by test : 11655.9</msg>
 <msg timestamp="20210301 14:20:27.375" level="INFO">Set tag 'cci_metric_elapsed_time'.</msg>
 <msg timestamp="20210301 14:20:27.376" level="INFO">${cci_metric_elapsed_time} = 11655.9</msg>
-<status status="PASS" starttime="20210301 14:20:27.374" endtime="20210301 14:20:27.376"></status>
+<status status="PASS" starttime="20210301 14:20:27.374" endtime="20210301 14:20:27.376"/>
 </kw>
 <kw name="Set Test Elapsed Time" library="cumulusci.robotframework.Salesforce">
-<doc>This keyword captures a computed rather than measured elapsed time for performance tests.</doc>
-<arguments>
 <arg>53</arg>
-</arguments>
+<doc>This keyword captures a computed rather than measured elapsed time for performance tests.</doc>
 <msg timestamp="20210301 14:20:27.376" level="INFO">Set test message to:
 Elapsed time set by test : 53.0</msg>
 <msg timestamp="20210301 14:20:27.376" level="INFO">Set tag 'cci_metric_elapsed_time'.</msg>
 <msg timestamp="20210301 14:20:27.377" level="INFO">${cci_metric_elapsed_time} = 53.0</msg>
-<status status="PASS" starttime="20210301 14:20:27.376" endtime="20210301 14:20:27.377"></status>
+<status status="PASS" starttime="20210301 14:20:27.376" endtime="20210301 14:20:27.377"/>
 </kw>
-<kw name="Delete Session Records" library="cumulusci.robotframework.Salesforce" type="teardown">
+<kw name="Delete Session Records" library="cumulusci.robotframework.Salesforce" type="TEARDOWN">
 <doc>Deletes records that were created while running this test case.</doc>
 <msg timestamp="20210301 14:20:27.377" level="INFO">Deleting 0 records</msg>
-<status status="PASS" starttime="20210301 14:20:27.377" endtime="20210301 14:20:27.378"></status>
+<status status="PASS" starttime="20210301 14:20:27.377" endtime="20210301 14:20:27.378"/>
 </kw>
-<tags>
 <tag>api</tag>
 <tag>cci_metric_elapsed_time</tag>
 <tag>no-browser</tag>
 <tag>perf</tag>
-</tags>
-<status status="PASS" starttime="20210301 14:20:27.374" endtime="20210301 14:20:27.378" critical="yes">Elapsed time set by test : 53.0</status>
+<status status="PASS" starttime="20210301 14:20:27.374" endtime="20210301 14:20:27.378">Elapsed time set by test : 53.0</status>
 </test>
 <test id="s1-t6" name="Test Perf Set Elapsed Time String">
 <kw name="Log" library="BuiltIn">
-<doc>Logs the given message with the given level.</doc>
-<arguments>
 <arg>A</arg>
-</arguments>
+<doc>Logs the given message with the given level.</doc>
 <msg timestamp="20210301 14:20:27.380" level="INFO">A</msg>
-<status status="PASS" starttime="20210301 14:20:27.380" endtime="20210301 14:20:27.380"></status>
+<status status="PASS" starttime="20210301 14:20:27.380" endtime="20210301 14:20:27.380"/>
 </kw>
 <kw name="Set Test Elapsed Time" library="cumulusci.robotframework.Salesforce">
-<doc>This keyword captures a computed rather than measured elapsed time for performance tests.</doc>
-<arguments>
 <arg>5 hours</arg>
-</arguments>
+<doc>This keyword captures a computed rather than measured elapsed time for performance tests.</doc>
 <msg timestamp="20210301 14:20:27.381" level="INFO">Set test message to:
 Elapsed time set by test : 18000.0</msg>
 <msg timestamp="20210301 14:20:27.381" level="INFO">Set tag 'cci_metric_elapsed_time'.</msg>
 <msg timestamp="20210301 14:20:27.382" level="INFO">${cci_metric_elapsed_time} = 18000.0</msg>
-<status status="PASS" starttime="20210301 14:20:27.380" endtime="20210301 14:20:27.382"></status>
+<status status="PASS" starttime="20210301 14:20:27.380" endtime="20210301 14:20:27.382"/>
 </kw>
-<kw name="Delete Session Records" library="cumulusci.robotframework.Salesforce" type="teardown">
+<kw name="Delete Session Records" library="cumulusci.robotframework.Salesforce" type="TEARDOWN">
 <doc>Deletes records that were created while running this test case.</doc>
 <msg timestamp="20210301 14:20:27.382" level="INFO">Deleting 0 records</msg>
-<status status="PASS" starttime="20210301 14:20:27.382" endtime="20210301 14:20:27.382"></status>
+<status status="PASS" starttime="20210301 14:20:27.382" endtime="20210301 14:20:27.382"/>
 </kw>
-<tags>
 <tag>api</tag>
 <tag>cci_metric_elapsed_time</tag>
 <tag>no-browser</tag>
 <tag>perf</tag>
-</tags>
-<status status="PASS" starttime="20210301 14:20:27.379" endtime="20210301 14:20:27.383" critical="yes">Elapsed time set by test : 18000.0</status>
+<status status="PASS" starttime="20210301 14:20:27.379" endtime="20210301 14:20:27.383">Elapsed time set by test : 18000.0</status>
 </test>
 <test id="s1-t7" name="Test Perf Measure Elapsed">
-<kw name="Log" library="BuiltIn" type="setup">
-<doc>Logs the given message with the given level.</doc>
-<arguments>
+<kw name="Log" library="BuiltIn" type="SETUP">
 <arg>Before</arg>
-</arguments>
+<doc>Logs the given message with the given level.</doc>
 <msg timestamp="20210301 14:20:27.397" level="INFO">Before</msg>
-<status status="PASS" starttime="20210301 14:20:27.397" endtime="20210301 14:20:27.397"></status>
+<status status="PASS" starttime="20210301 14:20:27.397" endtime="20210301 14:20:27.397"/>
 </kw>
 <kw name="Log" library="BuiltIn">
-<doc>Logs the given message with the given level.</doc>
-<arguments>
 <arg>B</arg>
-</arguments>
+<doc>Logs the given message with the given level.</doc>
 <msg timestamp="20210301 14:20:27.398" level="INFO">B</msg>
-<status status="PASS" starttime="20210301 14:20:27.398" endtime="20210301 14:20:27.398"></status>
+<status status="PASS" starttime="20210301 14:20:27.398" endtime="20210301 14:20:27.398"/>
 </kw>
 <kw name="Start Performance Timer" library="cumulusci.robotframework.Salesforce">
 <doc>Start an elapsed time stopwatch for performance tests.</doc>
 <msg timestamp="20210301 14:20:27.400" level="INFO">${__start_time} = 2021-03-01 14:20:27.398580</msg>
-<status status="PASS" starttime="20210301 14:20:27.398" endtime="20210301 14:20:27.400"></status>
+<status status="PASS" starttime="20210301 14:20:27.398" endtime="20210301 14:20:27.400"/>
 </kw>
 <kw name="Sleep" library="BuiltIn">
-<doc>Pauses the test executed for the given time.</doc>
-<arguments>
 <arg>1</arg>
-</arguments>
+<doc>Pauses the test executed for the given time.</doc>
 <msg timestamp="20210301 14:20:28.401" level="INFO">Slept 1 second</msg>
-<status status="PASS" starttime="20210301 14:20:27.400" endtime="20210301 14:20:28.402"></status>
+<status status="PASS" starttime="20210301 14:20:27.400" endtime="20210301 14:20:28.402"/>
 </kw>
 <kw name="Log" library="BuiltIn">
-<doc>Logs the given message with the given level.</doc>
-<arguments>
 <arg>Noop</arg>
-</arguments>
+<doc>Logs the given message with the given level.</doc>
 <msg timestamp="20210301 14:20:28.403" level="INFO">Noop</msg>
-<status status="PASS" starttime="20210301 14:20:28.403" endtime="20210301 14:20:28.403"></status>
+<status status="PASS" starttime="20210301 14:20:28.403" endtime="20210301 14:20:28.403"/>
 </kw>
 <kw name="Stop Performance Timer" library="cumulusci.robotframework.Salesforce">
 <doc>Record the results of a stopwatch. For perf testing.</doc>
@@ -361,36 +293,30 @@ Elapsed time set by test : 18000.0</msg>
 Elapsed time set by test : 1.0</msg>
 <msg timestamp="20210301 14:20:28.405" level="INFO">Set tag 'cci_metric_elapsed_time'.</msg>
 <msg timestamp="20210301 14:20:28.406" level="INFO">${cci_metric_elapsed_time} = 1.0</msg>
-<status status="PASS" starttime="20210301 14:20:28.404" endtime="20210301 14:20:28.406"></status>
+<status status="PASS" starttime="20210301 14:20:28.404" endtime="20210301 14:20:28.406"/>
 </kw>
-<kw name="Log" library="BuiltIn" type="teardown">
-<doc>Logs the given message with the given level.</doc>
-<arguments>
+<kw name="Log" library="BuiltIn" type="TEARDOWN">
 <arg>After</arg>
-</arguments>
+<doc>Logs the given message with the given level.</doc>
 <msg timestamp="20210301 14:20:28.407" level="INFO">After</msg>
-<status status="PASS" starttime="20210301 14:20:28.407" endtime="20210301 14:20:28.407"></status>
+<status status="PASS" starttime="20210301 14:20:28.407" endtime="20210301 14:20:28.407"/>
 </kw>
-<tags>
 <tag>api</tag>
 <tag>cci_metric_elapsed_time</tag>
 <tag>no-browser</tag>
-</tags>
-<status status="PASS" starttime="20210301 14:20:27.396" endtime="20210301 14:20:28.407" critical="yes">Elapsed time set by test : 1.0</status>
+<status status="PASS" starttime="20210301 14:20:27.396" endtime="20210301 14:20:28.407">Elapsed time set by test : 1.0</status>
 </test>
 <test id="s1-t8" name="Set Time and Also Metric">
 <kw name="Start Performance Timer" library="cumulusci.robotframework.Salesforce">
 <doc>Start an elapsed time stopwatch for performance tests.</doc>
 <msg timestamp="20210301 14:20:28.411" level="INFO">${__start_time} = 2021-03-01 14:20:28.410189</msg>
-<status status="PASS" starttime="20210301 14:20:28.410" endtime="20210301 14:20:28.411"></status>
+<status status="PASS" starttime="20210301 14:20:28.410" endtime="20210301 14:20:28.411"/>
 </kw>
 <kw name="Log" library="BuiltIn">
-<doc>Logs the given message with the given level.</doc>
-<arguments>
 <arg>Noop</arg>
-</arguments>
+<doc>Logs the given message with the given level.</doc>
 <msg timestamp="20210301 14:20:28.412" level="INFO">Noop</msg>
-<status status="PASS" starttime="20210301 14:20:28.412" endtime="20210301 14:20:28.412"></status>
+<status status="PASS" starttime="20210301 14:20:28.412" endtime="20210301 14:20:28.412"/>
 </kw>
 <kw name="Stop Performance Timer" library="cumulusci.robotframework.Salesforce">
 <doc>Record the results of a stopwatch. For perf testing.</doc>
@@ -398,94 +324,82 @@ Elapsed time set by test : 1.0</msg>
 Elapsed time set by test : 0.0</msg>
 <msg timestamp="20210301 14:20:28.413" level="INFO">Set tag 'cci_metric_elapsed_time'.</msg>
 <msg timestamp="20210301 14:20:28.413" level="INFO">${cci_metric_elapsed_time} = 0.0</msg>
-<status status="PASS" starttime="20210301 14:20:28.412" endtime="20210301 14:20:28.413"></status>
+<status status="PASS" starttime="20210301 14:20:28.412" endtime="20210301 14:20:28.413"/>
 </kw>
 <kw name="Set Test Metric" library="cumulusci.robotframework.Salesforce">
-<doc>This keyword captures any metric for performance monitoring.</doc>
-<arguments>
 <arg>number of records</arg>
 <arg>100</arg>
-</arguments>
+<doc>This keyword captures any metric for performance monitoring.</doc>
 <msg timestamp="20210301 14:20:28.414" level="INFO">Set tag 'cci_metric'.</msg>
 <msg timestamp="20210301 14:20:28.415" level="INFO">${cci_metric_number of records} = 100.0</msg>
-<status status="PASS" starttime="20210301 14:20:28.414" endtime="20210301 14:20:28.415"></status>
+<status status="PASS" starttime="20210301 14:20:28.414" endtime="20210301 14:20:28.415"/>
 </kw>
-<kw name="Delete Session Records" library="cumulusci.robotframework.Salesforce" type="teardown">
+<kw name="Delete Session Records" library="cumulusci.robotframework.Salesforce" type="TEARDOWN">
 <doc>Deletes records that were created while running this test case.</doc>
 <msg timestamp="20210301 14:20:28.416" level="INFO">Deleting 0 records</msg>
-<status status="PASS" starttime="20210301 14:20:28.416" endtime="20210301 14:20:28.416"></status>
+<status status="PASS" starttime="20210301 14:20:28.416" endtime="20210301 14:20:28.416"/>
 </kw>
-<tags>
 <tag>api</tag>
 <tag>cci_metric</tag>
 <tag>cci_metric_elapsed_time</tag>
 <tag>no-browser</tag>
-</tags>
-<status status="PASS" starttime="20210301 14:20:28.409" endtime="20210301 14:20:28.417" critical="yes">Elapsed time set by test : 0.0</status>
+<status status="PASS" starttime="20210301 14:20:28.409" endtime="20210301 14:20:28.417">Elapsed time set by test : 0.0</status>
 </test>
 <test id="s1-t9" name="Test Perf Measure Other Metric">
 <kw name="Set Test Metric" library="cumulusci.robotframework.Salesforce">
-<doc>This keyword captures any metric for performance monitoring.</doc>
-<arguments>
 <arg>Max_CPU_Percent</arg>
 <arg>30</arg>
-</arguments>
+<doc>This keyword captures any metric for performance monitoring.</doc>
 <msg timestamp="20210301 14:20:28.419" level="INFO">Set tag 'cci_metric'.</msg>
 <msg timestamp="20210301 14:20:28.420" level="INFO">${cci_metric_Max_CPU_Percent} = 30.0</msg>
-<status status="PASS" starttime="20210301 14:20:28.419" endtime="20210301 14:20:28.420"></status>
+<status status="PASS" starttime="20210301 14:20:28.419" endtime="20210301 14:20:28.420"/>
 </kw>
-<kw name="Delete Session Records" library="cumulusci.robotframework.Salesforce" type="teardown">
+<kw name="Delete Session Records" library="cumulusci.robotframework.Salesforce" type="TEARDOWN">
 <doc>Deletes records that were created while running this test case.</doc>
 <msg timestamp="20210301 14:20:28.421" level="INFO">Deleting 0 records</msg>
-<status status="PASS" starttime="20210301 14:20:28.421" endtime="20210301 14:20:28.421"></status>
+<status status="PASS" starttime="20210301 14:20:28.421" endtime="20210301 14:20:28.421"/>
 </kw>
-<tags>
 <tag>api</tag>
 <tag>cci_metric</tag>
 <tag>no-browser</tag>
-</tags>
-<status status="PASS" starttime="20210301 14:20:28.418" endtime="20210301 14:20:28.422" critical="yes"></status>
+<status status="PASS" starttime="20210301 14:20:28.418" endtime="20210301 14:20:28.422"/>
 </test>
 <test id="s1-t10" name="Mismatched Stop Performance Timer">
 <kw name="Run Keyword And Expect Error" library="BuiltIn">
-<doc>Runs the keyword and checks that the expected error occurred.</doc>
-<arguments>
 <arg>*Elapsed time clock was not*</arg>
 <arg>Stop Performance Timer</arg>
-</arguments>
+<doc>Runs the keyword and checks that the expected error occurred.</doc>
 <kw name="Stop Performance Timer" library="cumulusci.robotframework.Salesforce">
 <doc>Record the results of a stopwatch. For perf testing.</doc>
 <msg timestamp="20210301 14:20:28.425" level="FAIL">Elapsed time clock was not started. Use the Start Elapsed Time keyword to do so.</msg>
-<status status="FAIL" starttime="20210301 14:20:28.424" endtime="20210301 14:20:28.426"></status>
+<status status="FAIL" starttime="20210301 14:20:28.424" endtime="20210301 14:20:28.426"/>
 </kw>
-<status status="PASS" starttime="20210301 14:20:28.424" endtime="20210301 14:20:28.426"></status>
+<status status="PASS" starttime="20210301 14:20:28.424" endtime="20210301 14:20:28.426"/>
 </kw>
-<kw name="Delete Session Records" library="cumulusci.robotframework.Salesforce" type="teardown">
+<kw name="Delete Session Records" library="cumulusci.robotframework.Salesforce" type="TEARDOWN">
 <doc>Deletes records that were created while running this test case.</doc>
 <msg timestamp="20210301 14:20:28.427" level="INFO">Deleting 0 records</msg>
-<status status="PASS" starttime="20210301 14:20:28.426" endtime="20210301 14:20:28.427"></status>
+<status status="PASS" starttime="20210301 14:20:28.426" endtime="20210301 14:20:28.427"/>
 </kw>
-<tags>
 <tag>api</tag>
 <tag>no-browser</tag>
-</tags>
-<status status="PASS" starttime="20210301 14:20:28.423" endtime="20210301 14:20:28.427" critical="yes"></status>
+<status status="PASS" starttime="20210301 14:20:28.423" endtime="20210301 14:20:28.427"/>
 </test>
-<status status="PASS" starttime="20210301 14:20:18.963" endtime="20210301 14:20:28.429"></status>
+<status status="PASS" starttime="20210301 14:20:18.963" endtime="20210301 14:20:28.429"/>
 </suite>
 <statistics>
 <total>
-<stat pass="10" fail="0">Critical Tests</stat>
-<stat pass="10" fail="0">All Tests</stat>
+<stat pass="10" fail="0" skip="0">All Tests</stat>
 </total>
 <tag>
-<stat pass="0" fail="0" info="non-critical">noncritical</stat>
-<stat pass="10" fail="0">api</stat>
-<stat pass="10" fail="0">no-browser</stat>
-<stat pass="3" fail="0">perf</stat>
+<stat pass="10" fail="0" skip="0">api</stat>
+<stat pass="2" fail="0" skip="0">cci_metric</stat>
+<stat pass="6" fail="0" skip="0">cci_metric_elapsed_time</stat>
+<stat pass="10" fail="0" skip="0">no-browser</stat>
+<stat pass="3" fail="0" skip="0">perf</stat>
 </tag>
 <suite>
-<stat pass="10" fail="0" id="s1" name="Performance">Performance</stat>
+<stat pass="10" fail="0" skip="0" id="s1" name="Performance">Performance</stat>
 </suite>
 </statistics>
 <errors>

--- a/metaci/testresults/tests/robot_1.xml
+++ b/metaci/testresults/tests/robot_1.xml
@@ -1,17 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<robot generator="Robot 3.2.2 (Python 3.8.8 on darwin)" generated="20210402 16:28:14.939" rpa="false">
+<robot generator="Rebot 4.0.1 (Python 3.8.9 on darwin)" generated="20210511 10:41:55.110" rpa="false" schemaversion="2">
 <suite id="s1" name="Example" source="/private/tmp/example.robot">
 <test id="s1-t1" name="FakeTestResult">
 <kw name="Pass Execution" library="BuiltIn">
-<doc>Skips rest of the current test, setup, or teardown with PASS status.</doc>
-<arguments>
 <arg>Good Robot!</arg>
-</arguments>
+<doc>Skips rest of the current test, setup, or teardown with PASS status.</doc>
 <msg timestamp="20210402 16:28:14.960" level="INFO">Execution passed with message:
 Good Robot!</msg>
-<status status="PASS" starttime="20210402 16:28:14.959" endtime="20210402 16:28:14.960"></status>
+<status status="PASS" starttime="20210402 16:28:14.959" endtime="20210402 16:28:14.960"/>
 </kw>
-<tags>
 <tag>Bender</tag>
 <tag>Bishop</tag>
 <tag>C-3PO</tag>
@@ -26,37 +23,34 @@ Good Robot!</msg>
 <tag>T-1000</tag>
 <tag>The Iron Giant</tag>
 <tag>WALL-E</tag>
-</tags>
-<status status="PASS" starttime="20210402 16:28:14.959" endtime="20210402 16:28:14.960" critical="yes">Good Robot!</status>
+<status status="PASS" starttime="20210402 16:28:14.959" endtime="20210402 16:28:14.960">Good Robot!</status>
 </test>
 <doc>Test cases with lots of tags, for testing the results importer
 The goal is to have over 100 bytes worth of tags</doc>
-<status status="PASS" starttime="20210402 16:28:14.940" endtime="20210402 16:28:14.960"></status>
+<status status="PASS" starttime="20210402 16:28:14.940" endtime="20210402 16:28:14.960"/>
 </suite>
 <statistics>
 <total>
-<stat pass="1" fail="0">Critical Tests</stat>
-<stat pass="1" fail="0">All Tests</stat>
+<stat pass="1" fail="0" skip="0">All Tests</stat>
 </total>
 <tag>
-<stat pass="1" fail="0">Bender</stat>
-<stat pass="1" fail="0">Bishop</stat>
-<stat pass="1" fail="0">C-3PO</stat>
-<stat pass="1" fail="0">Curiosity</stat>
-<stat pass="1" fail="0">Huey Dewey and Louie</stat>
-<stat pass="1" fail="0">Johnny 5</stat>
-<stat pass="1" fail="0">Louie</stat>
-<stat pass="1" fail="0">Optimus Prime</stat>
-<stat pass="1" fail="0">Perserverance</stat>
-<stat pass="1" fail="0">R2-D2</stat>
-<stat pass="1" fail="0">Robby</stat>
-<stat pass="1" fail="0">Rosie</stat>
-<stat pass="1" fail="0">T-1000</stat>
-<stat pass="1" fail="0">The Iron Giant</stat>
-<stat pass="1" fail="0">WALL-E</stat>
+<stat pass="1" fail="0" skip="0">Bender</stat>
+<stat pass="1" fail="0" skip="0">Bishop</stat>
+<stat pass="1" fail="0" skip="0">C-3PO</stat>
+<stat pass="1" fail="0" skip="0">Curiosity</stat>
+<stat pass="1" fail="0" skip="0">Huey Dewey and Louie</stat>
+<stat pass="1" fail="0" skip="0">Johnny 5</stat>
+<stat pass="1" fail="0" skip="0">Optimus Prime</stat>
+<stat pass="1" fail="0" skip="0">Perserverance</stat>
+<stat pass="1" fail="0" skip="0">R2-D2</stat>
+<stat pass="1" fail="0" skip="0">Robby</stat>
+<stat pass="1" fail="0" skip="0">Rosie</stat>
+<stat pass="1" fail="0" skip="0">T-1000</stat>
+<stat pass="1" fail="0" skip="0">The Iron Giant</stat>
+<stat pass="1" fail="0" skip="0">WALL-E</stat>
 </tag>
 <suite>
-<stat pass="1" fail="0" id="s1" name="Example">Example</stat>
+<stat pass="1" fail="0" skip="0" id="s1" name="Example">Example</stat>
 </suite>
 </statistics>
 <errors>

--- a/metaci/testresults/tests/robot_screenshots.xml
+++ b/metaci/testresults/tests/robot_screenshots.xml
@@ -1,557 +1,444 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<robot generator="Robot 3.2.2 (Python 3.8.5 on darwin)" generated="20201208 16:39:42.980" rpa="false">
-    <suite id="s1" name="Tests" source="/private/var/folders/63/67f0g5cs35v75jf1f23y1xtw0000gq/T/tmpx9q5gbfa/SFDO-Tooling-CumulusCI-Test-f282047/tests">
-        <suite id="s1-s1" name="Standard Objects" source="/private/var/folders/63/67f0g5cs35v75jf1f23y1xtw0000gq/T/tmpx9q5gbfa/SFDO-Tooling-CumulusCI-Test-f282047/tests/standard_objects">
-            <suite id="s1-s1-s1" name="Create Contact" source="/private/var/folders/63/67f0g5cs35v75jf1f23y1xtw0000gq/T/tmpx9q5gbfa/SFDO-Tooling-CumulusCI-Test-f282047/tests/standard_objects/create_contact.robot">
-                <kw name="Run Keywords" library="BuiltIn" type="setup">
-                    <doc>Executes all the given keywords in a sequence.</doc>
-                    <arguments>
-                        <arg>Open Test Browser</arg>
-                        <arg>Capture page screenshot</arg>
-                    </arguments>
-                    <kw name="Open Test Browser" library="Salesforce">
-                        <doc>Opens a test browser to the org.</doc>
-                        <kw name="Login Url" library="cumulusci.robotframework.CumulusCI">
-                            <doc>Returns the login url which will automatically log into the target Salesforce org. By default, the org_name passed to the library constructor is used but this can be overridden with the org option to log into a different org.</doc>
-                            <assign>
-                                <var>${login_url}</var>
-                            </assign>
-                            <msg timestamp="20201208 16:39:43.252" level="INFO">${login_url} = https://data-connect-2957-dev-ed.cs40.my.salesforce.com//secur/frontdoor.jsp?sid=00D54000000HcuU!AQQAQI29qsozgQ0y9PRgWS_DNEqtvktRIR138cDCVLnl.NVVnH.8p4jN50bro_dz057S482u2UCNzw3EqTR2JKb1csxQ03OP</msg>
-                            <status status="PASS" starttime="20201208 16:39:43.252" endtime="20201208 16:39:43.252" />
-                        </kw>
-                        <kw name="Run Keyword If" library="BuiltIn">
-                            <doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
-                            <arguments>
-                                <arg>'${BROWSER}' == 'chrome'</arg>
-                                <arg>Open Test Browser Chrome</arg>
-                                <arg>${login_url}</arg>
-                                <arg>alias=${alias}</arg>
-                                <arg>ELSE IF</arg>
-                                <arg>'${BROWSER}' == 'firefox'</arg>
-                                <arg>Open Test Browser Firefox</arg>
-                                <arg>${login_url}</arg>
-                                <arg>alias=${alias}</arg>
-                                <arg>ELSE IF</arg>
-                                <arg>'${BROWSER}' == 'headlesschrome'</arg>
-                                <arg>Open Test Browser Chrome</arg>
-                                <arg>${login_url}</arg>
-                                <arg>alias=${alias}</arg>
-                                <arg>ELSE IF</arg>
-                                <arg>'${BROWSER}' == 'headlessfirefox'</arg>
-                                <arg>Open Test Browser Headless Firefox</arg>
-                                <arg>${login_url}</arg>
-                                <arg>alias=${alias}</arg>
-                                <arg>ELSE</arg>
-                                <arg>Open Browser</arg>
-                                <arg>${login_url}</arg>
-                                <arg>${BROWSER}</arg>
-                                <arg>alias=${alias}</arg>
-                            </arguments>
-                            <kw name="Open Test Browser Chrome" library="Salesforce">
-                                <doc>Opens a Chrome browser window and navigates to the org This keyword isn't normally called directly by a test. It is used by the `Open Test Browser` keyword.</doc>
-                                <arguments>
-                                    <arg>${login_url}</arg>
-                                    <arg>alias=${alias}</arg>
-                                </arguments>
-                                <kw name="Get Chrome Options" library="Salesforce">
-                                    <doc>Returns a dictionary of chrome options, for use by the keyword `Open Test Browser`.</doc>
-                                    <assign>
-                                        <var>${options}</var>
-                                    </assign>
-                                    <kw name="Evaluate" library="BuiltIn">
-                                        <doc>Evaluates the given expression in Python and returns the result.</doc>
-                                        <arguments>
-                                            <arg>selenium.webdriver.ChromeOptions()</arg>
-                                            <arg>modules=selenium</arg>
-                                        </arguments>
-                                        <assign>
-                                            <var>${options}</var>
-                                        </assign>
-                                        <msg timestamp="20201208 16:39:43.254" level="INFO">
+<robot generator="Rebot 4.0.1 (Python 3.8.9 on darwin)" generated="20210511 08:44:48.575" rpa="false" schemaversion="2">
+<suite id="s1" name="Tests" source="/private/var/folders/63/67f0g5cs35v75jf1f23y1xtw0000gq/T/tmpx9q5gbfa/SFDO-Tooling-CumulusCI-Test-f282047/tests">
+<suite id="s1-s1" name="Standard Objects" source="/private/var/folders/63/67f0g5cs35v75jf1f23y1xtw0000gq/T/tmpx9q5gbfa/SFDO-Tooling-CumulusCI-Test-f282047/tests/standard_objects">
+<suite id="s1-s1-s1" name="Create Contact" source="/private/var/folders/63/67f0g5cs35v75jf1f23y1xtw0000gq/T/tmpx9q5gbfa/SFDO-Tooling-CumulusCI-Test-f282047/tests/standard_objects/create_contact.robot">
+<kw name="Run Keywords" library="BuiltIn" type="SETUP">
+<arg>Open Test Browser</arg>
+<arg>Capture page screenshot</arg>
+<doc>Executes all the given keywords in a sequence.</doc>
+<kw name="Open Test Browser" library="Salesforce">
+<doc>Opens a test browser to the org.</doc>
+<kw name="Login Url" library="cumulusci.robotframework.CumulusCI">
+<var>${login_url}</var>
+<doc>Returns the login url which will automatically log into the target Salesforce org. By default, the org_name passed to the library constructor is used but this can be overridden with the org option to log into a different org.</doc>
+<msg timestamp="20201208 16:39:43.252" level="INFO">${login_url} = https://data-connect-2957-dev-ed.cs40.my.salesforce.com//secur/frontdoor.jsp?sid=00D54000000HcuU!AQQAQI29qsozgQ0y9PRgWS_DNEqtvktRIR138cDCVLnl.NVVnH.8p4jN50bro_dz057S482u2UCNzw3EqTR2JKb1csxQ03OP</msg>
+<status status="PASS" starttime="20201208 16:39:43.252" endtime="20201208 16:39:43.252"/>
+</kw>
+<kw name="Run Keyword If" library="BuiltIn">
+<arg>'${BROWSER}' == 'chrome'</arg>
+<arg>Open Test Browser Chrome</arg>
+<arg>${login_url}</arg>
+<arg>alias=${alias}</arg>
+<arg>ELSE IF</arg>
+<arg>'${BROWSER}' == 'firefox'</arg>
+<arg>Open Test Browser Firefox</arg>
+<arg>${login_url}</arg>
+<arg>alias=${alias}</arg>
+<arg>ELSE IF</arg>
+<arg>'${BROWSER}' == 'headlesschrome'</arg>
+<arg>Open Test Browser Chrome</arg>
+<arg>${login_url}</arg>
+<arg>alias=${alias}</arg>
+<arg>ELSE IF</arg>
+<arg>'${BROWSER}' == 'headlessfirefox'</arg>
+<arg>Open Test Browser Headless Firefox</arg>
+<arg>${login_url}</arg>
+<arg>alias=${alias}</arg>
+<arg>ELSE</arg>
+<arg>Open Browser</arg>
+<arg>${login_url}</arg>
+<arg>${BROWSER}</arg>
+<arg>alias=${alias}</arg>
+<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
+<kw name="Open Test Browser Chrome" library="Salesforce">
+<arg>${login_url}</arg>
+<arg>alias=${alias}</arg>
+<doc>Opens a Chrome browser window and navigates to the org This keyword isn't normally called directly by a test. It is used by the `Open Test Browser` keyword.</doc>
+<kw name="Get Chrome Options" library="Salesforce">
+<var>${options}</var>
+<doc>Returns a dictionary of chrome options, for use by the keyword `Open Test Browser`.</doc>
+<kw name="Evaluate" library="BuiltIn">
+<var>${options}</var>
+<arg>selenium.webdriver.ChromeOptions()</arg>
+<arg>modules=selenium</arg>
+<doc>Evaluates the given expression in Python and returns the result.</doc>
+<msg timestamp="20201208 16:39:43.254" level="INFO">
                                             ${options} =
-                                            <selenium.webdriver.chrome.options.Options />
+                                            &lt;selenium.webdriver.chrome.options.Options /&gt;
                                         </msg>
-                                        <status status="PASS" starttime="20201208 16:39:43.254" endtime="20201208 16:39:43.254" />
-                                    </kw>
-                                    <kw name="Run Keyword If" library="BuiltIn">
-                                        <doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
-                                        <arguments>
-                                            <arg>'${BROWSER}' == 'headlesschrome'</arg>
-                                            <arg>Chrome Set Headless</arg>
-                                            <arg>${options}</arg>
-                                        </arguments>
-                                        <kw name="Chrome Set Headless" library="Salesforce">
-                                            <doc>This keyword is used to set the chrome options dictionary values required to run headless chrome.</doc>
-                                            <arguments>
-                                                <arg>${options}</arg>
-                                            </arguments>
-                                            <kw name="Call Method" library="BuiltIn">
-                                                <doc>Calls the named method of the given object with the provided arguments.</doc>
-                                                <arguments>
-                                                    <arg>${options}</arg>
-                                                    <arg>set_headless</arg>
-                                                    <arg>${true}</arg>
-                                                </arguments>
-                                                <status status="PASS" starttime="20201208 16:39:43.254" endtime="20201208 16:39:43.255" />
-                                            </kw>
-                                            <kw name="Call Method" library="BuiltIn">
-                                                <doc>Calls the named method of the given object with the provided arguments.</doc>
-                                                <arguments>
-                                                    <arg>${options}</arg>
-                                                    <arg>add_argument</arg>
-                                                    <arg>--disable-dev-shm-usage</arg>
-                                                </arguments>
-                                                <status status="PASS" starttime="20201208 16:39:43.255" endtime="20201208 16:39:43.255" />
-                                            </kw>
-                                            <kw name="Call Method" library="BuiltIn">
-                                                <doc>Calls the named method of the given object with the provided arguments.</doc>
-                                                <arguments>
-                                                    <arg>${options}</arg>
-                                                    <arg>add_argument</arg>
-                                                    <arg>--disable-background-timer-throttling</arg>
-                                                </arguments>
-                                                <status status="PASS" starttime="20201208 16:39:43.255" endtime="20201208 16:39:43.255" />
-                                            </kw>
-                                            <status status="PASS" starttime="20201208 16:39:43.254" endtime="20201208 16:39:43.255" />
-                                        </kw>
-                                        <status status="PASS" starttime="20201208 16:39:43.254" endtime="20201208 16:39:43.255" />
-                                    </kw>
-                                    <kw name="Run Keyword If" library="BuiltIn">
-                                        <doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
-                                        <arguments>
-                                            <arg>'${CHROME_BINARY}' != '${empty}'</arg>
-                                            <arg>Chrome Set Binary</arg>
-                                            <arg>${options}</arg>
-                                        </arguments>
-                                        <status status="PASS" starttime="20201208 16:39:43.255" endtime="20201208 16:39:43.256" />
-                                    </kw>
-                                    <kw name="Call Method" library="BuiltIn">
-                                        <doc>Calls the named method of the given object with the provided arguments.</doc>
-                                        <arguments>
-                                            <arg>${options}</arg>
-                                            <arg>add_argument</arg>
-                                            <arg>--disable-notifications</arg>
-                                        </arguments>
-                                        <status status="PASS" starttime="20201208 16:39:43.256" endtime="20201208 16:39:43.256" />
-                                    </kw>
-                                    <msg timestamp="20201208 16:39:43.256" level="INFO">
+<status status="PASS" starttime="20201208 16:39:43.254" endtime="20201208 16:39:43.254"/>
+</kw>
+<kw name="Run Keyword If" library="BuiltIn">
+<arg>'${BROWSER}' == 'headlesschrome'</arg>
+<arg>Chrome Set Headless</arg>
+<arg>${options}</arg>
+<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
+<kw name="Chrome Set Headless" library="Salesforce">
+<arg>${options}</arg>
+<doc>This keyword is used to set the chrome options dictionary values required to run headless chrome.</doc>
+<kw name="Call Method" library="BuiltIn">
+<arg>${options}</arg>
+<arg>set_headless</arg>
+<arg>${true}</arg>
+<doc>Calls the named method of the given object with the provided arguments.</doc>
+<status status="PASS" starttime="20201208 16:39:43.254" endtime="20201208 16:39:43.255"/>
+</kw>
+<kw name="Call Method" library="BuiltIn">
+<arg>${options}</arg>
+<arg>add_argument</arg>
+<arg>--disable-dev-shm-usage</arg>
+<doc>Calls the named method of the given object with the provided arguments.</doc>
+<status status="PASS" starttime="20201208 16:39:43.255" endtime="20201208 16:39:43.255"/>
+</kw>
+<kw name="Call Method" library="BuiltIn">
+<arg>${options}</arg>
+<arg>add_argument</arg>
+<arg>--disable-background-timer-throttling</arg>
+<doc>Calls the named method of the given object with the provided arguments.</doc>
+<status status="PASS" starttime="20201208 16:39:43.255" endtime="20201208 16:39:43.255"/>
+</kw>
+<status status="PASS" starttime="20201208 16:39:43.254" endtime="20201208 16:39:43.255"/>
+</kw>
+<status status="PASS" starttime="20201208 16:39:43.254" endtime="20201208 16:39:43.255"/>
+</kw>
+<kw name="Run Keyword If" library="BuiltIn">
+<arg>'${CHROME_BINARY}' != '${empty}'</arg>
+<arg>Chrome Set Binary</arg>
+<arg>${options}</arg>
+<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
+<status status="PASS" starttime="20201208 16:39:43.255" endtime="20201208 16:39:43.256"/>
+</kw>
+<kw name="Call Method" library="BuiltIn">
+<arg>${options}</arg>
+<arg>add_argument</arg>
+<arg>--disable-notifications</arg>
+<doc>Calls the named method of the given object with the provided arguments.</doc>
+<status status="PASS" starttime="20201208 16:39:43.256" endtime="20201208 16:39:43.256"/>
+</kw>
+<msg timestamp="20201208 16:39:43.256" level="INFO">
                                         ${options} =
-                                        <selenium.webdriver.chrome.options.Options />
+                                        &lt;selenium.webdriver.chrome.options.Options /&gt;
                                     </msg>
-                                    <status status="PASS" starttime="20201208 16:39:43.253" endtime="20201208 16:39:43.256" />
-                                </kw>
-                                <kw name="Create Webdriver With Retry" library="cumulusci.robotframework.Salesforce">
-                                    <doc>Call the Create Webdriver keyword.</doc>
-                                    <arguments>
-                                        <arg>Chrome</arg>
-                                        <arg>options=${options}</arg>
-                                        <arg>alias=${alias}</arg>
-                                    </arguments>
-                                    <msg timestamp="20201208 16:39:43.256" level="INFO">Creating an instance of the Chrome WebDriver.</msg>
-                                    <status status="PASS" starttime="20201208 16:39:43.256" endtime="20201208 16:39:44.782" />
-                                </kw>
-                                <kw name="Set Selenium Implicit Wait" library="SeleniumLibrary">
-                                    <doc>Sets the implicit wait value used by Selenium.</doc>
-                                    <arguments>
-                                        <arg>${IMPLICIT_WAIT}</arg>
-                                    </arguments>
-                                    <status status="PASS" starttime="20201208 16:39:44.783" endtime="20201208 16:39:44.784" />
-                                </kw>
-                                <kw name="Set Selenium Timeout" library="SeleniumLibrary">
-                                    <doc>Sets the timeout that is used by various keywords.</doc>
-                                    <arguments>
-                                        <arg>${TIMEOUT}</arg>
-                                    </arguments>
-                                    <status status="PASS" starttime="20201208 16:39:44.784" endtime="20201208 16:39:44.786" />
-                                </kw>
-                                <kw name="Go To" library="SeleniumLibrary">
-                                    <doc>Navigates the current browser window to the provided ``url``.</doc>
-                                    <arguments>
-                                        <arg>${login_url}</arg>
-                                    </arguments>
-                                    <msg timestamp="20201208 16:39:44.786" level="INFO">Opening url 'https://data-connect-2957-dev-ed.cs40.my.salesforce.com//secur/frontdoor.jsp?sid=00D54000000HcuU!AQQAQI29qsozgQ0y9PRgWS_DNEqtvktRIR138cDCVLnl.NVVnH.8p4jN50bro_dz057S482u2UCNzw3EqTR2JKb1csxQ03OP'</msg>
-                                    <status status="PASS" starttime="20201208 16:39:44.786" endtime="20201208 16:39:46.789" />
-                                </kw>
-                                <status status="PASS" starttime="20201208 16:39:43.253" endtime="20201208 16:39:46.790" />
-                            </kw>
-                            <status status="PASS" starttime="20201208 16:39:43.252" endtime="20201208 16:39:46.790" />
-                        </kw>
-                        <kw name="Convert To Boolean" library="BuiltIn">
-                            <doc>Converts the given item to Boolean true or false.</doc>
-                            <arguments>
-                                <arg>${wait}</arg>
-                            </arguments>
-                            <assign>
-                                <var>${should_wait}</var>
-                            </assign>
-                            <msg timestamp="20201208 16:39:46.790" level="INFO">${should_wait} = True</msg>
-                            <status status="PASS" starttime="20201208 16:39:46.790" endtime="20201208 16:39:46.790" />
-                        </kw>
-                        <kw name="Run Keyword If" library="BuiltIn">
-                            <doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
-                            <arguments>
-                                <arg>$should_wait</arg>
-                                <arg>Wait Until Salesforce Is Ready</arg>
-                                <arg>timeout=180</arg>
-                            </arguments>
-                            <kw name="Wait Until Salesforce Is Ready" library="cumulusci.robotframework.Salesforce">
-                                <doc>Waits until we are able to render the initial salesforce landing page</doc>
-                                <arguments>
-                                    <arg>timeout=180</arg>
-                                </arguments>
-                                <status status="PASS" starttime="20201208 16:39:46.795" endtime="20201208 16:39:55.683" />
-                            </kw>
-                            <status status="PASS" starttime="20201208 16:39:46.791" endtime="20201208 16:39:55.683" />
-                        </kw>
-                        <kw name="Set Selenium Timeout" library="SeleniumLibrary">
-                            <doc>Sets the timeout that is used by various keywords.</doc>
-                            <arguments>
-                                <arg>${TIMEOUT}</arg>
-                            </arguments>
-                            <status status="PASS" starttime="20201208 16:39:55.683" endtime="20201208 16:39:55.684" />
-                        </kw>
-                        <kw name="Initialize Location Strategies" library="cumulusci.robotframework.Salesforce">
-                            <doc>Initialize the Salesforce location strategies 'text' and 'title' plus any strategies registered by other keyword libraries</doc>
-                            <status status="PASS" starttime="20201208 16:39:55.685" endtime="20201208 16:39:55.689" />
-                        </kw>
-                        <kw name="Split String" library="String">
-                            <doc>Splits the ``string`` using ``separator`` as a delimiter string.</doc>
-                            <arguments>
-                                <arg>${size}</arg>
-                                <arg>separator=x</arg>
-                                <arg>max_split=1</arg>
-                            </arguments>
-                            <assign>
-                                <var>${width}</var>
-                                <var>${height}</var>
-                            </assign>
-                            <msg timestamp="20201208 16:39:55.690" level="INFO">${width} = 1280</msg>
-                            <msg timestamp="20201208 16:39:55.690" level="INFO">${height} = 1024</msg>
-                            <status status="PASS" starttime="20201208 16:39:55.690" endtime="20201208 16:39:55.690" />
-                        </kw>
-                        <kw name="Set Window Size" library="SeleniumLibrary">
-                            <doc>Sets current windows size to given ``width`` and ``height``.</doc>
-                            <arguments>
-                                <arg>${width}</arg>
-                                <arg>${height}</arg>
-                            </arguments>
-                            <status status="PASS" starttime="20201208 16:39:55.690" endtime="20201208 16:39:55.924" />
-                        </kw>
-                        <kw name="Set Selenium Speed" library="SeleniumLibrary">
-                            <doc>Sets the delay that is waited after each Selenium command.</doc>
-                            <arguments>
-                                <arg>${SELENIUM_SPEED}</arg>
-                            </arguments>
-                            <status status="PASS" starttime="20201208 16:39:55.924" endtime="20201208 16:39:55.924" />
-                        </kw>
-                        <kw name="Log Browser Capabilities" library="cumulusci.robotframework.Salesforce">
-                            <doc>Logs all of the browser capabilities as reported by selenium</doc>
-                            <msg timestamp="20201208 16:39:55.925" level="INFO">selenium browser capabilities: { 'acceptInsecureCerts': False, 'browserName': 'chrome', 'browserVersion': '87.0.4280.88', 'chrome': { 'chromedriverVersion': '87.0.4280.88 ' '(89e2380a3e36c3464b5dd1302349b1382549290d-refs/branch-heads/4280@{#1761})', 'userDataDir': '/var/folders/63/67f0g5cs35v75jf1f23y1xtw0000gq/T/.com.google.Chrome.YkeMe8'}, 'goog:chromeOptions': {'debuggerAddress': 'localhost:56028'}, 'networkConnectionEnabled': False, 'pageLoadStrategy': 'normal', 'platformName': 'mac os x', 'proxy': {}, 'setWindowRect': True, 'strictFileInteractability': False, 'timeouts': {'implicit': 0, 'pageLoad': 300000, 'script': 30000}, 'unhandledPromptBehavior': 'dismiss and notify', 'webauthn:virtualAuthenticators': True}</msg>
-                            <status status="PASS" starttime="20201208 16:39:55.924" endtime="20201208 16:39:55.926" />
-                        </kw>
-                        <status status="PASS" starttime="20201208 16:39:43.252" endtime="20201208 16:39:55.926" />
-                    </kw>
-                    <kw name="Capture Page Screenshot" library="SeleniumLibrary">
-                        <doc>Takes a screenshot of the current page and embeds it into a log file.</doc>
-                        <msg timestamp="20201208 16:39:56.628" level="INFO" html="yes">
-                            &lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;3&quot;&gt;&lt;a href=&quot;selenium-screenshot-1.png&quot;&gt;&lt;img src=&quot;selenium-screenshot-1.png&quot; width=&quot;800px&quot;&gt;&lt;/a&gt;
+<status status="PASS" starttime="20201208 16:39:43.253" endtime="20201208 16:39:43.256"/>
+</kw>
+<kw name="Create Webdriver With Retry" library="cumulusci.robotframework.Salesforce">
+<arg>Chrome</arg>
+<arg>options=${options}</arg>
+<arg>alias=${alias}</arg>
+<doc>Call the Create Webdriver keyword.</doc>
+<msg timestamp="20201208 16:39:43.256" level="INFO">Creating an instance of the Chrome WebDriver.</msg>
+<status status="PASS" starttime="20201208 16:39:43.256" endtime="20201208 16:39:44.782"/>
+</kw>
+<kw name="Set Selenium Implicit Wait" library="SeleniumLibrary">
+<arg>${IMPLICIT_WAIT}</arg>
+<doc>Sets the implicit wait value used by Selenium.</doc>
+<status status="PASS" starttime="20201208 16:39:44.783" endtime="20201208 16:39:44.784"/>
+</kw>
+<kw name="Set Selenium Timeout" library="SeleniumLibrary">
+<arg>${TIMEOUT}</arg>
+<doc>Sets the timeout that is used by various keywords.</doc>
+<status status="PASS" starttime="20201208 16:39:44.784" endtime="20201208 16:39:44.786"/>
+</kw>
+<kw name="Go To" library="SeleniumLibrary">
+<arg>${login_url}</arg>
+<doc>Navigates the current browser window to the provided ``url``.</doc>
+<msg timestamp="20201208 16:39:44.786" level="INFO">Opening url 'https://data-connect-2957-dev-ed.cs40.my.salesforce.com//secur/frontdoor.jsp?sid=00D54000000HcuU!AQQAQI29qsozgQ0y9PRgWS_DNEqtvktRIR138cDCVLnl.NVVnH.8p4jN50bro_dz057S482u2UCNzw3EqTR2JKb1csxQ03OP'</msg>
+<status status="PASS" starttime="20201208 16:39:44.786" endtime="20201208 16:39:46.789"/>
+</kw>
+<status status="PASS" starttime="20201208 16:39:43.253" endtime="20201208 16:39:46.790"/>
+</kw>
+<status status="PASS" starttime="20201208 16:39:43.252" endtime="20201208 16:39:46.790"/>
+</kw>
+<kw name="Convert To Boolean" library="BuiltIn">
+<var>${should_wait}</var>
+<arg>${wait}</arg>
+<doc>Converts the given item to Boolean true or false.</doc>
+<msg timestamp="20201208 16:39:46.790" level="INFO">${should_wait} = True</msg>
+<status status="PASS" starttime="20201208 16:39:46.790" endtime="20201208 16:39:46.790"/>
+</kw>
+<kw name="Run Keyword If" library="BuiltIn">
+<arg>$should_wait</arg>
+<arg>Wait Until Salesforce Is Ready</arg>
+<arg>timeout=180</arg>
+<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
+<kw name="Wait Until Salesforce Is Ready" library="cumulusci.robotframework.Salesforce">
+<arg>timeout=180</arg>
+<doc>Waits until we are able to render the initial salesforce landing page</doc>
+<status status="PASS" starttime="20201208 16:39:46.795" endtime="20201208 16:39:55.683"/>
+</kw>
+<status status="PASS" starttime="20201208 16:39:46.791" endtime="20201208 16:39:55.683"/>
+</kw>
+<kw name="Set Selenium Timeout" library="SeleniumLibrary">
+<arg>${TIMEOUT}</arg>
+<doc>Sets the timeout that is used by various keywords.</doc>
+<status status="PASS" starttime="20201208 16:39:55.683" endtime="20201208 16:39:55.684"/>
+</kw>
+<kw name="Initialize Location Strategies" library="cumulusci.robotframework.Salesforce">
+<doc>Initialize the Salesforce location strategies 'text' and 'title' plus any strategies registered by other keyword libraries</doc>
+<status status="PASS" starttime="20201208 16:39:55.685" endtime="20201208 16:39:55.689"/>
+</kw>
+<kw name="Split String" library="String">
+<var>${width}</var>
+<var>${height}</var>
+<arg>${size}</arg>
+<arg>separator=x</arg>
+<arg>max_split=1</arg>
+<doc>Splits the ``string`` using ``separator`` as a delimiter string.</doc>
+<msg timestamp="20201208 16:39:55.690" level="INFO">${width} = 1280</msg>
+<msg timestamp="20201208 16:39:55.690" level="INFO">${height} = 1024</msg>
+<status status="PASS" starttime="20201208 16:39:55.690" endtime="20201208 16:39:55.690"/>
+</kw>
+<kw name="Set Window Size" library="SeleniumLibrary">
+<arg>${width}</arg>
+<arg>${height}</arg>
+<doc>Sets current windows size to given ``width`` and ``height``.</doc>
+<status status="PASS" starttime="20201208 16:39:55.690" endtime="20201208 16:39:55.924"/>
+</kw>
+<kw name="Set Selenium Speed" library="SeleniumLibrary">
+<arg>${SELENIUM_SPEED}</arg>
+<doc>Sets the delay that is waited after each Selenium command.</doc>
+<status status="PASS" starttime="20201208 16:39:55.924" endtime="20201208 16:39:55.924"/>
+</kw>
+<kw name="Log Browser Capabilities" library="cumulusci.robotframework.Salesforce">
+<doc>Logs all of the browser capabilities as reported by selenium</doc>
+<msg timestamp="20201208 16:39:55.925" level="INFO">selenium browser capabilities: { 'acceptInsecureCerts': False, 'browserName': 'chrome', 'browserVersion': '87.0.4280.88', 'chrome': { 'chromedriverVersion': '87.0.4280.88 ' '(89e2380a3e36c3464b5dd1302349b1382549290d-refs/branch-heads/4280@{#1761})', 'userDataDir': '/var/folders/63/67f0g5cs35v75jf1f23y1xtw0000gq/T/.com.google.Chrome.YkeMe8'}, 'goog:chromeOptions': {'debuggerAddress': 'localhost:56028'}, 'networkConnectionEnabled': False, 'pageLoadStrategy': 'normal', 'platformName': 'mac os x', 'proxy': {}, 'setWindowRect': True, 'strictFileInteractability': False, 'timeouts': {'implicit': 0, 'pageLoad': 300000, 'script': 30000}, 'unhandledPromptBehavior': 'dismiss and notify', 'webauthn:virtualAuthenticators': True}</msg>
+<status status="PASS" starttime="20201208 16:39:55.924" endtime="20201208 16:39:55.926"/>
+</kw>
+<status status="PASS" starttime="20201208 16:39:43.252" endtime="20201208 16:39:55.926"/>
+</kw>
+<kw name="Capture Page Screenshot" library="SeleniumLibrary">
+<doc>Takes a screenshot of the current page and embeds it into a log file.</doc>
+<msg timestamp="20201208 16:39:56.628" level="INFO" html="true">
+                            &lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td
+                            colspan="3"&gt;&lt;a href="selenium-screenshot-1.png"&gt;&lt;img src="selenium-screenshot-1.png" width="800px"&gt;&lt;/a&gt;
                         </msg>
-                        <status status="PASS" starttime="20201208 16:39:55.926" endtime="20201208 16:39:56.629" />
-                    </kw>
-                    <status status="PASS" starttime="20201208 16:39:43.251" endtime="20201208 16:39:56.629" />
-                </kw>
-                <test id="s1-s1-s1-t1" name="Via API">
-                    <kw name="Generate Random String" library="String">
-                        <doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
-                        <assign>
-                            <var>${first_name}</var>
-                        </assign>
-                        <msg timestamp="20201208 16:39:56.631" level="INFO">${first_name} = Rdoc2hv3</msg>
-                        <status status="PASS" starttime="20201208 16:39:56.630" endtime="20201208 16:39:56.631" />
-                    </kw>
-                    <kw name="Generate Random String" library="String">
-                        <doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
-                        <assign>
-                            <var>${last_name}</var>
-                        </assign>
-                        <msg timestamp="20201208 16:39:56.631" level="INFO">${last_name} = iSFbA3sW</msg>
-                        <status status="PASS" starttime="20201208 16:39:56.631" endtime="20201208 16:39:56.631" />
-                    </kw>
-                    <kw name="Salesforce Insert" library="cumulusci.robotframework.Salesforce">
-                        <doc>Creates a new Salesforce object and returns the Id.</doc>
-                        <arguments>
-                            <arg>Contact</arg>
-                            <arg>FirstName=${first_name}</arg>
-                            <arg>LastName=${last_name}</arg>
-                        </arguments>
-                        <assign>
-                            <var>${contact_id}</var>
-                        </assign>
-                        <msg timestamp="20201208 16:39:56.632" level="INFO">Inserting Contact with values {'FirstName': 'Rdoc2hv3', 'LastName': 'iSFbA3sW'}</msg>
-                        <msg timestamp="20201208 16:39:57.521" level="INFO">Storing Contact 0035400000alF6QAAU to session records</msg>
-                        <msg timestamp="20201208 16:39:57.523" level="INFO">${contact_id} = 0035400000alF6QAAU</msg>
-                        <status status="PASS" starttime="20201208 16:39:56.631" endtime="20201208 16:39:57.523" />
-                    </kw>
-                    <kw name="Salesforce Get" library="cumulusci.robotframework.Salesforce">
-                        <doc>Gets a Salesforce object by Id and returns the result as a dict.</doc>
-                        <arguments>
-                            <arg>Contact</arg>
-                            <arg>${contact_id}</arg>
-                        </arguments>
-                        <assign>
-                            <var>${contact}</var>
-                        </assign>
-                        <msg timestamp="20201208 16:39:57.523" level="INFO">Getting Contact with Id 0035400000alF6QAAU</msg>
-                        <msg timestamp="20201208 16:39:57.814" level="INFO">${contact} = { attributes={'type': 'Contact', 'url': '/services/data/v48.0/sobjects/Contact/0035400000alF6QAAU'} | Id=0035400000alF6QAAU | IsDeleted=False | MasterRecordId=None | AccountId=None | LastName=iSFbA3sW...</msg>
-                        <status status="PASS" starttime="20201208 16:39:57.523" endtime="20201208 16:39:57.814" />
-                    </kw>
-                    <kw name="Validate Contact">
-                        <doc>Given a contact id, validate that the contact has the expected first and last name both through the detail page in the UI and via the API.</doc>
-                        <arguments>
-                            <arg>${contact_id}</arg>
-                            <arg>${first_name}</arg>
-                            <arg>${last_name}</arg>
-                        </arguments>
-                        <kw name="Go To Page" library="cumulusci.robotframework.PageObjects">
-                            <doc>Go to the page of the given page object.</doc>
-                            <arguments>
-                                <arg>Detail</arg>
-                                <arg>Contact</arg>
-                                <arg>${contact_id}</arg>
-                            </arguments>
-                            <msg timestamp="20201208 16:39:57.818" level="INFO">Opening url 'https://data-connect-2957-dev-ed.lightning.force.com/lightning/r/Contact/0035400000alF6QAAU/view'</msg>
-                            <status status="PASS" starttime="20201208 16:39:57.815" endtime="20201208 16:39:59.828" />
-                        </kw>
-                        <kw name="Page Should Contain" library="SeleniumLibrary">
-                            <doc>Verifies that current page contains ``text``.</doc>
-                            <arguments>
-                                <arg>${first_name} ${last_name}</arg>
-                            </arguments>
-                            <msg timestamp="20201208 16:40:00.068" level="INFO">Current page contains text 'Rdoc2hv3 iSFbA3sW'.</msg>
-                            <status status="PASS" starttime="20201208 16:39:59.829" endtime="20201208 16:40:00.069" />
-                        </kw>
-                        <kw name="Salesforce Get" library="cumulusci.robotframework.Salesforce">
-                            <doc>Gets a Salesforce object by Id and returns the result as a dict.</doc>
-                            <arguments>
-                                <arg>Contact</arg>
-                                <arg>${contact_id}</arg>
-                            </arguments>
-                            <assign>
-                                <var>${contact}</var>
-                            </assign>
-                            <msg timestamp="20201208 16:40:00.069" level="INFO">Getting Contact with Id 0035400000alF6QAAU</msg>
-                            <msg timestamp="20201208 16:40:00.344" level="INFO">${contact} = { attributes={'type': 'Contact', 'url': '/services/data/v48.0/sobjects/Contact/0035400000alF6QAAU'} | Id=0035400000alF6QAAU | IsDeleted=False | MasterRecordId=None | AccountId=None | LastName=iSFbA3sW...</msg>
-                            <status status="PASS" starttime="20201208 16:40:00.069" endtime="20201208 16:40:00.344" />
-                        </kw>
-                        <kw name="Should Be Equal" library="BuiltIn">
-                            <doc>Fails if the given objects are unequal.</doc>
-                            <arguments>
-                                <arg>${first_name}</arg>
-                                <arg>${contact}[FirstName]</arg>
-                            </arguments>
-                            <msg timestamp="20201208 16:40:00.344" level="WARN">Accessing variable items using '${contact}[FirstName]' syntax is deprecated. Use '${contact}[FirstName]' instead.</msg>
-                            <status status="PASS" starttime="20201208 16:40:00.344" endtime="20201208 16:40:00.345" />
-                        </kw>
-                        <kw name="Should Be Equal" library="BuiltIn">
-                            <doc>Fails if the given objects are unequal.</doc>
-                            <arguments>
-                                <arg>${last_name}</arg>
-                                <arg>${contact}[LastName]</arg>
-                            </arguments>
-                            <msg timestamp="20201208 16:40:00.345" level="WARN">Accessing variable items using '${contact}[LastName]' syntax is deprecated. Use '${contact}[LastName]' instead.</msg>
-                            <status status="PASS" starttime="20201208 16:40:00.345" endtime="20201208 16:40:00.346" />
-                        </kw>
-                        <status status="PASS" starttime="20201208 16:39:57.814" endtime="20201208 16:40:00.346" />
-                    </kw>
-                    <status status="PASS" starttime="20201208 16:39:56.629" endtime="20201208 16:40:00.346" critical="yes" />
-                </test>
-                <test id="s1-s1-s1-t2" name="Via UI">
-                    <kw name="Generate Random String" library="String">
-                        <doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
-                        <assign>
-                            <var>${first_name}</var>
-                        </assign>
-                        <msg timestamp="20201208 16:40:00.348" level="INFO">${first_name} = yfPLSkjL</msg>
-                        <status status="PASS" starttime="20201208 16:40:00.348" endtime="20201208 16:40:00.348" />
-                    </kw>
-                    <kw name="Generate Random String" library="String">
-                        <doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
-                        <assign>
-                            <var>${last_name}</var>
-                        </assign>
-                        <msg timestamp="20201208 16:40:00.349" level="INFO">${last_name} = w3skK2yr</msg>
-                        <status status="PASS" starttime="20201208 16:40:00.348" endtime="20201208 16:40:00.349" />
-                    </kw>
-                    <kw name="Go To Page" library="cumulusci.robotframework.PageObjects">
-                        <doc>Go to the page of the given page object.</doc>
-                        <arguments>
-                            <arg>Home</arg>
-                            <arg>Contact</arg>
-                        </arguments>
-                        <msg timestamp="20201208 16:40:00.351" level="INFO">Opening url 'https://data-connect-2957-dev-ed.lightning.force.com/lightning/o/Contact/home'</msg>
-                        <status status="PASS" starttime="20201208 16:40:00.349" endtime="20201208 16:40:02.273" />
-                    </kw>
-                    <kw name="Click Object Button" library="cumulusci.robotframework.Salesforce">
-                        <doc>Clicks a button in an object's actions.</doc>
-                        <arguments>
-                            <arg>New</arg>
-                        </arguments>
-                        <status status="PASS" starttime="20201208 16:40:02.273" endtime="20201208 16:40:02.489" />
-                    </kw>
-                    <kw name="Wait For Modal" library="cumulusci.robotframework.PageObjects">
-                        <doc>Wait for the given page object modal to appear.</doc>
-                        <arguments>
-                            <arg>New</arg>
-                            <arg>Contact</arg>
-                        </arguments>
-                        <msg timestamp="20201208 16:40:03.532" level="INFO">Slept 1 second</msg>
-                        <status status="PASS" starttime="20201208 16:40:02.489" endtime="20201208 16:40:03.533" />
-                    </kw>
-                    <kw name="Populate Form" library="ContactNewPage">
-                        <doc>Populate the modal form</doc>
-                        <arguments>
-                            <arg>First Name=${first_name}</arg>
-                            <arg>Last Name=${last_name}</arg>
-                        </arguments>
-                        <status status="PASS" starttime="20201208 16:40:03.533" endtime="20201208 16:40:04.454" />
-                    </kw>
-                    <kw name="Capture Page Screenshot" library="SeleniumLibrary">
-                        <doc>Takes a screenshot of the current page and embeds it into a log file.</doc>
-                        <msg timestamp="20201208 16:40:05.046" level="INFO" html="yes">
-                            &lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;3&quot;&gt;&lt;a href=&quot;selenium-screenshot-2.png&quot;&gt;&lt;img src=&quot;selenium-screenshot-2.png&quot; width=&quot;800px&quot;&gt;&lt;/a&gt;
+<status status="PASS" starttime="20201208 16:39:55.926" endtime="20201208 16:39:56.629"/>
+</kw>
+<status status="PASS" starttime="20201208 16:39:43.251" endtime="20201208 16:39:56.629"/>
+</kw>
+<test id="s1-s1-s1-t1" name="Via API">
+<kw name="Generate Random String" library="String">
+<var>${first_name}</var>
+<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
+<msg timestamp="20201208 16:39:56.631" level="INFO">${first_name} = Rdoc2hv3</msg>
+<status status="PASS" starttime="20201208 16:39:56.630" endtime="20201208 16:39:56.631"/>
+</kw>
+<kw name="Generate Random String" library="String">
+<var>${last_name}</var>
+<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
+<msg timestamp="20201208 16:39:56.631" level="INFO">${last_name} = iSFbA3sW</msg>
+<status status="PASS" starttime="20201208 16:39:56.631" endtime="20201208 16:39:56.631"/>
+</kw>
+<kw name="Salesforce Insert" library="cumulusci.robotframework.Salesforce">
+<var>${contact_id}</var>
+<arg>Contact</arg>
+<arg>FirstName=${first_name}</arg>
+<arg>LastName=${last_name}</arg>
+<doc>Creates a new Salesforce object and returns the Id.</doc>
+<msg timestamp="20201208 16:39:56.632" level="INFO">Inserting Contact with values {'FirstName': 'Rdoc2hv3', 'LastName': 'iSFbA3sW'}</msg>
+<msg timestamp="20201208 16:39:57.521" level="INFO">Storing Contact 0035400000alF6QAAU to session records</msg>
+<msg timestamp="20201208 16:39:57.523" level="INFO">${contact_id} = 0035400000alF6QAAU</msg>
+<status status="PASS" starttime="20201208 16:39:56.631" endtime="20201208 16:39:57.523"/>
+</kw>
+<kw name="Salesforce Get" library="cumulusci.robotframework.Salesforce">
+<var>${contact}</var>
+<arg>Contact</arg>
+<arg>${contact_id}</arg>
+<doc>Gets a Salesforce object by Id and returns the result as a dict.</doc>
+<msg timestamp="20201208 16:39:57.523" level="INFO">Getting Contact with Id 0035400000alF6QAAU</msg>
+<msg timestamp="20201208 16:39:57.814" level="INFO">${contact} = { attributes={'type': 'Contact', 'url': '/services/data/v48.0/sobjects/Contact/0035400000alF6QAAU'} | Id=0035400000alF6QAAU | IsDeleted=False | MasterRecordId=None | AccountId=None | LastName=iSFbA3sW...</msg>
+<status status="PASS" starttime="20201208 16:39:57.523" endtime="20201208 16:39:57.814"/>
+</kw>
+<kw name="Validate Contact">
+<arg>${contact_id}</arg>
+<arg>${first_name}</arg>
+<arg>${last_name}</arg>
+<doc>Given a contact id, validate that the contact has the expected first and last name both through the detail page in the UI and via the API.</doc>
+<kw name="Go To Page" library="cumulusci.robotframework.PageObjects">
+<arg>Detail</arg>
+<arg>Contact</arg>
+<arg>${contact_id}</arg>
+<doc>Go to the page of the given page object.</doc>
+<msg timestamp="20201208 16:39:57.818" level="INFO">Opening url 'https://data-connect-2957-dev-ed.lightning.force.com/lightning/r/Contact/0035400000alF6QAAU/view'</msg>
+<status status="PASS" starttime="20201208 16:39:57.815" endtime="20201208 16:39:59.828"/>
+</kw>
+<kw name="Page Should Contain" library="SeleniumLibrary">
+<arg>${first_name} ${last_name}</arg>
+<doc>Verifies that current page contains ``text``.</doc>
+<msg timestamp="20201208 16:40:00.068" level="INFO">Current page contains text 'Rdoc2hv3 iSFbA3sW'.</msg>
+<status status="PASS" starttime="20201208 16:39:59.829" endtime="20201208 16:40:00.069"/>
+</kw>
+<kw name="Salesforce Get" library="cumulusci.robotframework.Salesforce">
+<var>${contact}</var>
+<arg>Contact</arg>
+<arg>${contact_id}</arg>
+<doc>Gets a Salesforce object by Id and returns the result as a dict.</doc>
+<msg timestamp="20201208 16:40:00.069" level="INFO">Getting Contact with Id 0035400000alF6QAAU</msg>
+<msg timestamp="20201208 16:40:00.344" level="INFO">${contact} = { attributes={'type': 'Contact', 'url': '/services/data/v48.0/sobjects/Contact/0035400000alF6QAAU'} | Id=0035400000alF6QAAU | IsDeleted=False | MasterRecordId=None | AccountId=None | LastName=iSFbA3sW...</msg>
+<status status="PASS" starttime="20201208 16:40:00.069" endtime="20201208 16:40:00.344"/>
+</kw>
+<kw name="Should Be Equal" library="BuiltIn">
+<arg>${first_name}</arg>
+<arg>${contact}[FirstName]</arg>
+<doc>Fails if the given objects are unequal.</doc>
+<msg timestamp="20201208 16:40:00.344" level="WARN">Accessing variable items using '${contact}[FirstName]' syntax is deprecated. Use '${contact}[FirstName]' instead.</msg>
+<status status="PASS" starttime="20201208 16:40:00.344" endtime="20201208 16:40:00.345"/>
+</kw>
+<kw name="Should Be Equal" library="BuiltIn">
+<arg>${last_name}</arg>
+<arg>${contact}[LastName]</arg>
+<doc>Fails if the given objects are unequal.</doc>
+<msg timestamp="20201208 16:40:00.345" level="WARN">Accessing variable items using '${contact}[LastName]' syntax is deprecated. Use '${contact}[LastName]' instead.</msg>
+<status status="PASS" starttime="20201208 16:40:00.345" endtime="20201208 16:40:00.346"/>
+</kw>
+<status status="PASS" starttime="20201208 16:39:57.814" endtime="20201208 16:40:00.346"/>
+</kw>
+<status status="PASS" starttime="20201208 16:39:56.629" endtime="20201208 16:40:00.346"/>
+</test>
+<test id="s1-s1-s1-t2" name="Via UI">
+<kw name="Generate Random String" library="String">
+<var>${first_name}</var>
+<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
+<msg timestamp="20201208 16:40:00.348" level="INFO">${first_name} = yfPLSkjL</msg>
+<status status="PASS" starttime="20201208 16:40:00.348" endtime="20201208 16:40:00.348"/>
+</kw>
+<kw name="Generate Random String" library="String">
+<var>${last_name}</var>
+<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
+<msg timestamp="20201208 16:40:00.349" level="INFO">${last_name} = w3skK2yr</msg>
+<status status="PASS" starttime="20201208 16:40:00.348" endtime="20201208 16:40:00.349"/>
+</kw>
+<kw name="Go To Page" library="cumulusci.robotframework.PageObjects">
+<arg>Home</arg>
+<arg>Contact</arg>
+<doc>Go to the page of the given page object.</doc>
+<msg timestamp="20201208 16:40:00.351" level="INFO">Opening url 'https://data-connect-2957-dev-ed.lightning.force.com/lightning/o/Contact/home'</msg>
+<status status="PASS" starttime="20201208 16:40:00.349" endtime="20201208 16:40:02.273"/>
+</kw>
+<kw name="Click Object Button" library="cumulusci.robotframework.Salesforce">
+<arg>New</arg>
+<doc>Clicks a button in an object's actions.</doc>
+<status status="PASS" starttime="20201208 16:40:02.273" endtime="20201208 16:40:02.489"/>
+</kw>
+<kw name="Wait For Modal" library="cumulusci.robotframework.PageObjects">
+<arg>New</arg>
+<arg>Contact</arg>
+<doc>Wait for the given page object modal to appear.</doc>
+<msg timestamp="20201208 16:40:03.532" level="INFO">Slept 1 second</msg>
+<status status="PASS" starttime="20201208 16:40:02.489" endtime="20201208 16:40:03.533"/>
+</kw>
+<kw name="Populate Form" library="ContactNewPage">
+<arg>First Name=${first_name}</arg>
+<arg>Last Name=${last_name}</arg>
+<doc>Populate the modal form</doc>
+<status status="PASS" starttime="20201208 16:40:03.533" endtime="20201208 16:40:04.454"/>
+</kw>
+<kw name="Capture Page Screenshot" library="SeleniumLibrary">
+<doc>Takes a screenshot of the current page and embeds it into a log file.</doc>
+<msg timestamp="20201208 16:40:05.046" level="INFO" html="true">
+                            &lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan="3"&gt;&lt;a href="selenium-screenshot-2.png"&gt;&lt;img src="selenium-screenshot-2.png" width="800px"&gt;&lt;/a&gt;
                         </msg>
-                        <status status="PASS" starttime="20201208 16:40:04.454" endtime="20201208 16:40:05.047" />
-                    </kw>
-                    <kw name="Click Modal Button" library="ContactNewPage">
-                        <doc>Click the named modal button (Save, Save &amp; New, Cancel, etc)</doc>
-                        <arguments>
-                            <arg>Save</arg>
-                        </arguments>
-                        <status status="PASS" starttime="20201208 16:40:05.047" endtime="20201208 16:40:05.133" />
-                    </kw>
-                    <kw name="Wait Until Modal Is Closed" library="ContactNewPage">
-                        <doc>Waits until the modal is no longer visible</doc>
-                        <status status="PASS" starttime="20201208 16:40:05.134" endtime="20201208 16:40:13.086" />
-                    </kw>
-                    <kw name="Get Current Record Id" library="cumulusci.robotframework.Salesforce">
-                        <doc>Parses the current url to get the object id of the current record. Expects url format like: [a-zA-Z0-9]{15,18}</doc>
-                        <assign>
-                            <var>${contact_id}</var>
-                        </assign>
-                        <msg timestamp="20201208 16:40:13.091" level="INFO">${contact_id} = 0035400000alF6VAAU</msg>
-                        <status status="PASS" starttime="20201208 16:40:13.086" endtime="20201208 16:40:13.091" />
-                    </kw>
-                    <kw name="Store Session Record" library="cumulusci.robotframework.Salesforce">
-                        <doc>Stores a Salesforce record's Id for use in the *Delete Session Records* keyword.</doc>
-                        <arguments>
-                            <arg>Contact</arg>
-                            <arg>${contact_id}</arg>
-                        </arguments>
-                        <msg timestamp="20201208 16:40:13.092" level="INFO">Storing Contact 0035400000alF6VAAU to session records</msg>
-                        <status status="PASS" starttime="20201208 16:40:13.091" endtime="20201208 16:40:13.092" />
-                    </kw>
-                    <kw name="Validate Contact">
-                        <doc>Given a contact id, validate that the contact has the expected first and last name both through the detail page in the UI and via the API.</doc>
-                        <arguments>
-                            <arg>${contact_id}</arg>
-                            <arg>${first_name}</arg>
-                            <arg>${last_name}</arg>
-                        </arguments>
-                        <kw name="Go To Page" library="cumulusci.robotframework.PageObjects">
-                            <doc>Go to the page of the given page object.</doc>
-                            <arguments>
-                                <arg>Detail</arg>
-                                <arg>Contact</arg>
-                                <arg>${contact_id}</arg>
-                            </arguments>
-                            <msg timestamp="20201208 16:40:13.093" level="INFO">Opening url 'https://data-connect-2957-dev-ed.lightning.force.com/lightning/r/Contact/0035400000alF6VAAU/view'</msg>
-                            <status status="PASS" starttime="20201208 16:40:13.092" endtime="20201208 16:40:14.815" />
-                        </kw>
-                        <kw name="Page Should Contain" library="SeleniumLibrary">
-                            <doc>Verifies that current page contains ``text``.</doc>
-                            <arguments>
-                                <arg>${first_name} ${last_name}</arg>
-                            </arguments>
-                            <msg timestamp="20201208 16:40:14.835" level="INFO">Current page contains text 'yfPLSkjL w3skK2yr'.</msg>
-                            <status status="PASS" starttime="20201208 16:40:14.815" endtime="20201208 16:40:14.835" />
-                        </kw>
-                        <kw name="Salesforce Get" library="cumulusci.robotframework.Salesforce">
-                            <doc>Gets a Salesforce object by Id and returns the result as a dict.</doc>
-                            <arguments>
-                                <arg>Contact</arg>
-                                <arg>${contact_id}</arg>
-                            </arguments>
-                            <assign>
-                                <var>${contact}</var>
-                            </assign>
-                            <msg timestamp="20201208 16:40:14.835" level="INFO">Getting Contact with Id 0035400000alF6VAAU</msg>
-                            <msg timestamp="20201208 16:40:15.395" level="INFO">${contact} = { attributes={'type': 'Contact', 'url': '/services/data/v48.0/sobjects/Contact/0035400000alF6VAAU'} | Id=0035400000alF6VAAU | IsDeleted=False | MasterRecordId=None | AccountId=None | LastName=w3skK2yr...</msg>
-                            <status status="PASS" starttime="20201208 16:40:14.835" endtime="20201208 16:40:15.395" />
-                        </kw>
-                        <kw name="Should Be Equal" library="BuiltIn">
-                            <doc>Fails if the given objects are unequal.</doc>
-                            <arguments>
-                                <arg>${first_name}</arg>
-                                <arg>${contact}[FirstName]</arg>
-                            </arguments>
-                            <msg timestamp="20201208 16:40:15.396" level="WARN">Accessing variable items using '${contact}[FirstName]' syntax is deprecated. Use '${contact}[FirstName]' instead.</msg>
-                            <status status="PASS" starttime="20201208 16:40:15.395" endtime="20201208 16:40:15.396" />
-                        </kw>
-                        <kw name="Should Be Equal" library="BuiltIn">
-                            <doc>Fails if the given objects are unequal.</doc>
-                            <arguments>
-                                <arg>${last_name}</arg>
-                                <arg>${contact}[LastName]</arg>
-                            </arguments>
-                            <msg timestamp="20201208 16:40:15.397" level="WARN">Accessing variable items using '${contact}[LastName]' syntax is deprecated. Use '${contact}[LastName]' instead.</msg>
-                            <status status="PASS" starttime="20201208 16:40:15.396" endtime="20201208 16:40:15.397" />
-                        </kw>
-                        <status status="PASS" starttime="20201208 16:40:13.092" endtime="20201208 16:40:15.397" />
-                    </kw>
-                    <status status="PASS" starttime="20201208 16:40:00.347" endtime="20201208 16:40:15.397" critical="yes" />
-                </test>
-                <kw name="Delete Records and Close Browser" library="Salesforce" type="teardown">
-                    <doc>This will close all open browser windows and then delete all records that were created with the Salesforce API during this testing session.</doc>
-                    <kw name="Close All Browsers" library="SeleniumLibrary">
-                        <doc>Closes all open browsers and resets the browser cache.</doc>
-                        <status status="PASS" starttime="20201208 16:40:15.401" endtime="20201208 16:40:15.492" />
-                    </kw>
-                    <kw name="Delete Session Records" library="cumulusci.robotframework.Salesforce">
-                        <doc>Deletes records that were created while running this test case.</doc>
-                        <msg timestamp="20201208 16:40:15.492" level="INFO">Deleting 2 records</msg>
-                        <msg timestamp="20201208 16:40:15.492" level="INFO"> Deleting Contact 0035400000alF6VAAU</msg>
-                        <msg timestamp="20201208 16:40:15.492" level="INFO">Deleting Contact with Id 0035400000alF6VAAU</msg>
-                        <msg timestamp="20201208 16:40:16.201" level="INFO"> Deleting Contact 0035400000alF6QAAU</msg>
-                        <msg timestamp="20201208 16:40:16.202" level="INFO">Deleting Contact with Id 0035400000alF6QAAU</msg>
-                        <status status="PASS" starttime="20201208 16:40:15.492" endtime="20201208 16:40:17.079" />
-                    </kw>
-                    <status status="PASS" starttime="20201208 16:40:15.401" endtime="20201208 16:40:17.080" />
-                </kw>
-                <metadata>
-                    <item name="Salesforce API Version">50</item>
-                </metadata>
-                <status status="PASS" starttime="20201208 16:39:43.002" endtime="20201208 16:40:17.080" />
-            </suite>
-            <status status="PASS" starttime="20201208 16:39:42.999" endtime="20201208 16:40:17.096" />
-        </suite>
-        <status status="PASS" starttime="20201208 16:39:42.980" endtime="20201208 16:40:17.106" />
-    </suite>
-    <statistics>
-        <total>
-            <stat pass="2" fail="0">Critical Tests</stat>
-            <stat pass="2" fail="0">All Tests</stat>
-        </total>
-        <tag></tag>
-        <suite>
-            <stat pass="2" fail="0" id="s1" name="Tests">Tests</stat>
-            <stat pass="2" fail="0" id="s1-s1" name="Standard Objects">Tests.Standard Objects</stat>
-            <stat pass="2" fail="0" id="s1-s1-s1" name="Create Contact">Tests.Standard Objects.Create Contact</stat>
-        </suite>
-    </statistics>
-    <errors>
-        <msg timestamp="20201208 16:40:00.344" level="WARN">Accessing variable items using '${contact}[FirstName]' syntax is deprecated. Use '${contact}[FirstName]' instead.</msg>
-        <msg timestamp="20201208 16:40:00.345" level="WARN">Accessing variable items using '${contact}[LastName]' syntax is deprecated. Use '${contact}[LastName]' instead.</msg>
-        <msg timestamp="20201208 16:40:15.396" level="WARN">Accessing variable items using '${contact}[FirstName]' syntax is deprecated. Use '${contact}[FirstName]' instead.</msg>
-        <msg timestamp="20201208 16:40:15.397" level="WARN">Accessing variable items using '${contact}[LastName]' syntax is deprecated. Use '${contact}[LastName]' instead.</msg>
-    </errors>
+<status status="PASS" starttime="20201208 16:40:04.454" endtime="20201208 16:40:05.047"/>
+</kw>
+<kw name="Click Modal Button" library="ContactNewPage">
+<arg>Save</arg>
+<doc>Click the named modal button (Save, Save &amp; New, Cancel, etc)</doc>
+<status status="PASS" starttime="20201208 16:40:05.047" endtime="20201208 16:40:05.133"/>
+</kw>
+<kw name="Wait Until Modal Is Closed" library="ContactNewPage">
+<doc>Waits until the modal is no longer visible</doc>
+<status status="PASS" starttime="20201208 16:40:05.134" endtime="20201208 16:40:13.086"/>
+</kw>
+<kw name="Get Current Record Id" library="cumulusci.robotframework.Salesforce">
+<var>${contact_id}</var>
+<doc>Parses the current url to get the object id of the current record. Expects url format like: [a-zA-Z0-9]{15,18}</doc>
+<msg timestamp="20201208 16:40:13.091" level="INFO">${contact_id} = 0035400000alF6VAAU</msg>
+<status status="PASS" starttime="20201208 16:40:13.086" endtime="20201208 16:40:13.091"/>
+</kw>
+<kw name="Store Session Record" library="cumulusci.robotframework.Salesforce">
+<arg>Contact</arg>
+<arg>${contact_id}</arg>
+<doc>Stores a Salesforce record's Id for use in the *Delete Session Records* keyword.</doc>
+<msg timestamp="20201208 16:40:13.092" level="INFO">Storing Contact 0035400000alF6VAAU to session records</msg>
+<status status="PASS" starttime="20201208 16:40:13.091" endtime="20201208 16:40:13.092"/>
+</kw>
+<kw name="Validate Contact">
+<arg>${contact_id}</arg>
+<arg>${first_name}</arg>
+<arg>${last_name}</arg>
+<doc>Given a contact id, validate that the contact has the expected first and last name both through the detail page in the UI and via the API.</doc>
+<kw name="Go To Page" library="cumulusci.robotframework.PageObjects">
+<arg>Detail</arg>
+<arg>Contact</arg>
+<arg>${contact_id}</arg>
+<doc>Go to the page of the given page object.</doc>
+<msg timestamp="20201208 16:40:13.093" level="INFO">Opening url 'https://data-connect-2957-dev-ed.lightning.force.com/lightning/r/Contact/0035400000alF6VAAU/view'</msg>
+<status status="PASS" starttime="20201208 16:40:13.092" endtime="20201208 16:40:14.815"/>
+</kw>
+<kw name="Page Should Contain" library="SeleniumLibrary">
+<arg>${first_name} ${last_name}</arg>
+<doc>Verifies that current page contains ``text``.</doc>
+<msg timestamp="20201208 16:40:14.835" level="INFO">Current page contains text 'yfPLSkjL w3skK2yr'.</msg>
+<status status="PASS" starttime="20201208 16:40:14.815" endtime="20201208 16:40:14.835"/>
+</kw>
+<kw name="Salesforce Get" library="cumulusci.robotframework.Salesforce">
+<var>${contact}</var>
+<arg>Contact</arg>
+<arg>${contact_id}</arg>
+<doc>Gets a Salesforce object by Id and returns the result as a dict.</doc>
+<msg timestamp="20201208 16:40:14.835" level="INFO">Getting Contact with Id 0035400000alF6VAAU</msg>
+<msg timestamp="20201208 16:40:15.395" level="INFO">${contact} = { attributes={'type': 'Contact', 'url': '/services/data/v48.0/sobjects/Contact/0035400000alF6VAAU'} | Id=0035400000alF6VAAU | IsDeleted=False | MasterRecordId=None | AccountId=None | LastName=w3skK2yr...</msg>
+<status status="PASS" starttime="20201208 16:40:14.835" endtime="20201208 16:40:15.395"/>
+</kw>
+<kw name="Should Be Equal" library="BuiltIn">
+<arg>${first_name}</arg>
+<arg>${contact}[FirstName]</arg>
+<doc>Fails if the given objects are unequal.</doc>
+<msg timestamp="20201208 16:40:15.396" level="WARN">Accessing variable items using '${contact}[FirstName]' syntax is deprecated. Use '${contact}[FirstName]' instead.</msg>
+<status status="PASS" starttime="20201208 16:40:15.395" endtime="20201208 16:40:15.396"/>
+</kw>
+<kw name="Should Be Equal" library="BuiltIn">
+<arg>${last_name}</arg>
+<arg>${contact}[LastName]</arg>
+<doc>Fails if the given objects are unequal.</doc>
+<msg timestamp="20201208 16:40:15.397" level="WARN">Accessing variable items using '${contact}[LastName]' syntax is deprecated. Use '${contact}[LastName]' instead.</msg>
+<status status="PASS" starttime="20201208 16:40:15.396" endtime="20201208 16:40:15.397"/>
+</kw>
+<status status="PASS" starttime="20201208 16:40:13.092" endtime="20201208 16:40:15.397"/>
+</kw>
+<status status="PASS" starttime="20201208 16:40:00.347" endtime="20201208 16:40:15.397"/>
+</test>
+<kw name="Delete Records and Close Browser" library="Salesforce" type="TEARDOWN">
+<doc>This will close all open browser windows and then delete all records that were created with the Salesforce API during this testing session.</doc>
+<kw name="Close All Browsers" library="SeleniumLibrary">
+<doc>Closes all open browsers and resets the browser cache.</doc>
+<status status="PASS" starttime="20201208 16:40:15.401" endtime="20201208 16:40:15.492"/>
+</kw>
+<kw name="Delete Session Records" library="cumulusci.robotframework.Salesforce">
+<doc>Deletes records that were created while running this test case.</doc>
+<msg timestamp="20201208 16:40:15.492" level="INFO">Deleting 2 records</msg>
+<msg timestamp="20201208 16:40:15.492" level="INFO"> Deleting Contact 0035400000alF6VAAU</msg>
+<msg timestamp="20201208 16:40:15.492" level="INFO">Deleting Contact with Id 0035400000alF6VAAU</msg>
+<msg timestamp="20201208 16:40:16.201" level="INFO"> Deleting Contact 0035400000alF6QAAU</msg>
+<msg timestamp="20201208 16:40:16.202" level="INFO">Deleting Contact with Id 0035400000alF6QAAU</msg>
+<status status="PASS" starttime="20201208 16:40:15.492" endtime="20201208 16:40:17.079"/>
+</kw>
+<status status="PASS" starttime="20201208 16:40:15.401" endtime="20201208 16:40:17.080"/>
+</kw>
+<meta name="Salesforce API Version">50</meta>
+<status status="PASS" starttime="20201208 16:39:43.002" endtime="20201208 16:40:17.080"/>
+</suite>
+<status status="PASS" starttime="20201208 16:39:42.999" endtime="20201208 16:40:17.096"/>
+</suite>
+<status status="PASS" starttime="20201208 16:39:42.980" endtime="20201208 16:40:17.106"/>
+</suite>
+<statistics>
+<total>
+<stat pass="2" fail="0" skip="0">All Tests</stat>
+</total>
+<tag>
+</tag>
+<suite>
+<stat pass="2" fail="0" skip="0" id="s1" name="Tests">Tests</stat>
+<stat pass="2" fail="0" skip="0" id="s1-s1" name="Standard Objects">Tests.Standard Objects</stat>
+<stat pass="2" fail="0" skip="0" id="s1-s1-s1" name="Create Contact">Tests.Standard Objects.Create Contact</stat>
+</suite>
+</statistics>
+<errors>
+<msg timestamp="20201208 16:40:00.344" level="WARN">Accessing variable items using '${contact}[FirstName]' syntax is deprecated. Use '${contact}[FirstName]' instead.</msg>
+<msg timestamp="20201208 16:40:00.345" level="WARN">Accessing variable items using '${contact}[LastName]' syntax is deprecated. Use '${contact}[LastName]' instead.</msg>
+<msg timestamp="20201208 16:40:15.396" level="WARN">Accessing variable items using '${contact}[FirstName]' syntax is deprecated. Use '${contact}[FirstName]' instead.</msg>
+<msg timestamp="20201208 16:40:15.397" level="WARN">Accessing variable items using '${contact}[LastName]' syntax is deprecated. Use '${contact}[LastName]' instead.</msg>
+</errors>
 </robot>

--- a/metaci/testresults/tests/robot_with_failures.xml
+++ b/metaci/testresults/tests/robot_with_failures.xml
@@ -1,119 +1,98 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<robot generator="Robot 3.2.1 (Python 3.7.6 on darwin)" generated="20200623 18:49:20.911" rpa="false">
-  <suite id="s1" name="Robot Fail" source="/private/tmp/robot_fail.robot">
-    <test id="s1-t1" name="Passing test">
-      <kw name="Pass Execution" library="BuiltIn">
-        <doc>Skips rest of the current test, setup, or teardown with PASS status.</doc>
-        <arguments>
-          <arg>Life is good, yo.</arg>
-        </arguments>
-        <msg timestamp="20200623 18:49:20.956" level="INFO">Execution passed with message:
+<robot generator="Rebot 4.0.1 (Python 3.8.9 on darwin)" generated="20210511 15:16:12.894" rpa="false" schemaversion="2">
+<suite id="s1" name="Robot Fail" source="/private/tmp/robot_fail.robot">
+<test id="s1-t1" name="Passing test">
+<kw name="Pass Execution" library="BuiltIn">
+<arg>Life is good, yo.</arg>
+<doc>Skips rest of the current test, setup, or teardown with PASS status.</doc>
+<msg timestamp="20200623 18:49:20.956" level="INFO">Execution passed with message:
         Life is good, yo.</msg>
-        <status status="PASS" starttime="20200623 18:49:20.956" endtime="20200623 18:49:20.956"></status>
-      </kw>
-      <status status="PASS" starttime="20200623 18:49:20.955" endtime="20200623 18:49:20.956" critical="yes">Life is good, yo.</status>
-    </test>
-    <test id="s1-t2" name="Failing test 1">
-      <kw name="Keyword with failure">
-        <kw name="Fail" library="BuiltIn">
-          <doc>Fails the test with the given message and optionally alters its tags.</doc>
-          <arguments>
-            <arg>${message}</arg>
-          </arguments>
-          <msg timestamp="20200623 18:49:20.959" level="FAIL">Danger, Will Robinson!</msg>
-          <status status="FAIL" starttime="20200623 18:49:20.958" endtime="20200623 18:49:20.959"></status>
-        </kw>
-        <status status="FAIL" starttime="20200623 18:49:20.957" endtime="20200623 18:49:20.959"></status>
-      </kw>
-      <doc>A test that fails with a keyword directly in the test</doc>
-      <status status="FAIL" starttime="20200623 18:49:20.957" endtime="20200623 18:49:20.960" critical="yes">Danger, Will Robinson!</status>
-    </test>
-    <test id="s1-t3" name="Failing test 2">
-      <kw name="Keyword which calls a failing keyword">
-        <kw name="Keyword with failure">
-          <arguments>
-            <arg>I'm sorry, Dave. I'm afraid I can't do that.</arg>
-          </arguments>
-          <kw name="Fail" library="BuiltIn">
-            <doc>Fails the test with the given message and optionally alters its tags.</doc>
-            <arguments>
-              <arg>${message}</arg>
-            </arguments>
-            <msg timestamp="20200623 18:49:20.962" level="FAIL">I'm sorry, Dave. I'm afraid I can't do that.</msg>
-            <status status="FAIL" starttime="20200623 18:49:20.961" endtime="20200623 18:49:20.962"></status>
-          </kw>
-          <status status="FAIL" starttime="20200623 18:49:20.961" endtime="20200623 18:49:20.962"></status>
-        </kw>
-        <status status="FAIL" starttime="20200623 18:49:20.961" endtime="20200623 18:49:20.962"></status>
-      </kw>
-      <doc>A test that fails due to a failure in a lower level keyword.</doc>
-      <status status="FAIL" starttime="20200623 18:49:20.960" endtime="20200623 18:49:20.963" critical="yes">I'm sorry, Dave. I'm afraid I can't do that.</status>
-    </test>
-    <test id="s1-t4" name="Failing test 3">
-      <kw name="Run Keyword And Continue On Failure" library="BuiltIn">
-        <doc>Runs the keyword and continues execution even if a failure occurs.</doc>
-        <arguments>
-          <arg>Keyword with failure</arg>
-          <arg>First failure</arg>
-        </arguments>
-        <kw name="Keyword with failure">
-          <arguments>
-            <arg>First failure</arg>
-          </arguments>
-          <kw name="Fail" library="BuiltIn">
-            <doc>Fails the test with the given message and optionally alters its tags.</doc>
-            <arguments>
-              <arg>${message}</arg>
-            </arguments>
-            <msg timestamp="20200623 18:49:21.021" level="FAIL">First failure</msg>
-            <status status="FAIL" starttime="20200623 18:49:21.020" endtime="20200623 18:49:21.021"></status>
-          </kw>
-          <status status="FAIL" starttime="20200623 18:49:21.019" endtime="20200623 18:49:21.021"></status>
-        </kw>
-        <status status="FAIL" starttime="20200623 18:49:21.019" endtime="20200623 18:49:21.021"></status>
-      </kw>
-      <kw name="Run Keyword And Continue On Failure" library="BuiltIn">
-        <doc>Runs the keyword and continues execution even if a failure occurs.</doc>
-        <arguments>
-          <arg>Keyword with failure</arg>
-          <arg>Second failure</arg>
-        </arguments>
-        <kw name="Keyword with failure">
-          <arguments>
-            <arg>Second failure</arg>
-          </arguments>
-          <kw name="Fail" library="BuiltIn">
-            <doc>Fails the test with the given message and optionally alters its tags.</doc>
-            <arguments>
-              <arg>${message}</arg>
-            </arguments>
-            <msg timestamp="20200623 18:49:21.023" level="FAIL">Second failure</msg>
-            <status status="FAIL" starttime="20200623 18:49:21.023" endtime="20200623 18:49:21.023"></status>
-          </kw>
-          <status status="FAIL" starttime="20200623 18:49:21.022" endtime="20200623 18:49:21.024"></status>
-        </kw>
-        <status status="FAIL" starttime="20200623 18:49:21.022" endtime="20200623 18:49:21.024"></status>
-      </kw>
-      <doc>A test that has multiple keyword failures</doc>
-      <status status="FAIL" starttime="20200623 18:49:21.017" endtime="20200623 18:49:21.024" critical="yes">Several failures occurred:
+<status status="PASS" starttime="20200623 18:49:20.956" endtime="20200623 18:49:20.956"/>
+</kw>
+<status status="PASS" starttime="20200623 18:49:20.955" endtime="20200623 18:49:20.956">Life is good, yo.</status>
+</test>
+<test id="s1-t2" name="Failing test 1">
+<kw name="Keyword with failure">
+<kw name="Fail" library="BuiltIn">
+<arg>${message}</arg>
+<doc>Fails the test with the given message and optionally alters its tags.</doc>
+<msg timestamp="20200623 18:49:20.959" level="FAIL">Danger, Will Robinson!</msg>
+<status status="FAIL" starttime="20200623 18:49:20.958" endtime="20200623 18:49:20.959"/>
+</kw>
+<status status="FAIL" starttime="20200623 18:49:20.957" endtime="20200623 18:49:20.959"/>
+</kw>
+<doc>A test that fails with a keyword directly in the test</doc>
+<status status="FAIL" starttime="20200623 18:49:20.957" endtime="20200623 18:49:20.960">Danger, Will Robinson!</status>
+</test>
+<test id="s1-t3" name="Failing test 2">
+<kw name="Keyword which calls a failing keyword">
+<kw name="Keyword with failure">
+<arg>I'm sorry, Dave. I'm afraid I can't do that.</arg>
+<kw name="Fail" library="BuiltIn">
+<arg>${message}</arg>
+<doc>Fails the test with the given message and optionally alters its tags.</doc>
+<msg timestamp="20200623 18:49:20.962" level="FAIL">I'm sorry, Dave. I'm afraid I can't do that.</msg>
+<status status="FAIL" starttime="20200623 18:49:20.961" endtime="20200623 18:49:20.962"/>
+</kw>
+<status status="FAIL" starttime="20200623 18:49:20.961" endtime="20200623 18:49:20.962"/>
+</kw>
+<status status="FAIL" starttime="20200623 18:49:20.961" endtime="20200623 18:49:20.962"/>
+</kw>
+<doc>A test that fails due to a failure in a lower level keyword.</doc>
+<status status="FAIL" starttime="20200623 18:49:20.960" endtime="20200623 18:49:20.963">I'm sorry, Dave. I'm afraid I can't do that.</status>
+</test>
+<test id="s1-t4" name="Failing test 3">
+<kw name="Run Keyword And Continue On Failure" library="BuiltIn">
+<arg>Keyword with failure</arg>
+<arg>First failure</arg>
+<doc>Runs the keyword and continues execution even if a failure occurs.</doc>
+<kw name="Keyword with failure">
+<arg>First failure</arg>
+<kw name="Fail" library="BuiltIn">
+<arg>${message}</arg>
+<doc>Fails the test with the given message and optionally alters its tags.</doc>
+<msg timestamp="20200623 18:49:21.021" level="FAIL">First failure</msg>
+<status status="FAIL" starttime="20200623 18:49:21.020" endtime="20200623 18:49:21.021"/>
+</kw>
+<status status="FAIL" starttime="20200623 18:49:21.019" endtime="20200623 18:49:21.021"/>
+</kw>
+<status status="FAIL" starttime="20200623 18:49:21.019" endtime="20200623 18:49:21.021"/>
+</kw>
+<kw name="Run Keyword And Continue On Failure" library="BuiltIn">
+<arg>Keyword with failure</arg>
+<arg>Second failure</arg>
+<doc>Runs the keyword and continues execution even if a failure occurs.</doc>
+<kw name="Keyword with failure">
+<arg>Second failure</arg>
+<kw name="Fail" library="BuiltIn">
+<arg>${message}</arg>
+<doc>Fails the test with the given message and optionally alters its tags.</doc>
+<msg timestamp="20200623 18:49:21.023" level="FAIL">Second failure</msg>
+<status status="FAIL" starttime="20200623 18:49:21.023" endtime="20200623 18:49:21.023"/>
+</kw>
+<status status="FAIL" starttime="20200623 18:49:21.022" endtime="20200623 18:49:21.024"/>
+</kw>
+<status status="FAIL" starttime="20200623 18:49:21.022" endtime="20200623 18:49:21.024"/>
+</kw>
+<doc>A test that has multiple keyword failures</doc>
+<status status="FAIL" starttime="20200623 18:49:21.017" endtime="20200623 18:49:21.024">Several failures occurred:
 
       1) First failure
 
       2) Second failure</status>
-    </test>
-    <status status="FAIL" starttime="20200623 18:49:20.915" endtime="20200623 18:49:21.026"></status>
-  </suite>
-  <statistics>
-    <total>
-      <stat pass="1" fail="3">Critical Tests</stat>
-      <stat pass="1" fail="3">All Tests</stat>
-    </total>
-    <tag>
-    </tag>
-    <suite>
-      <stat pass="1" fail="3" id="s1" name="Robot Fail">Robot Fail</stat>
-    </suite>
-  </statistics>
-  <errors>
-  </errors>
+</test>
+<status status="FAIL" starttime="20200623 18:49:20.915" endtime="20200623 18:49:21.026"/>
+</suite>
+<statistics>
+<total>
+<stat pass="1" fail="3" skip="0">All Tests</stat>
+</total>
+<tag>
+</tag>
+<suite>
+<stat pass="1" fail="3" skip="0" id="s1" name="Robot Fail">Robot Fail</stat>
+</suite>
+</statistics>
+<errors>
+</errors>
 </robot>

--- a/metaci/testresults/tests/robot_with_nested_suites.xml
+++ b/metaci/testresults/tests/robot_with_nested_suites.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<robot generator="Robot 3.1.2 (Python 3.7.3 on darwin)" generated="20191023 09:38:43.623" rpa="false">
+<robot generator="Rebot 4.0.1 (Python 3.8.9 on darwin)" generated="20210511 10:42:53.478" rpa="false" schemaversion="2">
 <suite id="s1" name="Nested" source="/Users/pprescod/code/CumulusCI/cumulusci/robotframework/tests">
 <suite id="s1-s1" name="Cumulusci" source="/Users/pprescod/code/CumulusCI/cumulusci/robotframework/tests/cumulusci">
 <suite id="s1-s1-s1" name="Base" source="/Users/pprescod/code/CumulusCI/cumulusci/robotframework/tests/cumulusci/base.robot">
@@ -8,524 +8,406 @@
 <doc>Sets the LOGIN_URL variable in the suite scope which will
 automatically log into the target Salesforce org.</doc>
 <msg timestamp="20191023 09:38:43.700" level="INFO">${LOGIN_URL} = https://efficiency-fun-590-dev-ed.cs93.my.salesforce.com/secur/frontdoor.jsp?sid=MASKED</msg>
-<status status="PASS" starttime="20191023 09:38:43.700" endtime="20191023 09:38:43.701"></status>
+<status status="PASS" starttime="20191023 09:38:43.700" endtime="20191023 09:38:43.701"/>
 </kw>
 <kw name="Variable Should Exist" library="BuiltIn">
-<doc>Fails unless the given variable exists within the current scope.</doc>
-<arguments>
 <arg>${LOGIN_URL}</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:38:43.701" endtime="20191023 09:38:43.701"></status>
+<doc>Fails unless the given variable exists within the current scope.</doc>
+<status status="PASS" starttime="20191023 09:38:43.701" endtime="20191023 09:38:43.701"/>
 </kw>
-<status status="PASS" starttime="20191023 09:38:43.500" endtime="20191023 09:38:43.75" critical="yes"></status>
+<status status="PASS" starttime="20191023 09:38:43.500" endtime="20191023 09:38:43.75"/>
 </test>
 <test id="s1-s1-s1-t2" name="Test Login Url">
 <kw name="Login Url" library="cumulusci.robotframework.CumulusCI">
+<var>${login_url}</var>
 <doc>Returns the login url which will automatically log into the target
 Salesforce org.  By default, the org_name passed to the library
 constructor is used but this can be overridden with the org option
 to log into a different org.</doc>
-<assign>
-<var>${login_url}</var>
-</assign>
 <msg timestamp="20191023 09:38:43.702" level="INFO">${login_url} = https://efficiency-fun-590-dev-ed.cs93.my.salesforce.com/secur/frontdoor.jsp?sid=MASKED</msg>
-<status status="PASS" starttime="20191023 09:38:43.702" endtime="20191023 09:38:43.702"></status>
+<status status="PASS" starttime="20191023 09:38:43.702" endtime="20191023 09:38:43.702"/>
 </kw>
 <kw name="Should Contain" library="BuiltIn">
-<doc>Fails if ``container`` does not contain ``item`` one or more times.</doc>
-<arguments>
 <arg>${login_url}</arg>
 <arg>secur/frontdoor.jsp?sid=</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:38:43.702" endtime="20191023 09:38:43.702"></status>
+<doc>Fails if ``container`` does not contain ``item`` one or more times.</doc>
+<status status="PASS" starttime="20191023 09:38:43.702" endtime="20191023 09:38:43.702"/>
 </kw>
-<status status="PASS" starttime="20191023 09:38:43.701" endtime="20191023 09:38:43.702" critical="yes"></status>
+<status status="PASS" starttime="20191023 09:38:43.701" endtime="20191023 09:38:43.702"/>
 </test>
 <test id="s1-s1-s1-t3" name="Test Get Org Info">
 <kw name="Get Org Info" library="cumulusci.robotframework.CumulusCI">
+<var>&amp;{org_info}</var>
 <doc>Returns a dictionary of the org information for the current target
 Salesforce org</doc>
-<assign>
-<var>&amp;{org_info}</var>
-</assign>
 <msg timestamp="20191023 09:38:43.704" level="INFO">&amp;{org_info} = { config_file=orgs/dev.json | days=7 | set_password=False | scratch=True | namespaced=False | config_name=dev | sfdx_alias=CumulusCI__dev | scratch_org_type=workspace | email_address=pprescod@salesfor...</msg>
-<status status="PASS" starttime="20191023 09:38:43.703" endtime="20191023 09:38:43.704"></status>
+<status status="PASS" starttime="20191023 09:38:43.703" endtime="20191023 09:38:43.704"/>
 </kw>
 <kw name="Dictionary Should Contain Key" library="Collections">
-<doc>Fails if ``key`` is not found from ``dictionary``.</doc>
-<arguments>
 <arg>${org_info}</arg>
 <arg>org_id</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:38:43.704" endtime="20191023 09:38:43.704"></status>
+<doc>Fails if ``key`` is not found from ``dictionary``.</doc>
+<status status="PASS" starttime="20191023 09:38:43.704" endtime="20191023 09:38:43.704"/>
 </kw>
 <kw name="Dictionary Should Contain Key" library="Collections">
-<doc>Fails if ``key`` is not found from ``dictionary``.</doc>
-<arguments>
 <arg>${org_info}</arg>
 <arg>username</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:38:43.704" endtime="20191023 09:38:43.705"></status>
+<doc>Fails if ``key`` is not found from ``dictionary``.</doc>
+<status status="PASS" starttime="20191023 09:38:43.704" endtime="20191023 09:38:43.705"/>
 </kw>
-<status status="PASS" starttime="20191023 09:38:43.703" endtime="20191023 09:38:43.705" critical="yes"></status>
+<status status="PASS" starttime="20191023 09:38:43.703" endtime="20191023 09:38:43.705"/>
 </test>
 <test id="s1-s1-s1-t4" name="Test Get Namespace Prefix">
 <kw name="Get Namespace Prefix" library="cumulusci.robotframework.CumulusCI">
+<var>${ns}</var>
 <doc>Returns the namespace prefix (including __) for the specified package name.
 (Defaults to project__package__name_managed from the current project config.)</doc>
-<assign>
-<var>${ns}</var>
-</assign>
 <msg timestamp="20191023 09:38:44.288" level="INFO">${ns} = </msg>
-<status status="PASS" starttime="20191023 09:38:43.706" endtime="20191023 09:38:44.288"></status>
+<status status="PASS" starttime="20191023 09:38:43.706" endtime="20191023 09:38:44.288"/>
 </kw>
 <kw name="Should Be Empty" library="BuiltIn">
-<doc>Verifies that the given item is empty.</doc>
-<arguments>
 <arg>${ns}</arg>
-</arguments>
+<doc>Verifies that the given item is empty.</doc>
 <msg timestamp="20191023 09:38:44.288" level="INFO">Length is 0</msg>
-<status status="PASS" starttime="20191023 09:38:44.288" endtime="20191023 09:38:44.288"></status>
+<status status="PASS" starttime="20191023 09:38:44.288" endtime="20191023 09:38:44.288"/>
 </kw>
-<status status="PASS" starttime="20191023 09:38:43.705" endtime="20191023 09:38:44.289" critical="yes"></status>
+<status status="PASS" starttime="20191023 09:38:43.705" endtime="20191023 09:38:44.289"/>
 </test>
 <test id="s1-s1-s1-t5" name="Test Run Task">
 <kw name="Run Task" library="cumulusci.robotframework.CumulusCI">
+<arg>create_package</arg>
 <doc>Runs a named CumulusCI task for the current project with optional
 support for overriding task options via kwargs.</doc>
-<arguments>
-<arg>create_package</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:38:44.289" endtime="20191023 09:38:48.254"></status>
+<status status="PASS" starttime="20191023 09:38:44.289" endtime="20191023 09:38:48.254"/>
 </kw>
-<status status="PASS" starttime="20191023 09:38:44.289" endtime="20191023 09:38:48.255" critical="yes"></status>
+<status status="PASS" starttime="20191023 09:38:44.289" endtime="20191023 09:38:48.255"/>
 </test>
 <test id="s1-s1-s1-t6" name="Test Run Task With Options">
 <kw name="Run Task" library="cumulusci.robotframework.CumulusCI">
-<doc>Runs a named CumulusCI task for the current project with optional
-support for overriding task options via kwargs.</doc>
-<arguments>
 <arg>create_package</arg>
 <arg>package=Test Package</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:38:48.257" endtime="20191023 09:38:51.204"></status>
+<doc>Runs a named CumulusCI task for the current project with optional
+support for overriding task options via kwargs.</doc>
+<status status="PASS" starttime="20191023 09:38:48.257" endtime="20191023 09:38:51.204"/>
 </kw>
-<status status="PASS" starttime="20191023 09:38:48.256" endtime="20191023 09:38:51.204" critical="yes"></status>
+<status status="PASS" starttime="20191023 09:38:48.256" endtime="20191023 09:38:51.204"/>
 </test>
 <test id="s1-s1-s1-t7" name="Test Run Task Missing">
 <kw name="Run Keyword And Expect Error" library="BuiltIn">
-<doc>Runs the keyword and checks that the expected error occurred.</doc>
-<arguments>
 <arg>TaskNotFoundError: Task not found: does_not_exist</arg>
 <arg>Run Task</arg>
 <arg>does_not_exist</arg>
-</arguments>
+<doc>Runs the keyword and checks that the expected error occurred.</doc>
 <kw name="Run Task" library="cumulusci.robotframework.CumulusCI">
+<arg>does_not_exist</arg>
 <doc>Runs a named CumulusCI task for the current project with optional
 support for overriding task options via kwargs.</doc>
-<arguments>
-<arg>does_not_exist</arg>
-</arguments>
 <msg timestamp="20191023 09:38:51.212" level="FAIL">TaskNotFoundError: Task not found: does_not_exist</msg>
-<status status="FAIL" starttime="20191023 09:38:51.207" endtime="20191023 09:38:51.212"></status>
+<status status="FAIL" starttime="20191023 09:38:51.207" endtime="20191023 09:38:51.212"/>
 </kw>
-<status status="PASS" starttime="20191023 09:38:51.206" endtime="20191023 09:38:51.213"></status>
+<status status="PASS" starttime="20191023 09:38:51.206" endtime="20191023 09:38:51.213"/>
 </kw>
-<status status="PASS" starttime="20191023 09:38:51.205" endtime="20191023 09:38:51.213" critical="yes"></status>
+<status status="PASS" starttime="20191023 09:38:51.205" endtime="20191023 09:38:51.213"/>
 </test>
 <test id="s1-s1-s1-t8" name="Test Run Task Class">
 <kw name="Run Task Class" library="cumulusci.robotframework.CumulusCI">
-<doc>Runs a CumulusCI task class with task options via kwargs.</doc>
-<arguments>
 <arg>cumulusci.tasks.salesforce.CreatePackage</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:38:51.214" endtime="20191023 09:38:54.801"></status>
+<doc>Runs a CumulusCI task class with task options via kwargs.</doc>
+<status status="PASS" starttime="20191023 09:38:51.214" endtime="20191023 09:38:54.801"/>
 </kw>
-<status status="PASS" starttime="20191023 09:38:51.213" endtime="20191023 09:38:54.802" critical="yes"></status>
+<status status="PASS" starttime="20191023 09:38:51.213" endtime="20191023 09:38:54.802"/>
 </test>
 <test id="s1-s1-s1-t9" name="Test Run Task Class With Options">
 <kw name="Run Task Class" library="cumulusci.robotframework.CumulusCI">
-<doc>Runs a CumulusCI task class with task options via kwargs.</doc>
-<arguments>
 <arg>cumulusci.tasks.salesforce.CreatePackage</arg>
 <arg>package=Test Package</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:38:54.805" endtime="20191023 09:38:58.263"></status>
+<doc>Runs a CumulusCI task class with task options via kwargs.</doc>
+<status status="PASS" starttime="20191023 09:38:54.805" endtime="20191023 09:38:58.263"/>
 </kw>
-<status status="PASS" starttime="20191023 09:38:54.802" endtime="20191023 09:38:58.264" critical="yes"></status>
+<status status="PASS" starttime="20191023 09:38:54.802" endtime="20191023 09:38:58.264"/>
 </test>
-<status status="PASS" starttime="20191023 09:38:43.649" endtime="20191023 09:38:58.266"></status>
+<status status="PASS" starttime="20191023 09:38:43.649" endtime="20191023 09:38:58.266"/>
 </suite>
 <suite id="s1-s1-s2" name="Bulkdata" source="/Users/pprescod/code/CumulusCI/cumulusci/robotframework/tests/cumulusci/bulkdata.robot">
 <test id="s1-s1-s2-t1" name="Test Run Bulk Data Generation">
 <kw name="Run Task Class" library="cumulusci.robotframework.CumulusCI">
-<doc>Runs a CumulusCI task class with task options via kwargs.</doc>
-<arguments>
 <arg>cumulusci.tasks.bulkdata.delete.DeleteData</arg>
 <arg>objects=Account</arg>
 <arg>where=BillingStreet='Baker St.'</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:38:58.540" endtime="20191023 09:39:06.671"></status>
+<doc>Runs a CumulusCI task class with task options via kwargs.</doc>
+<status status="PASS" starttime="20191023 09:38:58.540" endtime="20191023 09:39:06.671"/>
 </kw>
 <kw name="Run Task Class" library="cumulusci.robotframework.CumulusCI">
-<doc>Runs a CumulusCI task class with task options via kwargs.</doc>
-<arguments>
 <arg>cumulusci.tasks.bulkdata.delete.DeleteData</arg>
 <arg>objects=Contact</arg>
 <arg>where=MailingStreet='Baker St.'</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:39:06.672" endtime="20191023 09:39:13.447"></status>
+<doc>Runs a CumulusCI task class with task options via kwargs.</doc>
+<status status="PASS" starttime="20191023 09:39:06.672" endtime="20191023 09:39:13.447"/>
 </kw>
 <kw name="Run Task Class" library="cumulusci.robotframework.CumulusCI">
-<doc>Runs a CumulusCI task class with task options via kwargs.</doc>
-<arguments>
 <arg>cumulusci.tasks.bulkdata.generate_and_load_data.GenerateAndLoadData</arg>
 <arg>num_records=20</arg>
 <arg>mapping=cumulusci/tasks/bulkdata/tests/mapping_vanilla_sf.yml</arg>
 <arg>data_generation_task=cumulusci.tasks.bulkdata.tests.dummy_data_factory.GenerateDummyData</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:39:13.447" endtime="20191023 09:39:26.164"></status>
+<doc>Runs a CumulusCI task class with task options via kwargs.</doc>
+<status status="PASS" starttime="20191023 09:39:13.447" endtime="20191023 09:39:26.164"/>
 </kw>
 <kw name="Assert Row Count">
-<arguments>
 <arg>20</arg>
 <arg>Account</arg>
 <arg>BillingStreet=Baker St.</arg>
-</arguments>
 <kw name="Run Keyword And Ignore Error" library="BuiltIn">
-<doc>Runs the given keyword with the given arguments and ignores possible error.</doc>
-<arguments>
+<var>${status}</var>
+<var>${result}</var>
 <arg>Salesforce Query</arg>
 <arg>${object_name}</arg>
 <arg>select=COUNT(Id)</arg>
 <arg>&amp;{kwargs}</arg>
-</arguments>
-<assign>
-<var>${status}</var>
-<var>${result}</var>
-</assign>
+<doc>Runs the given keyword with the given arguments and ignores possible error.</doc>
 <kw name="Salesforce Query" library="cumulusci.robotframework.Salesforce">
-<doc>Constructs and runs a simple SOQL query and returns the dict results</doc>
-<arguments>
 <arg>${object_name}</arg>
 <arg>select=COUNT(Id)</arg>
 <arg>&amp;{kwargs}</arg>
-</arguments>
+<doc>Constructs and runs a simple SOQL query and returns the dict results</doc>
 <msg timestamp="20191023 09:39:26.165" level="INFO">Running SOQL Query: SELECT COUNT(Id) FROM Account WHERE BillingStreet = 'Baker St.'</msg>
-<status status="PASS" starttime="20191023 09:39:26.165" endtime="20191023 09:39:26.928"></status>
+<status status="PASS" starttime="20191023 09:39:26.165" endtime="20191023 09:39:26.928"/>
 </kw>
 <msg timestamp="20191023 09:39:26.928" level="INFO">${status} = PASS</msg>
 <msg timestamp="20191023 09:39:26.928" level="INFO">${result} = [OrderedDict([('attributes', OrderedDict([('type', 'AggregateResult')])), ('expr0', 20)])]</msg>
-<status status="PASS" starttime="20191023 09:39:26.165" endtime="20191023 09:39:26.928"></status>
+<status status="PASS" starttime="20191023 09:39:26.165" endtime="20191023 09:39:26.928"/>
 </kw>
 <kw name="Run Keyword If" library="BuiltIn">
-<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
-<arguments>
 <arg>'${status}' != 'PASS'</arg>
 <arg>Log</arg>
 <arg>Salesforce query failed: probably timeout. ${object_name} ${result}</arg>
 <arg>console=True</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:39:26.929" endtime="20191023 09:39:26.930"></status>
+<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
+<status status="PASS" starttime="20191023 09:39:26.929" endtime="20191023 09:39:26.930"/>
 </kw>
 <kw name="Should Be Equal" library="BuiltIn">
-<doc>Fails if the given objects are unequal.</doc>
-<arguments>
 <arg>PASS</arg>
 <arg>${status}</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:39:26.930" endtime="20191023 09:39:26.930"></status>
+<doc>Fails if the given objects are unequal.</doc>
+<status status="PASS" starttime="20191023 09:39:26.930" endtime="20191023 09:39:26.930"/>
 </kw>
 <kw name="Set Variable" library="BuiltIn">
-<doc>Returns the given values which can then be assigned to a variables.</doc>
-<arguments>
-<arg>${result}[0][expr0]</arg>
-</arguments>
-<assign>
 <var>${matching_records}</var>
-</assign>
+<arg>${result}[0][expr0]</arg>
+<doc>Returns the given values which can then be assigned to a variables.</doc>
 <msg timestamp="20191023 09:39:26.931" level="INFO">${matching_records} = 20</msg>
-<status status="PASS" starttime="20191023 09:39:26.930" endtime="20191023 09:39:26.931"></status>
+<status status="PASS" starttime="20191023 09:39:26.930" endtime="20191023 09:39:26.931"/>
 </kw>
 <kw name="Should Be Equal As Numbers" library="BuiltIn">
-<doc>Fails if objects are unequal after converting them to real numbers.</doc>
-<arguments>
 <arg>${matching_records}</arg>
 <arg>${count}</arg>
-</arguments>
+<doc>Fails if objects are unequal after converting them to real numbers.</doc>
 <msg timestamp="20191023 09:39:26.931" level="INFO">Argument types are:
 &lt;class 'int'&gt;
 &lt;type 'unicode'&gt;</msg>
-<status status="PASS" starttime="20191023 09:39:26.931" endtime="20191023 09:39:26.931"></status>
+<status status="PASS" starttime="20191023 09:39:26.931" endtime="20191023 09:39:26.931"/>
 </kw>
-<status status="PASS" starttime="20191023 09:39:26.164" endtime="20191023 09:39:26.932"></status>
+<status status="PASS" starttime="20191023 09:39:26.164" endtime="20191023 09:39:26.932"/>
 </kw>
 <kw name="Assert Row Count">
-<arguments>
 <arg>15</arg>
 <arg>Contact</arg>
 <arg>MailingStreet=Baker St.</arg>
-</arguments>
 <kw name="Run Keyword And Ignore Error" library="BuiltIn">
-<doc>Runs the given keyword with the given arguments and ignores possible error.</doc>
-<arguments>
+<var>${status}</var>
+<var>${result}</var>
 <arg>Salesforce Query</arg>
 <arg>${object_name}</arg>
 <arg>select=COUNT(Id)</arg>
 <arg>&amp;{kwargs}</arg>
-</arguments>
-<assign>
-<var>${status}</var>
-<var>${result}</var>
-</assign>
+<doc>Runs the given keyword with the given arguments and ignores possible error.</doc>
 <kw name="Salesforce Query" library="cumulusci.robotframework.Salesforce">
-<doc>Constructs and runs a simple SOQL query and returns the dict results</doc>
-<arguments>
 <arg>${object_name}</arg>
 <arg>select=COUNT(Id)</arg>
 <arg>&amp;{kwargs}</arg>
-</arguments>
+<doc>Constructs and runs a simple SOQL query and returns the dict results</doc>
 <msg timestamp="20191023 09:39:26.933" level="INFO">Running SOQL Query: SELECT COUNT(Id) FROM Contact WHERE MailingStreet = 'Baker St.'</msg>
-<status status="PASS" starttime="20191023 09:39:26.933" endtime="20191023 09:39:27.082"></status>
+<status status="PASS" starttime="20191023 09:39:26.933" endtime="20191023 09:39:27.082"/>
 </kw>
 <msg timestamp="20191023 09:39:27.082" level="INFO">${status} = PASS</msg>
 <msg timestamp="20191023 09:39:27.082" level="INFO">${result} = [OrderedDict([('attributes', OrderedDict([('type', 'AggregateResult')])), ('expr0', 15)])]</msg>
-<status status="PASS" starttime="20191023 09:39:26.932" endtime="20191023 09:39:27.082"></status>
+<status status="PASS" starttime="20191023 09:39:26.932" endtime="20191023 09:39:27.082"/>
 </kw>
 <kw name="Run Keyword If" library="BuiltIn">
-<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
-<arguments>
 <arg>'${status}' != 'PASS'</arg>
 <arg>Log</arg>
 <arg>Salesforce query failed: probably timeout. ${object_name} ${result}</arg>
 <arg>console=True</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:39:27.083" endtime="20191023 09:39:27.084"></status>
+<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
+<status status="PASS" starttime="20191023 09:39:27.083" endtime="20191023 09:39:27.084"/>
 </kw>
 <kw name="Should Be Equal" library="BuiltIn">
-<doc>Fails if the given objects are unequal.</doc>
-<arguments>
 <arg>PASS</arg>
 <arg>${status}</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:39:27.084" endtime="20191023 09:39:27.084"></status>
+<doc>Fails if the given objects are unequal.</doc>
+<status status="PASS" starttime="20191023 09:39:27.084" endtime="20191023 09:39:27.084"/>
 </kw>
 <kw name="Set Variable" library="BuiltIn">
-<doc>Returns the given values which can then be assigned to a variables.</doc>
-<arguments>
-<arg>${result}[0][expr0]</arg>
-</arguments>
-<assign>
 <var>${matching_records}</var>
-</assign>
+<arg>${result}[0][expr0]</arg>
+<doc>Returns the given values which can then be assigned to a variables.</doc>
 <msg timestamp="20191023 09:39:27.085" level="INFO">${matching_records} = 15</msg>
-<status status="PASS" starttime="20191023 09:39:27.085" endtime="20191023 09:39:27.085"></status>
+<status status="PASS" starttime="20191023 09:39:27.085" endtime="20191023 09:39:27.085"/>
 </kw>
 <kw name="Should Be Equal As Numbers" library="BuiltIn">
-<doc>Fails if objects are unequal after converting them to real numbers.</doc>
-<arguments>
 <arg>${matching_records}</arg>
 <arg>${count}</arg>
-</arguments>
+<doc>Fails if objects are unequal after converting them to real numbers.</doc>
 <msg timestamp="20191023 09:39:27.087" level="INFO">Argument types are:
 &lt;class 'int'&gt;
 &lt;type 'unicode'&gt;</msg>
-<status status="PASS" starttime="20191023 09:39:27.085" endtime="20191023 09:39:27.087"></status>
+<status status="PASS" starttime="20191023 09:39:27.085" endtime="20191023 09:39:27.087"/>
 </kw>
-<status status="PASS" starttime="20191023 09:39:26.932" endtime="20191023 09:39:27.087"></status>
+<status status="PASS" starttime="20191023 09:39:26.932" endtime="20191023 09:39:27.087"/>
 </kw>
-<tags>
 <tag>bulkdata</tag>
-</tags>
-<status status="PASS" starttime="20191023 09:38:58.539" endtime="20191023 09:39:27.088" critical="yes"></status>
+<status status="PASS" starttime="20191023 09:38:58.539" endtime="20191023 09:39:27.088"/>
 </test>
 <test id="s1-s1-s2-t2" name="Test Batching">
 <kw name="Run Task Class" library="cumulusci.robotframework.CumulusCI">
-<doc>Runs a CumulusCI task class with task options via kwargs.</doc>
-<arguments>
 <arg>cumulusci.tasks.bulkdata.delete.DeleteData</arg>
 <arg>objects=Account</arg>
 <arg>where=BillingStreet='Baker St.'</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:39:27.089" endtime="20191023 09:39:38.109"></status>
+<doc>Runs a CumulusCI task class with task options via kwargs.</doc>
+<status status="PASS" starttime="20191023 09:39:27.089" endtime="20191023 09:39:38.109"/>
 </kw>
 <kw name="Run Task Class" library="cumulusci.robotframework.CumulusCI">
-<doc>Runs a CumulusCI task class with task options via kwargs.</doc>
-<arguments>
 <arg>cumulusci.tasks.bulkdata.delete.DeleteData</arg>
 <arg>objects=Contact</arg>
 <arg>where=MailingStreet='Baker St.'</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:39:38.109" endtime="20191023 09:39:44.431"></status>
+<doc>Runs a CumulusCI task class with task options via kwargs.</doc>
+<status status="PASS" starttime="20191023 09:39:38.109" endtime="20191023 09:39:44.431"/>
 </kw>
 <kw name="Run Task Class" library="cumulusci.robotframework.CumulusCI">
-<doc>Runs a CumulusCI task class with task options via kwargs.</doc>
-<arguments>
 <arg>cumulusci.tasks.bulkdata.generate_and_load_data.GenerateAndLoadData</arg>
 <arg>num_records=20</arg>
 <arg>mapping=cumulusci/tasks/bulkdata/tests/mapping_vanilla_sf.yml</arg>
 <arg>batch_size=4</arg>
 <arg>data_generation_task=cumulusci.tasks.bulkdata.tests.dummy_data_factory.GenerateDummyData</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:39:44.432" endtime="20191023 09:40:43.443"></status>
+<doc>Runs a CumulusCI task class with task options via kwargs.</doc>
+<status status="PASS" starttime="20191023 09:39:44.432" endtime="20191023 09:40:43.443"/>
 </kw>
 <kw name="Assert Row Count">
-<arguments>
 <arg>20</arg>
 <arg>Account</arg>
 <arg>BillingStreet=Baker St.</arg>
-</arguments>
 <kw name="Run Keyword And Ignore Error" library="BuiltIn">
-<doc>Runs the given keyword with the given arguments and ignores possible error.</doc>
-<arguments>
+<var>${status}</var>
+<var>${result}</var>
 <arg>Salesforce Query</arg>
 <arg>${object_name}</arg>
 <arg>select=COUNT(Id)</arg>
 <arg>&amp;{kwargs}</arg>
-</arguments>
-<assign>
-<var>${status}</var>
-<var>${result}</var>
-</assign>
+<doc>Runs the given keyword with the given arguments and ignores possible error.</doc>
 <kw name="Salesforce Query" library="cumulusci.robotframework.Salesforce">
-<doc>Constructs and runs a simple SOQL query and returns the dict results</doc>
-<arguments>
 <arg>${object_name}</arg>
 <arg>select=COUNT(Id)</arg>
 <arg>&amp;{kwargs}</arg>
-</arguments>
+<doc>Constructs and runs a simple SOQL query and returns the dict results</doc>
 <msg timestamp="20191023 09:40:43.445" level="INFO">Running SOQL Query: SELECT COUNT(Id) FROM Account WHERE BillingStreet = 'Baker St.'</msg>
-<status status="PASS" starttime="20191023 09:40:43.444" endtime="20191023 09:40:43.627"></status>
+<status status="PASS" starttime="20191023 09:40:43.444" endtime="20191023 09:40:43.627"/>
 </kw>
 <msg timestamp="20191023 09:40:43.628" level="INFO">${status} = PASS</msg>
 <msg timestamp="20191023 09:40:43.628" level="INFO">${result} = [OrderedDict([('attributes', OrderedDict([('type', 'AggregateResult')])), ('expr0', 20)])]</msg>
-<status status="PASS" starttime="20191023 09:40:43.444" endtime="20191023 09:40:43.628"></status>
+<status status="PASS" starttime="20191023 09:40:43.444" endtime="20191023 09:40:43.628"/>
 </kw>
 <kw name="Run Keyword If" library="BuiltIn">
-<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
-<arguments>
 <arg>'${status}' != 'PASS'</arg>
 <arg>Log</arg>
 <arg>Salesforce query failed: probably timeout. ${object_name} ${result}</arg>
 <arg>console=True</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:40:43.628" endtime="20191023 09:40:43.629"></status>
+<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
+<status status="PASS" starttime="20191023 09:40:43.628" endtime="20191023 09:40:43.629"/>
 </kw>
 <kw name="Should Be Equal" library="BuiltIn">
-<doc>Fails if the given objects are unequal.</doc>
-<arguments>
 <arg>PASS</arg>
 <arg>${status}</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:40:43.629" endtime="20191023 09:40:43.629"></status>
+<doc>Fails if the given objects are unequal.</doc>
+<status status="PASS" starttime="20191023 09:40:43.629" endtime="20191023 09:40:43.629"/>
 </kw>
 <kw name="Set Variable" library="BuiltIn">
-<doc>Returns the given values which can then be assigned to a variables.</doc>
-<arguments>
-<arg>${result}[0][expr0]</arg>
-</arguments>
-<assign>
 <var>${matching_records}</var>
-</assign>
+<arg>${result}[0][expr0]</arg>
+<doc>Returns the given values which can then be assigned to a variables.</doc>
 <msg timestamp="20191023 09:40:43.630" level="INFO">${matching_records} = 20</msg>
-<status status="PASS" starttime="20191023 09:40:43.630" endtime="20191023 09:40:43.630"></status>
+<status status="PASS" starttime="20191023 09:40:43.630" endtime="20191023 09:40:43.630"/>
 </kw>
 <kw name="Should Be Equal As Numbers" library="BuiltIn">
-<doc>Fails if objects are unequal after converting them to real numbers.</doc>
-<arguments>
 <arg>${matching_records}</arg>
 <arg>${count}</arg>
-</arguments>
+<doc>Fails if objects are unequal after converting them to real numbers.</doc>
 <msg timestamp="20191023 09:40:43.630" level="INFO">Argument types are:
 &lt;class 'int'&gt;
 &lt;type 'unicode'&gt;</msg>
-<status status="PASS" starttime="20191023 09:40:43.630" endtime="20191023 09:40:43.631"></status>
+<status status="PASS" starttime="20191023 09:40:43.630" endtime="20191023 09:40:43.631"/>
 </kw>
-<status status="PASS" starttime="20191023 09:40:43.443" endtime="20191023 09:40:43.631"></status>
+<status status="PASS" starttime="20191023 09:40:43.443" endtime="20191023 09:40:43.631"/>
 </kw>
 <kw name="Assert Row Count">
-<arguments>
 <arg>15</arg>
 <arg>Contact</arg>
 <arg>MailingStreet=Baker St.</arg>
-</arguments>
 <kw name="Run Keyword And Ignore Error" library="BuiltIn">
-<doc>Runs the given keyword with the given arguments and ignores possible error.</doc>
-<arguments>
+<var>${status}</var>
+<var>${result}</var>
 <arg>Salesforce Query</arg>
 <arg>${object_name}</arg>
 <arg>select=COUNT(Id)</arg>
 <arg>&amp;{kwargs}</arg>
-</arguments>
-<assign>
-<var>${status}</var>
-<var>${result}</var>
-</assign>
+<doc>Runs the given keyword with the given arguments and ignores possible error.</doc>
 <kw name="Salesforce Query" library="cumulusci.robotframework.Salesforce">
-<doc>Constructs and runs a simple SOQL query and returns the dict results</doc>
-<arguments>
 <arg>${object_name}</arg>
 <arg>select=COUNT(Id)</arg>
 <arg>&amp;{kwargs}</arg>
-</arguments>
+<doc>Constructs and runs a simple SOQL query and returns the dict results</doc>
 <msg timestamp="20191023 09:40:43.632" level="INFO">Running SOQL Query: SELECT COUNT(Id) FROM Contact WHERE MailingStreet = 'Baker St.'</msg>
-<status status="PASS" starttime="20191023 09:40:43.632" endtime="20191023 09:40:43.889"></status>
+<status status="PASS" starttime="20191023 09:40:43.632" endtime="20191023 09:40:43.889"/>
 </kw>
 <msg timestamp="20191023 09:40:43.890" level="INFO">${status} = PASS</msg>
 <msg timestamp="20191023 09:40:43.890" level="INFO">${result} = [OrderedDict([('attributes', OrderedDict([('type', 'AggregateResult')])), ('expr0', 15)])]</msg>
-<status status="PASS" starttime="20191023 09:40:43.632" endtime="20191023 09:40:43.890"></status>
+<status status="PASS" starttime="20191023 09:40:43.632" endtime="20191023 09:40:43.890"/>
 </kw>
 <kw name="Run Keyword If" library="BuiltIn">
-<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
-<arguments>
 <arg>'${status}' != 'PASS'</arg>
 <arg>Log</arg>
 <arg>Salesforce query failed: probably timeout. ${object_name} ${result}</arg>
 <arg>console=True</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:40:43.890" endtime="20191023 09:40:43.891"></status>
+<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
+<status status="PASS" starttime="20191023 09:40:43.890" endtime="20191023 09:40:43.891"/>
 </kw>
 <kw name="Should Be Equal" library="BuiltIn">
-<doc>Fails if the given objects are unequal.</doc>
-<arguments>
 <arg>PASS</arg>
 <arg>${status}</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:40:43.891" endtime="20191023 09:40:43.891"></status>
+<doc>Fails if the given objects are unequal.</doc>
+<status status="PASS" starttime="20191023 09:40:43.891" endtime="20191023 09:40:43.891"/>
 </kw>
 <kw name="Set Variable" library="BuiltIn">
-<doc>Returns the given values which can then be assigned to a variables.</doc>
-<arguments>
-<arg>${result}[0][expr0]</arg>
-</arguments>
-<assign>
 <var>${matching_records}</var>
-</assign>
+<arg>${result}[0][expr0]</arg>
+<doc>Returns the given values which can then be assigned to a variables.</doc>
 <msg timestamp="20191023 09:40:43.892" level="INFO">${matching_records} = 15</msg>
-<status status="PASS" starttime="20191023 09:40:43.892" endtime="20191023 09:40:43.892"></status>
+<status status="PASS" starttime="20191023 09:40:43.892" endtime="20191023 09:40:43.892"/>
 </kw>
 <kw name="Should Be Equal As Numbers" library="BuiltIn">
-<doc>Fails if objects are unequal after converting them to real numbers.</doc>
-<arguments>
 <arg>${matching_records}</arg>
 <arg>${count}</arg>
-</arguments>
+<doc>Fails if objects are unequal after converting them to real numbers.</doc>
 <msg timestamp="20191023 09:40:43.893" level="INFO">Argument types are:
 &lt;class 'int'&gt;
 &lt;type 'unicode'&gt;</msg>
-<status status="PASS" starttime="20191023 09:40:43.892" endtime="20191023 09:40:43.893"></status>
+<status status="PASS" starttime="20191023 09:40:43.892" endtime="20191023 09:40:43.893"/>
 </kw>
-<status status="PASS" starttime="20191023 09:40:43.631" endtime="20191023 09:40:43.893"></status>
+<status status="PASS" starttime="20191023 09:40:43.631" endtime="20191023 09:40:43.893"/>
 </kw>
-<tags>
 <tag>bulkdata</tag>
-</tags>
-<status status="PASS" starttime="20191023 09:39:27.088" endtime="20191023 09:40:43.893" critical="yes"></status>
+<status status="PASS" starttime="20191023 09:39:27.088" endtime="20191023 09:40:43.893"/>
 </test>
 <test id="s1-s1-s2-t3" name="Test Error Handling">
 <kw name="Run Keyword And Expect Error" library="BuiltIn">
-<doc>Runs the keyword and checks that the expected error occurred.</doc>
-<arguments>
 <arg>STARTS:TaskOptionsError:</arg>
 <arg>Run Task Class</arg>
 <arg>cumulusci.tasks.bulkdata.generate_and_load_data.GenerateAndLoadData</arg>
@@ -534,33 +416,27 @@ support for overriding task options via kwargs.</doc>
 <arg>batch_size=5</arg>
 <arg>database_url=sqlite:////tmp/foo.db</arg>
 <arg>data_generation_task=cumulusci.tasks.bulkdata.tests.dummy_data_factory.GenerateDummyData</arg>
-</arguments>
+<doc>Runs the keyword and checks that the expected error occurred.</doc>
 <kw name="Run Task Class" library="cumulusci.robotframework.CumulusCI">
-<doc>Runs a CumulusCI task class with task options via kwargs.</doc>
-<arguments>
 <arg>cumulusci.tasks.bulkdata.generate_and_load_data.GenerateAndLoadData</arg>
 <arg>num_records=20</arg>
 <arg>mapping=cumulusci/tasks/bulkdata/tests/mapping_vanilla_sf.yml</arg>
 <arg>batch_size=5</arg>
 <arg>database_url=sqlite:////tmp/foo.db</arg>
 <arg>data_generation_task=cumulusci.tasks.bulkdata.tests.dummy_data_factory.GenerateDummyData</arg>
-</arguments>
+<doc>Runs a CumulusCI task class with task options via kwargs.</doc>
 <msg timestamp="20191023 09:40:43.899" level="FAIL">TaskOptionsError: You may not specify both `database_url` and `batch_size` options.</msg>
-<status status="FAIL" starttime="20191023 09:40:43.895" endtime="20191023 09:40:43.899"></status>
+<status status="FAIL" starttime="20191023 09:40:43.895" endtime="20191023 09:40:43.899"/>
 </kw>
-<status status="PASS" starttime="20191023 09:40:43.895" endtime="20191023 09:40:43.899"></status>
+<status status="PASS" starttime="20191023 09:40:43.895" endtime="20191023 09:40:43.899"/>
 </kw>
-<tags>
 <tag>bulkdata</tag>
-</tags>
-<status status="PASS" starttime="20191023 09:40:43.894" endtime="20191023 09:40:43.899" critical="yes"></status>
+<status status="PASS" starttime="20191023 09:40:43.894" endtime="20191023 09:40:43.899"/>
 </test>
-<status status="PASS" starttime="20191023 09:38:58.270" endtime="20191023 09:40:43.901"></status>
+<status status="PASS" starttime="20191023 09:38:58.270" endtime="20191023 09:40:43.901"/>
 </suite>
 <suite id="s1-s1-s3" name="Communities" source="/Users/pprescod/code/CumulusCI/cumulusci/robotframework/tests/cumulusci/communities.robot">
-<kw name="Run Keywords" library="BuiltIn" type="setup">
-<doc>Executes all the given keywords in a sequence.</doc>
-<arguments>
+<kw name="Run Keywords" library="BuiltIn" type="SETUP">
 <arg>Ensure community exists</arg>
 <arg>Kōkua</arg>
 <arg>kokua</arg>
@@ -568,274 +444,212 @@ support for overriding task options via kwargs.</doc>
 <arg>Ensure community exists</arg>
 <arg>Ohana</arg>
 <arg>ohana</arg>
-</arguments>
+<doc>Executes all the given keywords in a sequence.</doc>
 <kw name="Ensure community exists">
-<doc>Creates a community with the given name if it doesn't exist</doc>
-<arguments>
 <arg>Kōkua</arg>
 <arg>kokua</arg>
-</arguments>
+<doc>Creates a community with the given name if it doesn't exist</doc>
 <kw name="Run Keyword And Return Status" library="BuiltIn">
-<doc>Runs the given keyword with given arguments and returns the status as a Boolean value.</doc>
-<arguments>
+<var>${passed}</var>
 <arg>get community info</arg>
 <arg>${community name}</arg>
-</arguments>
-<assign>
-<var>${passed}</var>
-</assign>
+<doc>Runs the given keyword with given arguments and returns the status as a Boolean value.</doc>
 <kw name="Get Community Info" library="cumulusci.robotframework.CumulusCI">
-<doc>This keyword uses the Salesforce API to get information about a community.</doc>
-<arguments>
 <arg>${community name}</arg>
-</arguments>
+<doc>This keyword uses the Salesforce API to get information about a community.</doc>
 <msg timestamp="20191023 09:40:44.925" level="FAIL">Unable to find community information for 'Kōkua'</msg>
-<status status="FAIL" starttime="20191023 09:40:43.980" endtime="20191023 09:40:44.925"></status>
+<status status="FAIL" starttime="20191023 09:40:43.980" endtime="20191023 09:40:44.925"/>
 </kw>
 <msg timestamp="20191023 09:40:44.925" level="INFO">${passed} = False</msg>
-<status status="PASS" starttime="20191023 09:40:43.980" endtime="20191023 09:40:44.925"></status>
+<status status="PASS" starttime="20191023 09:40:43.980" endtime="20191023 09:40:44.925"/>
 </kw>
 <kw name="Run Keyword If" library="BuiltIn">
-<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
-<arguments>
 <arg>not $passed</arg>
 <arg>run task</arg>
 <arg>create_community</arg>
 <arg>template=VF Template</arg>
 <arg>name=${community name}</arg>
 <arg>url_path_prefix=${url prefix}</arg>
-</arguments>
+<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
 <kw name="Run Task" library="cumulusci.robotframework.CumulusCI">
-<doc>Runs a named CumulusCI task for the current project with optional
-support for overriding task options via kwargs.</doc>
-<arguments>
 <arg>create_community</arg>
 <arg>template=VF Template</arg>
 <arg>name=${community name}</arg>
 <arg>url_path_prefix=${url prefix}</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:40:44.931" endtime="20191023 09:41:34.315"></status>
+<doc>Runs a named CumulusCI task for the current project with optional
+support for overriding task options via kwargs.</doc>
+<status status="PASS" starttime="20191023 09:40:44.931" endtime="20191023 09:41:34.315"/>
 </kw>
-<status status="PASS" starttime="20191023 09:40:44.925" endtime="20191023 09:41:34.315"></status>
+<status status="PASS" starttime="20191023 09:40:44.925" endtime="20191023 09:41:34.315"/>
 </kw>
-<status status="PASS" starttime="20191023 09:40:43.979" endtime="20191023 09:41:34.315"></status>
+<status status="PASS" starttime="20191023 09:40:43.979" endtime="20191023 09:41:34.315"/>
 </kw>
 <kw name="Ensure community exists">
-<doc>Creates a community with the given name if it doesn't exist</doc>
-<arguments>
 <arg>Ohana</arg>
 <arg>ohana</arg>
-</arguments>
+<doc>Creates a community with the given name if it doesn't exist</doc>
 <kw name="Run Keyword And Return Status" library="BuiltIn">
-<doc>Runs the given keyword with given arguments and returns the status as a Boolean value.</doc>
-<arguments>
+<var>${passed}</var>
 <arg>get community info</arg>
 <arg>${community name}</arg>
-</arguments>
-<assign>
-<var>${passed}</var>
-</assign>
+<doc>Runs the given keyword with given arguments and returns the status as a Boolean value.</doc>
 <kw name="Get Community Info" library="cumulusci.robotframework.CumulusCI">
-<doc>This keyword uses the Salesforce API to get information about a community.</doc>
-<arguments>
 <arg>${community name}</arg>
-</arguments>
+<doc>This keyword uses the Salesforce API to get information about a community.</doc>
 <msg timestamp="20191023 09:41:34.879" level="FAIL">Unable to find community information for 'Ohana'</msg>
-<status status="FAIL" starttime="20191023 09:41:34.316" endtime="20191023 09:41:34.879"></status>
+<status status="FAIL" starttime="20191023 09:41:34.316" endtime="20191023 09:41:34.879"/>
 </kw>
 <msg timestamp="20191023 09:41:34.879" level="INFO">${passed} = False</msg>
-<status status="PASS" starttime="20191023 09:41:34.316" endtime="20191023 09:41:34.879"></status>
+<status status="PASS" starttime="20191023 09:41:34.316" endtime="20191023 09:41:34.879"/>
 </kw>
 <kw name="Run Keyword If" library="BuiltIn">
-<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
-<arguments>
 <arg>not $passed</arg>
 <arg>run task</arg>
 <arg>create_community</arg>
 <arg>template=VF Template</arg>
 <arg>name=${community name}</arg>
 <arg>url_path_prefix=${url prefix}</arg>
-</arguments>
+<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
 <kw name="Run Task" library="cumulusci.robotframework.CumulusCI">
-<doc>Runs a named CumulusCI task for the current project with optional
-support for overriding task options via kwargs.</doc>
-<arguments>
 <arg>create_community</arg>
 <arg>template=VF Template</arg>
 <arg>name=${community name}</arg>
 <arg>url_path_prefix=${url prefix}</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:41:34.881" endtime="20191023 09:41:52.054"></status>
+<doc>Runs a named CumulusCI task for the current project with optional
+support for overriding task options via kwargs.</doc>
+<status status="PASS" starttime="20191023 09:41:34.881" endtime="20191023 09:41:52.054"/>
 </kw>
-<status status="PASS" starttime="20191023 09:41:34.880" endtime="20191023 09:41:52.054"></status>
+<status status="PASS" starttime="20191023 09:41:34.880" endtime="20191023 09:41:52.054"/>
 </kw>
-<status status="PASS" starttime="20191023 09:41:34.315" endtime="20191023 09:41:52.055"></status>
+<status status="PASS" starttime="20191023 09:41:34.315" endtime="20191023 09:41:52.055"/>
 </kw>
-<status status="PASS" starttime="20191023 09:40:43.978" endtime="20191023 09:41:52.055"></status>
+<status status="PASS" starttime="20191023 09:40:43.978" endtime="20191023 09:41:52.055"/>
 </kw>
 <test id="s1-s1-s3-t1" name="Get community info for specific community">
 <kw name="Get Community Info" library="cumulusci.robotframework.CumulusCI">
-<doc>This keyword uses the Salesforce API to get information about a community.</doc>
-<arguments>
-<arg>Kōkua</arg>
-</arguments>
-<assign>
 <var>${info}</var>
-</assign>
+<arg>Kōkua</arg>
+<doc>This keyword uses the Salesforce API to get information about a community.</doc>
 <msg timestamp="20191023 09:41:52.056" level="INFO">${info} = {'allowChatterAccessWithoutLogin': False, 'allowMembersToFlag': False, 'description': None, 'id': '0DB4F0000004Z0PWAU', 'invitationsEnabled': False, 'knowledgeableEnabled': False, 'loginUrl': 'https:/...</msg>
-<status status="PASS" starttime="20191023 09:41:52.056" endtime="20191023 09:41:52.056"></status>
+<status status="PASS" starttime="20191023 09:41:52.056" endtime="20191023 09:41:52.056"/>
 </kw>
 <kw name="Dictionary Should Contain Key" library="Collections">
-<doc>Fails if ``key`` is not found from ``dictionary``.</doc>
-<arguments>
 <arg>${info}</arg>
 <arg>name</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:41:52.056" endtime="20191023 09:41:52.056"></status>
+<doc>Fails if ``key`` is not found from ``dictionary``.</doc>
+<status status="PASS" starttime="20191023 09:41:52.056" endtime="20191023 09:41:52.056"/>
 </kw>
 <kw name="Dictionary Should Contain Key" library="Collections">
-<doc>Fails if ``key`` is not found from ``dictionary``.</doc>
-<arguments>
 <arg>${info}</arg>
 <arg>loginUrl</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:41:52.057" endtime="20191023 09:41:52.057"></status>
+<doc>Fails if ``key`` is not found from ``dictionary``.</doc>
+<status status="PASS" starttime="20191023 09:41:52.057" endtime="20191023 09:41:52.057"/>
 </kw>
 <kw name="Dictionary Should Contain Key" library="Collections">
-<doc>Fails if ``key`` is not found from ``dictionary``.</doc>
-<arguments>
 <arg>${info}</arg>
 <arg>siteUrl</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:41:52.057" endtime="20191023 09:41:52.057"></status>
+<doc>Fails if ``key`` is not found from ``dictionary``.</doc>
+<status status="PASS" starttime="20191023 09:41:52.057" endtime="20191023 09:41:52.057"/>
 </kw>
 <kw name="Should Be Equal" library="BuiltIn">
-<doc>Fails if the given objects are unequal.</doc>
-<arguments>
 <arg>${info['name']}</arg>
 <arg>Kōkua</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:41:52.057" endtime="20191023 09:41:52.058"></status>
+<doc>Fails if the given objects are unequal.</doc>
+<status status="PASS" starttime="20191023 09:41:52.057" endtime="20191023 09:41:52.058"/>
 </kw>
 <kw name="Should Be Equal" library="BuiltIn">
-<doc>Fails if the given objects are unequal.</doc>
-<arguments>
 <arg>${info['urlPathPrefix']}</arg>
 <arg>kokua</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:41:52.058" endtime="20191023 09:41:52.058"></status>
+<doc>Fails if the given objects are unequal.</doc>
+<status status="PASS" starttime="20191023 09:41:52.058" endtime="20191023 09:41:52.058"/>
 </kw>
 <kw name="Get Community Info" library="cumulusci.robotframework.CumulusCI">
-<doc>This keyword uses the Salesforce API to get information about a community.</doc>
-<arguments>
-<arg>Ohana</arg>
-</arguments>
-<assign>
 <var>${info}</var>
-</assign>
+<arg>Ohana</arg>
+<doc>This keyword uses the Salesforce API to get information about a community.</doc>
 <msg timestamp="20191023 09:41:52.639" level="INFO">${info} = {'allowChatterAccessWithoutLogin': False, 'allowMembersToFlag': False, 'description': None, 'id': '0DB4F0000004Z0UWAU', 'invitationsEnabled': False, 'knowledgeableEnabled': False, 'loginUrl': 'https:/...</msg>
-<status status="PASS" starttime="20191023 09:41:52.058" endtime="20191023 09:41:52.639"></status>
+<status status="PASS" starttime="20191023 09:41:52.058" endtime="20191023 09:41:52.639"/>
 </kw>
 <kw name="Should Be Equal" library="BuiltIn">
-<doc>Fails if the given objects are unequal.</doc>
-<arguments>
 <arg>${info['name']}</arg>
 <arg>Ohana</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:41:52.639" endtime="20191023 09:41:52.640"></status>
+<doc>Fails if the given objects are unequal.</doc>
+<status status="PASS" starttime="20191023 09:41:52.639" endtime="20191023 09:41:52.640"/>
 </kw>
 <kw name="Should Be Equal" library="BuiltIn">
-<doc>Fails if the given objects are unequal.</doc>
-<arguments>
 <arg>${info['urlPathPrefix']}</arg>
 <arg>ohana</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:41:52.640" endtime="20191023 09:41:52.640"></status>
+<doc>Fails if the given objects are unequal.</doc>
+<status status="PASS" starttime="20191023 09:41:52.640" endtime="20191023 09:41:52.640"/>
 </kw>
-<status status="PASS" starttime="20191023 09:41:52.055" endtime="20191023 09:41:52.641" critical="yes"></status>
+<status status="PASS" starttime="20191023 09:41:52.055" endtime="20191023 09:41:52.641"/>
 </test>
 <test id="s1-s1-s3-t2" name="Get community info for non-existing community throws error">
 <kw name="Run Keyword And Expect Error" library="BuiltIn">
-<doc>Runs the keyword and checks that the expected error occurred.</doc>
-<arguments>
 <arg>Unable to find community information for 'bōgusCommunity'</arg>
 <arg>get community info</arg>
 <arg>bōgusCommunity</arg>
-</arguments>
+<doc>Runs the keyword and checks that the expected error occurred.</doc>
 <kw name="Get Community Info" library="cumulusci.robotframework.CumulusCI">
-<doc>This keyword uses the Salesforce API to get information about a community.</doc>
-<arguments>
 <arg>bōgusCommunity</arg>
-</arguments>
+<doc>This keyword uses the Salesforce API to get information about a community.</doc>
 <msg timestamp="20191023 09:41:53.216" level="FAIL">Unable to find community information for 'bōgusCommunity'</msg>
-<status status="FAIL" starttime="20191023 09:41:52.642" endtime="20191023 09:41:53.216"></status>
+<status status="FAIL" starttime="20191023 09:41:52.642" endtime="20191023 09:41:53.216"/>
 </kw>
-<status status="PASS" starttime="20191023 09:41:52.642" endtime="20191023 09:41:53.217"></status>
+<status status="PASS" starttime="20191023 09:41:52.642" endtime="20191023 09:41:53.217"/>
 </kw>
 <doc>Verify that an unknown community name throws a reasonable error message</doc>
-<status status="PASS" starttime="20191023 09:41:52.641" endtime="20191023 09:41:53.217" critical="yes"></status>
+<status status="PASS" starttime="20191023 09:41:52.641" endtime="20191023 09:41:53.217"/>
 </test>
 <test id="s1-s1-s3-t3" name="Get community info with key">
 <kw name="Get Community Info" library="cumulusci.robotframework.CumulusCI">
-<doc>This keyword uses the Salesforce API to get information about a community.</doc>
-<arguments>
+<var>${loginUrl}</var>
 <arg>Kōkua</arg>
 <arg>loginUrl</arg>
-</arguments>
-<assign>
-<var>${loginUrl}</var>
-</assign>
+<doc>This keyword uses the Salesforce API to get information about a community.</doc>
 <msg timestamp="20191023 09:41:53.218" level="INFO">${loginUrl} = https://sandbox-efficiency-fun-590-dev-ed-16df06531de.cs93.force.com/kokua/login</msg>
-<status status="PASS" starttime="20191023 09:41:53.218" endtime="20191023 09:41:53.218"></status>
+<status status="PASS" starttime="20191023 09:41:53.218" endtime="20191023 09:41:53.218"/>
 </kw>
 <kw name="Should Match Regexp" library="BuiltIn">
-<doc>Fails if ``string`` does not match ``pattern`` as a regular expression.</doc>
-<arguments>
 <arg>${loginUrl}</arg>
 <arg>https://.*/kokua/login</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:41:53.218" endtime="20191023 09:41:53.218"></status>
+<doc>Fails if ``string`` does not match ``pattern`` as a regular expression.</doc>
+<status status="PASS" starttime="20191023 09:41:53.218" endtime="20191023 09:41:53.218"/>
 </kw>
 <doc>Verify we can Fetch data for a single key</doc>
-<status status="PASS" starttime="20191023 09:41:53.217" endtime="20191023 09:41:53.219" critical="yes"></status>
+<status status="PASS" starttime="20191023 09:41:53.217" endtime="20191023 09:41:53.219"/>
 </test>
 <test id="s1-s1-s3-t4" name="Get community info with unknown key throws error">
 <kw name="Run Keyword And Expect Error" library="BuiltIn">
-<doc>Runs the keyword and checks that the expected error occurred.</doc>
-<arguments>
 <arg>Invalid key 'bōgus'</arg>
 <arg>get community info</arg>
 <arg>Kōkua</arg>
 <arg>bōgus</arg>
-</arguments>
+<doc>Runs the keyword and checks that the expected error occurred.</doc>
 <kw name="Get Community Info" library="cumulusci.robotframework.CumulusCI">
-<doc>This keyword uses the Salesforce API to get information about a community.</doc>
-<arguments>
 <arg>Kōkua</arg>
 <arg>bōgus</arg>
-</arguments>
+<doc>This keyword uses the Salesforce API to get information about a community.</doc>
 <msg timestamp="20191023 09:41:53.220" level="FAIL">Invalid key 'bōgus'</msg>
-<status status="FAIL" starttime="20191023 09:41:53.220" endtime="20191023 09:41:53.220"></status>
+<status status="FAIL" starttime="20191023 09:41:53.220" endtime="20191023 09:41:53.220"/>
 </kw>
-<status status="PASS" starttime="20191023 09:41:53.219" endtime="20191023 09:41:53.220"></status>
+<status status="PASS" starttime="20191023 09:41:53.219" endtime="20191023 09:41:53.220"/>
 </kw>
 <doc>Verify that an unknown key throws a reasonable error message</doc>
-<status status="PASS" starttime="20191023 09:41:53.219" endtime="20191023 09:41:53.220" critical="yes"></status>
+<status status="PASS" starttime="20191023 09:41:53.219" endtime="20191023 09:41:53.220"/>
 </test>
-<status status="PASS" starttime="20191023 09:40:43.904" endtime="20191023 09:41:53.221"></status>
+<status status="PASS" starttime="20191023 09:40:43.904" endtime="20191023 09:41:53.221"/>
 </suite>
-<status status="PASS" starttime="20191023 09:38:43.647" endtime="20191023 09:41:53.223"></status>
+<status status="PASS" starttime="20191023 09:38:43.647" endtime="20191023 09:41:53.223"/>
 </suite>
 <suite id="s1-s2" name="Salesforce" source="/Users/pprescod/code/CumulusCI/cumulusci/robotframework/tests/salesforce">
 <suite id="s1-s2-s1" name="Api" source="/Users/pprescod/code/CumulusCI/cumulusci/robotframework/tests/salesforce/api.robot">
 <test id="s1-s2-s1-t1" name="Salesforce Delete">
-<kw name="Sleep" library="BuiltIn" type="setup">
-<doc>Pauses the test executed for the given time.</doc>
-<arguments>
+<kw name="Sleep" library="BuiltIn" type="SETUP">
 <arg>6</arg>
-</arguments>
+<doc>Pauses the test executed for the given time.</doc>
 <msg timestamp="20191023 09:41:59.237" level="INFO">Slept 6 seconds</msg>
-<status status="PASS" starttime="20191023 09:41:53.237" endtime="20191023 09:41:59.238"></status>
+<status status="PASS" starttime="20191023 09:41:53.237" endtime="20191023 09:41:59.238"/>
 </kw>
 <kw name="Log Variables" library="BuiltIn">
 <doc>Logs all variables in the current scope with given log level.</doc>
@@ -875,470 +689,342 @@ support for overriding task options via kwargs.</doc>
 <msg timestamp="20191023 09:41:59.243" level="INFO">@{TEST_TAGS} = [ api | Runme ]</msg>
 <msg timestamp="20191023 09:41:59.243" level="INFO">${TIMEOUT} = 30.0</msg>
 <msg timestamp="20191023 09:41:59.243" level="INFO">${True} = True</msg>
-<status status="PASS" starttime="20191023 09:41:59.238" endtime="20191023 09:41:59.243"></status>
+<status status="PASS" starttime="20191023 09:41:59.238" endtime="20191023 09:41:59.243"/>
 </kw>
 <kw name="Create Contact">
-<assign>
 <var>&amp;{contact}</var>
-</assign>
 <kw name="Generate Random String" library="String">
-<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
-<assign>
 <var>${first_name}</var>
-</assign>
+<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
 <msg timestamp="20191023 09:41:59.244" level="INFO">${first_name} = qRm2evRT</msg>
-<status status="PASS" starttime="20191023 09:41:59.244" endtime="20191023 09:41:59.244"></status>
+<status status="PASS" starttime="20191023 09:41:59.244" endtime="20191023 09:41:59.244"/>
 </kw>
 <kw name="Generate Random String" library="String">
-<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
-<assign>
 <var>${last_name}</var>
-</assign>
+<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
 <msg timestamp="20191023 09:41:59.244" level="INFO">${last_name} = Z73DSk6w</msg>
-<status status="PASS" starttime="20191023 09:41:59.244" endtime="20191023 09:41:59.244"></status>
+<status status="PASS" starttime="20191023 09:41:59.244" endtime="20191023 09:41:59.244"/>
 </kw>
 <kw name="Salesforce Insert" library="cumulusci.robotframework.Salesforce">
-<doc>Inserts a Salesforce object setting fields using kwargs and returns the id</doc>
-<arguments>
+<var>${contact_id}</var>
 <arg>Contact</arg>
 <arg>FirstName=${first_name}</arg>
 <arg>LastName=${last_name}</arg>
-</arguments>
-<assign>
-<var>${contact_id}</var>
-</assign>
+<doc>Inserts a Salesforce object setting fields using kwargs and returns the id</doc>
 <msg timestamp="20191023 09:41:59.245" level="INFO">Inserting Contact with values {'FirstName': 'qRm2evRT', 'LastName': 'Z73DSk6w'}</msg>
 <msg timestamp="20191023 09:41:59.702" level="INFO">Storing Contact 0034F00000SaS2SQAV to session records</msg>
 <msg timestamp="20191023 09:41:59.702" level="INFO">${contact_id} = 0034F00000SaS2SQAV</msg>
-<status status="PASS" starttime="20191023 09:41:59.245" endtime="20191023 09:41:59.702"></status>
+<status status="PASS" starttime="20191023 09:41:59.245" endtime="20191023 09:41:59.702"/>
 </kw>
 <kw name="Salesforce Get" library="cumulusci.robotframework.Salesforce">
-<doc>Gets a Salesforce object by id and returns the dict result</doc>
-<arguments>
+<var>&amp;{contact}</var>
 <arg>Contact</arg>
 <arg>${contact_id}</arg>
-</arguments>
-<assign>
-<var>&amp;{contact}</var>
-</assign>
+<doc>Gets a Salesforce object by id and returns the dict result</doc>
 <msg timestamp="20191023 09:41:59.703" level="INFO">Getting Contact with Id 0034F00000SaS2SQAV</msg>
 <msg timestamp="20191023 09:41:59.893" level="INFO">&amp;{contact} = { attributes={'type': 'Contact', 'url': '/services/data/v46.0/sobjects/Contact/0034F00000SaS2SQAV'} | Id=0034F00000SaS2SQAV | IsDeleted=False | MasterRecordId=None | AccountId=None | LastName=Z73DSk6w...</msg>
-<status status="PASS" starttime="20191023 09:41:59.702" endtime="20191023 09:41:59.893"></status>
+<status status="PASS" starttime="20191023 09:41:59.702" endtime="20191023 09:41:59.893"/>
 </kw>
 <msg timestamp="20191023 09:41:59.893" level="INFO">&amp;{contact} = { attributes={'type': 'Contact', 'url': '/services/data/v46.0/sobjects/Contact/0034F00000SaS2SQAV'} | Id=0034F00000SaS2SQAV | IsDeleted=False | MasterRecordId=None | AccountId=None | LastName=Z73DSk6w...</msg>
-<status status="PASS" starttime="20191023 09:41:59.243" endtime="20191023 09:41:59.893"></status>
+<status status="PASS" starttime="20191023 09:41:59.243" endtime="20191023 09:41:59.893"/>
 </kw>
 <kw name="Salesforce Delete" library="cumulusci.robotframework.Salesforce">
-<doc>Deletes a Saleforce object by id and returns the dict result</doc>
-<arguments>
 <arg>Contact</arg>
 <arg>&amp;{contact}[Id]</arg>
-</arguments>
+<doc>Deletes a Saleforce object by id and returns the dict result</doc>
 <msg timestamp="20191023 09:41:59.894" level="INFO">Deleting Contact with Id 0034F00000SaS2SQAV</msg>
-<status status="PASS" starttime="20191023 09:41:59.894" endtime="20191023 09:42:00.252"></status>
+<status status="PASS" starttime="20191023 09:41:59.894" endtime="20191023 09:42:00.252"/>
 </kw>
 <kw name="Soql Query" library="cumulusci.robotframework.Salesforce">
-<doc>Runs a simple SOQL query and returns the dict results</doc>
-<arguments>
-<arg>Select Id from Contact WHERE Id = '&amp;{contact}[Id]'</arg>
-</arguments>
-<assign>
 <var>&amp;{result}</var>
-</assign>
+<arg>Select Id from Contact WHERE Id = '&amp;{contact}[Id]'</arg>
+<doc>Runs a simple SOQL query and returns the dict results</doc>
 <msg timestamp="20191023 09:42:00.254" level="INFO">Running SOQL Query: Select Id from Contact WHERE Id = '0034F00000SaS2SQAV'</msg>
 <msg timestamp="20191023 09:42:00.415" level="INFO">&amp;{result} = { totalSize=0 | done=True | records=[] }</msg>
-<status status="PASS" starttime="20191023 09:42:00.253" endtime="20191023 09:42:00.415"></status>
+<status status="PASS" starttime="20191023 09:42:00.253" endtime="20191023 09:42:00.415"/>
 </kw>
 <kw name="Should Be Equal" library="BuiltIn">
-<doc>Fails if the given objects are unequal.</doc>
-<arguments>
 <arg>&amp;{result}[totalSize]</arg>
 <arg>${0}</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:42:00.415" endtime="20191023 09:42:00.416"></status>
+<doc>Fails if the given objects are unequal.</doc>
+<status status="PASS" starttime="20191023 09:42:00.415" endtime="20191023 09:42:00.416"/>
 </kw>
-<tags>
 <tag>api</tag>
 <tag>Runme</tag>
-</tags>
-<status status="PASS" starttime="20191023 09:41:53.236" endtime="20191023 09:42:00.417" critical="yes"></status>
+<status status="PASS" starttime="20191023 09:41:53.236" endtime="20191023 09:42:00.417"/>
 </test>
 <test id="s1-s2-s1-t2" name="Salesforce Insert">
-<kw name="Sleep" library="BuiltIn" type="setup">
-<doc>Pauses the test executed for the given time.</doc>
-<arguments>
+<kw name="Sleep" library="BuiltIn" type="SETUP">
 <arg>6</arg>
-</arguments>
+<doc>Pauses the test executed for the given time.</doc>
 <msg timestamp="20191023 09:42:06.421" level="INFO">Slept 6 seconds</msg>
-<status status="PASS" starttime="20191023 09:42:00.418" endtime="20191023 09:42:06.421"></status>
+<status status="PASS" starttime="20191023 09:42:00.418" endtime="20191023 09:42:06.421"/>
 </kw>
 <kw name="Generate Random String" library="String">
-<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
-<assign>
 <var>${first_name}</var>
-</assign>
+<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
 <msg timestamp="20191023 09:42:06.423" level="INFO">${first_name} = rWrcbgBU</msg>
-<status status="PASS" starttime="20191023 09:42:06.422" endtime="20191023 09:42:06.423"></status>
+<status status="PASS" starttime="20191023 09:42:06.422" endtime="20191023 09:42:06.423"/>
 </kw>
 <kw name="Generate Random String" library="String">
-<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
-<assign>
 <var>${last_name}</var>
-</assign>
+<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
 <msg timestamp="20191023 09:42:06.424" level="INFO">${last_name} = CiqFi7VB</msg>
-<status status="PASS" starttime="20191023 09:42:06.423" endtime="20191023 09:42:06.424"></status>
+<status status="PASS" starttime="20191023 09:42:06.423" endtime="20191023 09:42:06.424"/>
 </kw>
 <kw name="Salesforce Insert" library="cumulusci.robotframework.Salesforce">
-<doc>Inserts a Salesforce object setting fields using kwargs and returns the id</doc>
-<arguments>
+<var>${contact_id}</var>
 <arg>Contact</arg>
 <arg>FirstName=${first_name}</arg>
 <arg>LastName=${last_name}</arg>
-</arguments>
-<assign>
-<var>${contact_id}</var>
-</assign>
+<doc>Inserts a Salesforce object setting fields using kwargs and returns the id</doc>
 <msg timestamp="20191023 09:42:06.425" level="INFO">Inserting Contact with values {'FirstName': 'rWrcbgBU', 'LastName': 'CiqFi7VB'}</msg>
 <msg timestamp="20191023 09:42:06.800" level="INFO">Storing Contact 0034F00000SaS2lQAF to session records</msg>
 <msg timestamp="20191023 09:42:06.800" level="INFO">${contact_id} = 0034F00000SaS2lQAF</msg>
-<status status="PASS" starttime="20191023 09:42:06.424" endtime="20191023 09:42:06.807"></status>
+<status status="PASS" starttime="20191023 09:42:06.424" endtime="20191023 09:42:06.807"/>
 </kw>
 <kw name="Salesforce Get" library="cumulusci.robotframework.Salesforce">
-<doc>Gets a Salesforce object by id and returns the dict result</doc>
-<arguments>
+<var>&amp;{contact}</var>
 <arg>Contact</arg>
 <arg>${contact_id}</arg>
-</arguments>
-<assign>
-<var>&amp;{contact}</var>
-</assign>
+<doc>Gets a Salesforce object by id and returns the dict result</doc>
 <msg timestamp="20191023 09:42:06.808" level="INFO">Getting Contact with Id 0034F00000SaS2lQAF</msg>
 <msg timestamp="20191023 09:42:07.008" level="INFO">&amp;{contact} = { attributes={'type': 'Contact', 'url': '/services/data/v46.0/sobjects/Contact/0034F00000SaS2lQAF'} | Id=0034F00000SaS2lQAF | IsDeleted=False | MasterRecordId=None | AccountId=None | LastName=CiqFi7VB...</msg>
-<status status="PASS" starttime="20191023 09:42:06.807" endtime="20191023 09:42:07.008"></status>
+<status status="PASS" starttime="20191023 09:42:06.807" endtime="20191023 09:42:07.008"/>
 </kw>
 <kw name="Should Be Equal" library="BuiltIn">
-<doc>Fails if the given objects are unequal.</doc>
-<arguments>
 <arg>&amp;{contact}[FirstName]</arg>
 <arg>${first_name}</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:42:07.009" endtime="20191023 09:42:07.009"></status>
+<doc>Fails if the given objects are unequal.</doc>
+<status status="PASS" starttime="20191023 09:42:07.009" endtime="20191023 09:42:07.009"/>
 </kw>
 <kw name="Should Be Equal" library="BuiltIn">
-<doc>Fails if the given objects are unequal.</doc>
-<arguments>
 <arg>&amp;{contact}[LastName]</arg>
 <arg>${last_name}</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:42:07.009" endtime="20191023 09:42:07.010"></status>
+<doc>Fails if the given objects are unequal.</doc>
+<status status="PASS" starttime="20191023 09:42:07.009" endtime="20191023 09:42:07.010"/>
 </kw>
-<tags>
 <tag>api</tag>
-</tags>
-<status status="PASS" starttime="20191023 09:42:00.417" endtime="20191023 09:42:07.010" critical="yes"></status>
+<status status="PASS" starttime="20191023 09:42:00.417" endtime="20191023 09:42:07.010"/>
 </test>
 <test id="s1-s2-s1-t3" name="Salesforce Update">
-<kw name="Sleep" library="BuiltIn" type="setup">
-<doc>Pauses the test executed for the given time.</doc>
-<arguments>
+<kw name="Sleep" library="BuiltIn" type="SETUP">
 <arg>6</arg>
-</arguments>
+<doc>Pauses the test executed for the given time.</doc>
 <msg timestamp="20191023 09:42:13.014" level="INFO">Slept 6 seconds</msg>
-<status status="PASS" starttime="20191023 09:42:07.011" endtime="20191023 09:42:13.014"></status>
+<status status="PASS" starttime="20191023 09:42:07.011" endtime="20191023 09:42:13.014"/>
 </kw>
 <kw name="Create Contact">
-<assign>
 <var>&amp;{contact}</var>
-</assign>
 <kw name="Generate Random String" library="String">
-<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
-<assign>
 <var>${first_name}</var>
-</assign>
+<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
 <msg timestamp="20191023 09:42:13.017" level="INFO">${first_name} = GeVqq7X5</msg>
-<status status="PASS" starttime="20191023 09:42:13.016" endtime="20191023 09:42:13.017"></status>
+<status status="PASS" starttime="20191023 09:42:13.016" endtime="20191023 09:42:13.017"/>
 </kw>
 <kw name="Generate Random String" library="String">
-<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
-<assign>
 <var>${last_name}</var>
-</assign>
+<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
 <msg timestamp="20191023 09:42:13.017" level="INFO">${last_name} = rSzRp1Y9</msg>
-<status status="PASS" starttime="20191023 09:42:13.017" endtime="20191023 09:42:13.018"></status>
+<status status="PASS" starttime="20191023 09:42:13.017" endtime="20191023 09:42:13.018"/>
 </kw>
 <kw name="Salesforce Insert" library="cumulusci.robotframework.Salesforce">
-<doc>Inserts a Salesforce object setting fields using kwargs and returns the id</doc>
-<arguments>
+<var>${contact_id}</var>
 <arg>Contact</arg>
 <arg>FirstName=${first_name}</arg>
 <arg>LastName=${last_name}</arg>
-</arguments>
-<assign>
-<var>${contact_id}</var>
-</assign>
+<doc>Inserts a Salesforce object setting fields using kwargs and returns the id</doc>
 <msg timestamp="20191023 09:42:13.019" level="INFO">Inserting Contact with values {'FirstName': 'GeVqq7X5', 'LastName': 'rSzRp1Y9'}</msg>
 <msg timestamp="20191023 09:42:13.323" level="INFO">Storing Contact 0034F00000SaS3KQAV to session records</msg>
 <msg timestamp="20191023 09:42:13.324" level="INFO">${contact_id} = 0034F00000SaS3KQAV</msg>
-<status status="PASS" starttime="20191023 09:42:13.018" endtime="20191023 09:42:13.324"></status>
+<status status="PASS" starttime="20191023 09:42:13.018" endtime="20191023 09:42:13.324"/>
 </kw>
 <kw name="Salesforce Get" library="cumulusci.robotframework.Salesforce">
-<doc>Gets a Salesforce object by id and returns the dict result</doc>
-<arguments>
+<var>&amp;{contact}</var>
 <arg>Contact</arg>
 <arg>${contact_id}</arg>
-</arguments>
-<assign>
-<var>&amp;{contact}</var>
-</assign>
+<doc>Gets a Salesforce object by id and returns the dict result</doc>
 <msg timestamp="20191023 09:42:13.324" level="INFO">Getting Contact with Id 0034F00000SaS3KQAV</msg>
 <msg timestamp="20191023 09:42:13.477" level="INFO">&amp;{contact} = { attributes={'type': 'Contact', 'url': '/services/data/v46.0/sobjects/Contact/0034F00000SaS3KQAV'} | Id=0034F00000SaS3KQAV | IsDeleted=False | MasterRecordId=None | AccountId=None | LastName=rSzRp1Y9...</msg>
-<status status="PASS" starttime="20191023 09:42:13.324" endtime="20191023 09:42:13.478"></status>
+<status status="PASS" starttime="20191023 09:42:13.324" endtime="20191023 09:42:13.478"/>
 </kw>
 <msg timestamp="20191023 09:42:13.478" level="INFO">&amp;{contact} = { attributes={'type': 'Contact', 'url': '/services/data/v46.0/sobjects/Contact/0034F00000SaS3KQAV'} | Id=0034F00000SaS3KQAV | IsDeleted=False | MasterRecordId=None | AccountId=None | LastName=rSzRp1Y9...</msg>
-<status status="PASS" starttime="20191023 09:42:13.015" endtime="20191023 09:42:13.478"></status>
+<status status="PASS" starttime="20191023 09:42:13.015" endtime="20191023 09:42:13.478"/>
 </kw>
 <kw name="Generate Random String" library="String">
-<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
-<assign>
 <var>${new_last_name}</var>
-</assign>
+<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
 <msg timestamp="20191023 09:42:13.479" level="INFO">${new_last_name} = hC0xjHaq</msg>
-<status status="PASS" starttime="20191023 09:42:13.479" endtime="20191023 09:42:13.479"></status>
+<status status="PASS" starttime="20191023 09:42:13.479" endtime="20191023 09:42:13.479"/>
 </kw>
 <kw name="Salesforce Update" library="cumulusci.robotframework.Salesforce">
-<doc>Updates a Salesforce object by id and returns the dict results</doc>
-<arguments>
 <arg>Contact</arg>
 <arg>&amp;{contact}[Id]</arg>
 <arg>LastName=${new_last_name}</arg>
-</arguments>
+<doc>Updates a Salesforce object by id and returns the dict results</doc>
 <msg timestamp="20191023 09:42:13.480" level="INFO">Updating Contact 0034F00000SaS3KQAV with values {'LastName': 'hC0xjHaq'}</msg>
-<status status="PASS" starttime="20191023 09:42:13.479" endtime="20191023 09:42:14.181"></status>
+<status status="PASS" starttime="20191023 09:42:13.479" endtime="20191023 09:42:14.181"/>
 </kw>
 <kw name="Salesforce Get" library="cumulusci.robotframework.Salesforce">
-<doc>Gets a Salesforce object by id and returns the dict result</doc>
-<arguments>
+<var>&amp;{contact}</var>
 <arg>Contact</arg>
 <arg>&amp;{contact}[Id]</arg>
-</arguments>
-<assign>
-<var>&amp;{contact}</var>
-</assign>
+<doc>Gets a Salesforce object by id and returns the dict result</doc>
 <msg timestamp="20191023 09:42:14.182" level="INFO">Getting Contact with Id 0034F00000SaS3KQAV</msg>
 <msg timestamp="20191023 09:42:14.341" level="INFO">&amp;{contact} = { attributes={'type': 'Contact', 'url': '/services/data/v46.0/sobjects/Contact/0034F00000SaS3KQAV'} | Id=0034F00000SaS3KQAV | IsDeleted=False | MasterRecordId=None | AccountId=None | LastName=hC0xjHaq...</msg>
-<status status="PASS" starttime="20191023 09:42:14.182" endtime="20191023 09:42:14.341"></status>
+<status status="PASS" starttime="20191023 09:42:14.182" endtime="20191023 09:42:14.341"/>
 </kw>
 <kw name="Should Be Equal" library="BuiltIn">
-<doc>Fails if the given objects are unequal.</doc>
-<arguments>
 <arg>&amp;{contact}[LastName]</arg>
 <arg>${new_last_name}</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:42:14.341" endtime="20191023 09:42:14.342"></status>
+<doc>Fails if the given objects are unequal.</doc>
+<status status="PASS" starttime="20191023 09:42:14.341" endtime="20191023 09:42:14.342"/>
 </kw>
-<tags>
 <tag>api</tag>
-</tags>
-<status status="PASS" starttime="20191023 09:42:07.011" endtime="20191023 09:42:14.342" critical="yes"></status>
+<status status="PASS" starttime="20191023 09:42:07.011" endtime="20191023 09:42:14.342"/>
 </test>
 <test id="s1-s2-s1-t4" name="Salesforce Query">
-<kw name="Sleep" library="BuiltIn" type="setup">
-<doc>Pauses the test executed for the given time.</doc>
-<arguments>
+<kw name="Sleep" library="BuiltIn" type="SETUP">
 <arg>6</arg>
-</arguments>
+<doc>Pauses the test executed for the given time.</doc>
 <msg timestamp="20191023 09:42:20.345" level="INFO">Slept 6 seconds</msg>
-<status status="PASS" starttime="20191023 09:42:14.343" endtime="20191023 09:42:20.346"></status>
+<status status="PASS" starttime="20191023 09:42:14.343" endtime="20191023 09:42:20.346"/>
 </kw>
 <kw name="Create Contact">
-<assign>
 <var>&amp;{new_contact}</var>
-</assign>
 <kw name="Generate Random String" library="String">
-<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
-<assign>
 <var>${first_name}</var>
-</assign>
+<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
 <msg timestamp="20191023 09:42:20.347" level="INFO">${first_name} = jjiIiwqf</msg>
-<status status="PASS" starttime="20191023 09:42:20.346" endtime="20191023 09:42:20.347"></status>
+<status status="PASS" starttime="20191023 09:42:20.346" endtime="20191023 09:42:20.347"/>
 </kw>
 <kw name="Generate Random String" library="String">
-<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
-<assign>
 <var>${last_name}</var>
-</assign>
+<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
 <msg timestamp="20191023 09:42:20.347" level="INFO">${last_name} = U0Nh4qo8</msg>
-<status status="PASS" starttime="20191023 09:42:20.347" endtime="20191023 09:42:20.347"></status>
+<status status="PASS" starttime="20191023 09:42:20.347" endtime="20191023 09:42:20.347"/>
 </kw>
 <kw name="Salesforce Insert" library="cumulusci.robotframework.Salesforce">
-<doc>Inserts a Salesforce object setting fields using kwargs and returns the id</doc>
-<arguments>
+<var>${contact_id}</var>
 <arg>Contact</arg>
 <arg>FirstName=${first_name}</arg>
 <arg>LastName=${last_name}</arg>
-</arguments>
-<assign>
-<var>${contact_id}</var>
-</assign>
+<doc>Inserts a Salesforce object setting fields using kwargs and returns the id</doc>
 <msg timestamp="20191023 09:42:20.347" level="INFO">Inserting Contact with values {'FirstName': 'jjiIiwqf', 'LastName': 'U0Nh4qo8'}</msg>
 <msg timestamp="20191023 09:42:20.640" level="INFO">Storing Contact 0034F00000SaS3oQAF to session records</msg>
 <msg timestamp="20191023 09:42:20.640" level="INFO">${contact_id} = 0034F00000SaS3oQAF</msg>
-<status status="PASS" starttime="20191023 09:42:20.347" endtime="20191023 09:42:20.640"></status>
+<status status="PASS" starttime="20191023 09:42:20.347" endtime="20191023 09:42:20.640"/>
 </kw>
 <kw name="Salesforce Get" library="cumulusci.robotframework.Salesforce">
-<doc>Gets a Salesforce object by id and returns the dict result</doc>
-<arguments>
+<var>&amp;{contact}</var>
 <arg>Contact</arg>
 <arg>${contact_id}</arg>
-</arguments>
-<assign>
-<var>&amp;{contact}</var>
-</assign>
+<doc>Gets a Salesforce object by id and returns the dict result</doc>
 <msg timestamp="20191023 09:42:20.641" level="INFO">Getting Contact with Id 0034F00000SaS3oQAF</msg>
 <msg timestamp="20191023 09:42:20.883" level="INFO">&amp;{contact} = { attributes={'type': 'Contact', 'url': '/services/data/v46.0/sobjects/Contact/0034F00000SaS3oQAF'} | Id=0034F00000SaS3oQAF | IsDeleted=False | MasterRecordId=None | AccountId=None | LastName=U0Nh4qo8...</msg>
-<status status="PASS" starttime="20191023 09:42:20.640" endtime="20191023 09:42:20.883"></status>
+<status status="PASS" starttime="20191023 09:42:20.640" endtime="20191023 09:42:20.883"/>
 </kw>
 <msg timestamp="20191023 09:42:20.884" level="INFO">&amp;{new_contact} = { attributes={'type': 'Contact', 'url': '/services/data/v46.0/sobjects/Contact/0034F00000SaS3oQAF'} | Id=0034F00000SaS3oQAF | IsDeleted=False | MasterRecordId=None | AccountId=None | LastName=U0Nh4qo8...</msg>
-<status status="PASS" starttime="20191023 09:42:20.346" endtime="20191023 09:42:20.884"></status>
+<status status="PASS" starttime="20191023 09:42:20.346" endtime="20191023 09:42:20.884"/>
 </kw>
 <kw name="Salesforce Query" library="cumulusci.robotframework.Salesforce">
-<doc>Constructs and runs a simple SOQL query and returns the dict results</doc>
-<arguments>
+<var>@{records}</var>
 <arg>Contact</arg>
 <arg>select=Id,FirstName,LastName</arg>
 <arg>Id=&amp;{new_contact}[Id]</arg>
-</arguments>
-<assign>
-<var>@{records}</var>
-</assign>
+<doc>Constructs and runs a simple SOQL query and returns the dict results</doc>
 <msg timestamp="20191023 09:42:20.885" level="INFO">Running SOQL Query: SELECT Id,FirstName,LastName FROM Contact WHERE Id = '0034F00000SaS3oQAF'</msg>
 <msg timestamp="20191023 09:42:21.041" level="INFO">@{records} = [ OrderedDict([('attributes', OrderedDict([('type', 'Contact'), ('url', '/services/data/v46.0/sobjects/Contact/0034F00000SaS3oQAF')])), ('Id', '0034F00000SaS3oQAF'), ('FirstName', 'jjiIiwqf'), ('LastN...</msg>
-<status status="PASS" starttime="20191023 09:42:20.885" endtime="20191023 09:42:21.041"></status>
+<status status="PASS" starttime="20191023 09:42:20.885" endtime="20191023 09:42:21.041"/>
 </kw>
 <kw name="Get From List" library="Collections">
-<doc>Returns the value specified with an ``index`` from ``list``.</doc>
-<arguments>
+<var>&amp;{contact}</var>
 <arg>${records}</arg>
 <arg>0</arg>
-</arguments>
-<assign>
-<var>&amp;{contact}</var>
-</assign>
+<doc>Returns the value specified with an ``index`` from ``list``.</doc>
 <msg timestamp="20191023 09:42:21.042" level="INFO">&amp;{contact} = { attributes={'type': 'Contact', 'url': '/services/data/v46.0/sobjects/Contact/0034F00000SaS3oQAF'} | Id=0034F00000SaS3oQAF | FirstName=jjiIiwqf | LastName=U0Nh4qo8 }</msg>
-<status status="PASS" starttime="20191023 09:42:21.042" endtime="20191023 09:42:21.042"></status>
+<status status="PASS" starttime="20191023 09:42:21.042" endtime="20191023 09:42:21.042"/>
 </kw>
 <kw name="Should Be Equal" library="BuiltIn">
-<doc>Fails if the given objects are unequal.</doc>
-<arguments>
 <arg>&amp;{contact}[Id]</arg>
 <arg>&amp;{new_contact}[Id]</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:42:21.043" endtime="20191023 09:42:21.043"></status>
+<doc>Fails if the given objects are unequal.</doc>
+<status status="PASS" starttime="20191023 09:42:21.043" endtime="20191023 09:42:21.043"/>
 </kw>
 <kw name="Should Be Equal" library="BuiltIn">
-<doc>Fails if the given objects are unequal.</doc>
-<arguments>
 <arg>&amp;{contact}[FirstName]</arg>
 <arg>&amp;{new_contact}[FirstName]</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:42:21.044" endtime="20191023 09:42:21.044"></status>
+<doc>Fails if the given objects are unequal.</doc>
+<status status="PASS" starttime="20191023 09:42:21.044" endtime="20191023 09:42:21.044"/>
 </kw>
 <kw name="Should Be Equal" library="BuiltIn">
-<doc>Fails if the given objects are unequal.</doc>
-<arguments>
 <arg>&amp;{contact}[LastName]</arg>
 <arg>&amp;{new_contact}[LastName]</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:42:21.044" endtime="20191023 09:42:21.045"></status>
+<doc>Fails if the given objects are unequal.</doc>
+<status status="PASS" starttime="20191023 09:42:21.044" endtime="20191023 09:42:21.045"/>
 </kw>
-<tags>
 <tag>api</tag>
-</tags>
-<status status="PASS" starttime="20191023 09:42:14.343" endtime="20191023 09:42:21.045" critical="yes"></status>
+<status status="PASS" starttime="20191023 09:42:14.343" endtime="20191023 09:42:21.045"/>
 </test>
 <test id="s1-s2-s1-t5" name="SOQL Query">
-<kw name="Sleep" library="BuiltIn" type="setup">
-<doc>Pauses the test executed for the given time.</doc>
-<arguments>
+<kw name="Sleep" library="BuiltIn" type="SETUP">
 <arg>6</arg>
-</arguments>
+<doc>Pauses the test executed for the given time.</doc>
 <msg timestamp="20191023 09:42:27.047" level="INFO">Slept 6 seconds</msg>
-<status status="PASS" starttime="20191023 09:42:21.046" endtime="20191023 09:42:27.047"></status>
+<status status="PASS" starttime="20191023 09:42:21.046" endtime="20191023 09:42:27.047"/>
 </kw>
 <kw name="Create Contact">
-<assign>
 <var>&amp;{new_contact}</var>
-</assign>
 <kw name="Generate Random String" library="String">
-<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
-<assign>
 <var>${first_name}</var>
-</assign>
+<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
 <msg timestamp="20191023 09:42:27.050" level="INFO">${first_name} = q9zyi6aE</msg>
-<status status="PASS" starttime="20191023 09:42:27.049" endtime="20191023 09:42:27.050"></status>
+<status status="PASS" starttime="20191023 09:42:27.049" endtime="20191023 09:42:27.050"/>
 </kw>
 <kw name="Generate Random String" library="String">
-<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
-<assign>
 <var>${last_name}</var>
-</assign>
+<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
 <msg timestamp="20191023 09:42:27.051" level="INFO">${last_name} = DtOvNp4U</msg>
-<status status="PASS" starttime="20191023 09:42:27.051" endtime="20191023 09:42:27.051"></status>
+<status status="PASS" starttime="20191023 09:42:27.051" endtime="20191023 09:42:27.051"/>
 </kw>
 <kw name="Salesforce Insert" library="cumulusci.robotframework.Salesforce">
-<doc>Inserts a Salesforce object setting fields using kwargs and returns the id</doc>
-<arguments>
+<var>${contact_id}</var>
 <arg>Contact</arg>
 <arg>FirstName=${first_name}</arg>
 <arg>LastName=${last_name}</arg>
-</arguments>
-<assign>
-<var>${contact_id}</var>
-</assign>
+<doc>Inserts a Salesforce object setting fields using kwargs and returns the id</doc>
 <msg timestamp="20191023 09:42:27.052" level="INFO">Inserting Contact with values {'FirstName': 'q9zyi6aE', 'LastName': 'DtOvNp4U'}</msg>
 <msg timestamp="20191023 09:42:27.348" level="INFO">Storing Contact 0034F00000SaS3yQAF to session records</msg>
 <msg timestamp="20191023 09:42:27.348" level="INFO">${contact_id} = 0034F00000SaS3yQAF</msg>
-<status status="PASS" starttime="20191023 09:42:27.051" endtime="20191023 09:42:27.348"></status>
+<status status="PASS" starttime="20191023 09:42:27.051" endtime="20191023 09:42:27.348"/>
 </kw>
 <kw name="Salesforce Get" library="cumulusci.robotframework.Salesforce">
-<doc>Gets a Salesforce object by id and returns the dict result</doc>
-<arguments>
+<var>&amp;{contact}</var>
 <arg>Contact</arg>
 <arg>${contact_id}</arg>
-</arguments>
-<assign>
-<var>&amp;{contact}</var>
-</assign>
+<doc>Gets a Salesforce object by id and returns the dict result</doc>
 <msg timestamp="20191023 09:42:27.349" level="INFO">Getting Contact with Id 0034F00000SaS3yQAF</msg>
 <msg timestamp="20191023 09:42:27.602" level="INFO">&amp;{contact} = { attributes={'type': 'Contact', 'url': '/services/data/v46.0/sobjects/Contact/0034F00000SaS3yQAF'} | Id=0034F00000SaS3yQAF | IsDeleted=False | MasterRecordId=None | AccountId=None | LastName=DtOvNp4U...</msg>
-<status status="PASS" starttime="20191023 09:42:27.349" endtime="20191023 09:42:27.602"></status>
+<status status="PASS" starttime="20191023 09:42:27.349" endtime="20191023 09:42:27.602"/>
 </kw>
 <msg timestamp="20191023 09:42:27.603" level="INFO">&amp;{new_contact} = { attributes={'type': 'Contact', 'url': '/services/data/v46.0/sobjects/Contact/0034F00000SaS3yQAF'} | Id=0034F00000SaS3yQAF | IsDeleted=False | MasterRecordId=None | AccountId=None | LastName=DtOvNp4U...</msg>
-<status status="PASS" starttime="20191023 09:42:27.048" endtime="20191023 09:42:27.603"></status>
+<status status="PASS" starttime="20191023 09:42:27.048" endtime="20191023 09:42:27.603"/>
 </kw>
 <kw name="Soql Query" library="cumulusci.robotframework.Salesforce">
-<doc>Runs a simple SOQL query and returns the dict results</doc>
-<arguments>
-<arg>Select Id, FirstName, LastName from Contact WHERE Id = '&amp;{new_contact}[Id]'</arg>
-</arguments>
-<assign>
 <var>&amp;{result}</var>
-</assign>
+<arg>Select Id, FirstName, LastName from Contact WHERE Id = '&amp;{new_contact}[Id]'</arg>
+<doc>Runs a simple SOQL query and returns the dict results</doc>
 <msg timestamp="20191023 09:42:27.603" level="INFO">Running SOQL Query: Select Id, FirstName, LastName from Contact WHERE Id = '0034F00000SaS3yQAF'</msg>
 <msg timestamp="20191023 09:42:27.833" level="INFO">&amp;{result} = { totalSize=1 | done=True | records=[{'attributes': {'type': 'Contact', 'url': '/services/data/v46.0/sobjects/Contact/0034F00000SaS3yQAF'}, 'Id': '0034F00000SaS3yQAF', 'FirstName': 'q9zyi6aE', 'LastNa...</msg>
-<status status="PASS" starttime="20191023 09:42:27.603" endtime="20191023 09:42:27.833"></status>
+<status status="PASS" starttime="20191023 09:42:27.603" endtime="20191023 09:42:27.833"/>
 </kw>
 <kw name="Get From Dictionary" library="Collections">
-<doc>Returns a value from the given ``dictionary`` based on the given ``key``.</doc>
-<arguments>
+<var>@{records}</var>
 <arg>${result}</arg>
 <arg>records</arg>
-</arguments>
-<assign>
-<var>@{records}</var>
-</assign>
+<doc>Returns a value from the given ``dictionary`` based on the given ``key``.</doc>
 <msg timestamp="20191023 09:42:27.834" level="INFO">@{records} = [ {'attributes': {'type': 'Contact', 'url': '/services/data/v46.0/sobjects/Contact/0034F00000SaS3yQAF'}, 'Id': '0034F00000SaS3yQAF', 'FirstName': 'q9zyi6aE', 'LastName': 'DtOvNp4U'} ]</msg>
-<status status="PASS" starttime="20191023 09:42:27.834" endtime="20191023 09:42:27.834"></status>
+<status status="PASS" starttime="20191023 09:42:27.834" endtime="20191023 09:42:27.834"/>
 </kw>
 <kw name="Log Variables" library="BuiltIn">
 <doc>Logs all variables in the current scope with given log level.</doc>
@@ -1381,204 +1067,156 @@ support for overriding task options via kwargs.</doc>
 <msg timestamp="20191023 09:42:27.836" level="INFO">@{TEST_TAGS} = [ api ]</msg>
 <msg timestamp="20191023 09:42:27.836" level="INFO">${TIMEOUT} = 30.0</msg>
 <msg timestamp="20191023 09:42:27.837" level="INFO">${True} = True</msg>
-<status status="PASS" starttime="20191023 09:42:27.834" endtime="20191023 09:42:27.837"></status>
+<status status="PASS" starttime="20191023 09:42:27.834" endtime="20191023 09:42:27.837"/>
 </kw>
 <kw name="Get From List" library="Collections">
-<doc>Returns the value specified with an ``index`` from ``list``.</doc>
-<arguments>
+<var>&amp;{contact}</var>
 <arg>${records}</arg>
 <arg>0</arg>
-</arguments>
-<assign>
-<var>&amp;{contact}</var>
-</assign>
+<doc>Returns the value specified with an ``index`` from ``list``.</doc>
 <msg timestamp="20191023 09:42:27.837" level="INFO">&amp;{contact} = { attributes={'type': 'Contact', 'url': '/services/data/v46.0/sobjects/Contact/0034F00000SaS3yQAF'} | Id=0034F00000SaS3yQAF | FirstName=q9zyi6aE | LastName=DtOvNp4U }</msg>
-<status status="PASS" starttime="20191023 09:42:27.837" endtime="20191023 09:42:27.837"></status>
+<status status="PASS" starttime="20191023 09:42:27.837" endtime="20191023 09:42:27.837"/>
 </kw>
 <kw name="Should Be Equal" library="BuiltIn">
-<doc>Fails if the given objects are unequal.</doc>
-<arguments>
 <arg>&amp;{result}[totalSize]</arg>
 <arg>${1}</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:42:27.838" endtime="20191023 09:42:27.838"></status>
+<doc>Fails if the given objects are unequal.</doc>
+<status status="PASS" starttime="20191023 09:42:27.838" endtime="20191023 09:42:27.838"/>
 </kw>
 <kw name="Should Be Equal" library="BuiltIn">
-<doc>Fails if the given objects are unequal.</doc>
-<arguments>
 <arg>&amp;{contact}[FirstName]</arg>
 <arg>&amp;{new_contact}[FirstName]</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:42:27.838" endtime="20191023 09:42:27.839"></status>
+<doc>Fails if the given objects are unequal.</doc>
+<status status="PASS" starttime="20191023 09:42:27.838" endtime="20191023 09:42:27.839"/>
 </kw>
 <kw name="Should Be Equal" library="BuiltIn">
-<doc>Fails if the given objects are unequal.</doc>
-<arguments>
 <arg>&amp;{contact}[LastName]</arg>
 <arg>&amp;{new_contact}[LastName]</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:42:27.839" endtime="20191023 09:42:27.839"></status>
+<doc>Fails if the given objects are unequal.</doc>
+<status status="PASS" starttime="20191023 09:42:27.839" endtime="20191023 09:42:27.839"/>
 </kw>
-<tags>
 <tag>api</tag>
-</tags>
-<status status="PASS" starttime="20191023 09:42:21.046" endtime="20191023 09:42:27.840" critical="yes"></status>
+<status status="PASS" starttime="20191023 09:42:21.046" endtime="20191023 09:42:27.840"/>
 </test>
 <test id="s1-s2-s1-t6" name="Salesforce Delete Session Records">
-<kw name="Sleep" library="BuiltIn" type="setup">
-<doc>Pauses the test executed for the given time.</doc>
-<arguments>
+<kw name="Sleep" library="BuiltIn" type="SETUP">
 <arg>6</arg>
-</arguments>
+<doc>Pauses the test executed for the given time.</doc>
 <msg timestamp="20191023 09:42:33.843" level="INFO">Slept 6 seconds</msg>
-<status status="PASS" starttime="20191023 09:42:27.842" endtime="20191023 09:42:33.844"></status>
+<status status="PASS" starttime="20191023 09:42:27.842" endtime="20191023 09:42:33.844"/>
 </kw>
 <kw name="Generate Random String" library="String">
-<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
-<assign>
 <var>${random string}</var>
-</assign>
+<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
 <msg timestamp="20191023 09:42:33.845" level="INFO">${random string} = nQpY3L2D</msg>
-<status status="PASS" starttime="20191023 09:42:33.844" endtime="20191023 09:42:33.845"></status>
+<status status="PASS" starttime="20191023 09:42:33.844" endtime="20191023 09:42:33.845"/>
 </kw>
 <kw name="Salesforce Query" library="cumulusci.robotframework.Salesforce">
-<doc>Constructs and runs a simple SOQL query and returns the dict results</doc>
-<arguments>
+<var>@{query}</var>
 <arg>Contact</arg>
 <arg>LastName=${random string}</arg>
-</arguments>
-<assign>
-<var>@{query}</var>
-</assign>
+<doc>Constructs and runs a simple SOQL query and returns the dict results</doc>
 <msg timestamp="20191023 09:42:33.846" level="INFO">Running SOQL Query: SELECT Id FROM Contact WHERE LastName = 'nQpY3L2D'</msg>
 <msg timestamp="20191023 09:42:34.069" level="INFO">@{query} = [ ]</msg>
-<status status="PASS" starttime="20191023 09:42:33.845" endtime="20191023 09:42:34.069"></status>
+<status status="PASS" starttime="20191023 09:42:33.845" endtime="20191023 09:42:34.069"/>
 </kw>
 <kw name="Length Should Be" library="BuiltIn">
-<doc>Verifies that the length of the given item is correct.</doc>
-<arguments>
 <arg>${query}</arg>
 <arg>0</arg>
 <arg>Expected the query to return no records, but it returned ${query}</arg>
-</arguments>
+<doc>Verifies that the length of the given item is correct.</doc>
 <msg timestamp="20191023 09:42:34.070" level="INFO">Length is 0</msg>
-<status status="PASS" starttime="20191023 09:42:34.069" endtime="20191023 09:42:34.070"></status>
+<status status="PASS" starttime="20191023 09:42:34.069" endtime="20191023 09:42:34.070"/>
 </kw>
-<kw name="${i} IN RANGE [ 5 ]" type="for">
-<kw name="${i} = 0" type="foritem">
+<kw name="${i} IN RANGE [ 5 ]" type="FOR">
+<kw name="${i} = 0" type="FOR ITERATION">
 <kw name="Salesforce Insert" library="cumulusci.robotframework.Salesforce">
-<doc>Inserts a Salesforce object setting fields using kwargs and returns the id</doc>
-<arguments>
+<var>${contact_id}</var>
 <arg>Contact</arg>
 <arg>FirstName=User-${i}</arg>
 <arg>LastName=${random string}</arg>
-</arguments>
-<assign>
-<var>${contact_id}</var>
-</assign>
+<doc>Inserts a Salesforce object setting fields using kwargs and returns the id</doc>
 <msg timestamp="20191023 09:42:34.071" level="INFO">Inserting Contact with values {'FirstName': 'User-0', 'LastName': 'nQpY3L2D'}</msg>
 <msg timestamp="20191023 09:42:34.831" level="INFO">Storing Contact 0034F00000SaS48QAF to session records</msg>
 <msg timestamp="20191023 09:42:34.831" level="INFO">${contact_id} = 0034F00000SaS48QAF</msg>
-<status status="PASS" starttime="20191023 09:42:34.071" endtime="20191023 09:42:34.831"></status>
+<status status="PASS" starttime="20191023 09:42:34.071" endtime="20191023 09:42:34.831"/>
 </kw>
-<status status="PASS" starttime="20191023 09:42:34.070" endtime="20191023 09:42:34.831"></status>
+<status status="PASS" starttime="20191023 09:42:34.070" endtime="20191023 09:42:34.831"/>
 </kw>
-<kw name="${i} = 1" type="foritem">
+<kw name="${i} = 1" type="FOR ITERATION">
 <kw name="Salesforce Insert" library="cumulusci.robotframework.Salesforce">
-<doc>Inserts a Salesforce object setting fields using kwargs and returns the id</doc>
-<arguments>
+<var>${contact_id}</var>
 <arg>Contact</arg>
 <arg>FirstName=User-${i}</arg>
 <arg>LastName=${random string}</arg>
-</arguments>
-<assign>
-<var>${contact_id}</var>
-</assign>
+<doc>Inserts a Salesforce object setting fields using kwargs and returns the id</doc>
 <msg timestamp="20191023 09:42:34.832" level="INFO">Inserting Contact with values {'FirstName': 'User-1', 'LastName': 'nQpY3L2D'}</msg>
 <msg timestamp="20191023 09:42:35.118" level="INFO">Storing Contact 0034F00000SaS4DQAV to session records</msg>
 <msg timestamp="20191023 09:42:35.118" level="INFO">${contact_id} = 0034F00000SaS4DQAV</msg>
-<status status="PASS" starttime="20191023 09:42:34.832" endtime="20191023 09:42:35.118"></status>
+<status status="PASS" starttime="20191023 09:42:34.832" endtime="20191023 09:42:35.118"/>
 </kw>
-<status status="PASS" starttime="20191023 09:42:34.831" endtime="20191023 09:42:35.119"></status>
+<status status="PASS" starttime="20191023 09:42:34.831" endtime="20191023 09:42:35.119"/>
 </kw>
-<kw name="${i} = 2" type="foritem">
+<kw name="${i} = 2" type="FOR ITERATION">
 <kw name="Salesforce Insert" library="cumulusci.robotframework.Salesforce">
-<doc>Inserts a Salesforce object setting fields using kwargs and returns the id</doc>
-<arguments>
+<var>${contact_id}</var>
 <arg>Contact</arg>
 <arg>FirstName=User-${i}</arg>
 <arg>LastName=${random string}</arg>
-</arguments>
-<assign>
-<var>${contact_id}</var>
-</assign>
+<doc>Inserts a Salesforce object setting fields using kwargs and returns the id</doc>
 <msg timestamp="20191023 09:42:35.119" level="INFO">Inserting Contact with values {'FirstName': 'User-2', 'LastName': 'nQpY3L2D'}</msg>
 <msg timestamp="20191023 09:42:35.447" level="INFO">Storing Contact 0034F00000SaS4IQAV to session records</msg>
 <msg timestamp="20191023 09:42:35.447" level="INFO">${contact_id} = 0034F00000SaS4IQAV</msg>
-<status status="PASS" starttime="20191023 09:42:35.119" endtime="20191023 09:42:35.447"></status>
+<status status="PASS" starttime="20191023 09:42:35.119" endtime="20191023 09:42:35.447"/>
 </kw>
-<status status="PASS" starttime="20191023 09:42:35.119" endtime="20191023 09:42:35.447"></status>
+<status status="PASS" starttime="20191023 09:42:35.119" endtime="20191023 09:42:35.447"/>
 </kw>
-<kw name="${i} = 3" type="foritem">
+<kw name="${i} = 3" type="FOR ITERATION">
 <kw name="Salesforce Insert" library="cumulusci.robotframework.Salesforce">
-<doc>Inserts a Salesforce object setting fields using kwargs and returns the id</doc>
-<arguments>
+<var>${contact_id}</var>
 <arg>Contact</arg>
 <arg>FirstName=User-${i}</arg>
 <arg>LastName=${random string}</arg>
-</arguments>
-<assign>
-<var>${contact_id}</var>
-</assign>
+<doc>Inserts a Salesforce object setting fields using kwargs and returns the id</doc>
 <msg timestamp="20191023 09:42:35.448" level="INFO">Inserting Contact with values {'FirstName': 'User-3', 'LastName': 'nQpY3L2D'}</msg>
 <msg timestamp="20191023 09:42:35.800" level="INFO">Storing Contact 0034F00000SaS4NQAV to session records</msg>
 <msg timestamp="20191023 09:42:35.800" level="INFO">${contact_id} = 0034F00000SaS4NQAV</msg>
-<status status="PASS" starttime="20191023 09:42:35.448" endtime="20191023 09:42:35.800"></status>
+<status status="PASS" starttime="20191023 09:42:35.448" endtime="20191023 09:42:35.800"/>
 </kw>
-<status status="PASS" starttime="20191023 09:42:35.447" endtime="20191023 09:42:35.800"></status>
+<status status="PASS" starttime="20191023 09:42:35.447" endtime="20191023 09:42:35.800"/>
 </kw>
-<kw name="${i} = 4" type="foritem">
+<kw name="${i} = 4" type="FOR ITERATION">
 <kw name="Salesforce Insert" library="cumulusci.robotframework.Salesforce">
-<doc>Inserts a Salesforce object setting fields using kwargs and returns the id</doc>
-<arguments>
+<var>${contact_id}</var>
 <arg>Contact</arg>
 <arg>FirstName=User-${i}</arg>
 <arg>LastName=${random string}</arg>
-</arguments>
-<assign>
-<var>${contact_id}</var>
-</assign>
+<doc>Inserts a Salesforce object setting fields using kwargs and returns the id</doc>
 <msg timestamp="20191023 09:42:35.801" level="INFO">Inserting Contact with values {'FirstName': 'User-4', 'LastName': 'nQpY3L2D'}</msg>
 <msg timestamp="20191023 09:42:36.452" level="INFO">Storing Contact 0034F00000SaS4SQAV to session records</msg>
 <msg timestamp="20191023 09:42:36.452" level="INFO">${contact_id} = 0034F00000SaS4SQAV</msg>
-<status status="PASS" starttime="20191023 09:42:35.801" endtime="20191023 09:42:36.452"></status>
+<status status="PASS" starttime="20191023 09:42:35.801" endtime="20191023 09:42:36.452"/>
 </kw>
-<status status="PASS" starttime="20191023 09:42:35.800" endtime="20191023 09:42:36.452"></status>
+<status status="PASS" starttime="20191023 09:42:35.800" endtime="20191023 09:42:36.452"/>
 </kw>
-<status status="PASS" starttime="20191023 09:42:34.070" endtime="20191023 09:42:36.452"></status>
+<status status="PASS" starttime="20191023 09:42:34.070" endtime="20191023 09:42:36.452"/>
 </kw>
 <kw name="Salesforce Query" library="cumulusci.robotframework.Salesforce">
-<doc>Constructs and runs a simple SOQL query and returns the dict results</doc>
-<arguments>
+<var>@{query}</var>
 <arg>Contact</arg>
 <arg>LastName=${random string}</arg>
-</arguments>
-<assign>
-<var>@{query}</var>
-</assign>
+<doc>Constructs and runs a simple SOQL query and returns the dict results</doc>
 <msg timestamp="20191023 09:42:36.453" level="INFO">Running SOQL Query: SELECT Id FROM Contact WHERE LastName = 'nQpY3L2D'</msg>
 <msg timestamp="20191023 09:42:36.602" level="INFO">@{query} = [ OrderedDict([('attributes', OrderedDict([('type', 'Contact'), ('url', '/services/data/v46.0/sobjects/Contact/0034F00000SaS48QAF')])), ('Id', '0034F00000SaS48QAF')]) | OrderedDict([('attributes', Ord...</msg>
-<status status="PASS" starttime="20191023 09:42:36.452" endtime="20191023 09:42:36.602"></status>
+<status status="PASS" starttime="20191023 09:42:36.452" endtime="20191023 09:42:36.602"/>
 </kw>
 <kw name="Length Should Be" library="BuiltIn">
-<doc>Verifies that the length of the given item is correct.</doc>
-<arguments>
 <arg>${query}</arg>
 <arg>5</arg>
 <arg>Expected the query to return five records, but it returned ${query}</arg>
-</arguments>
+<doc>Verifies that the length of the given item is correct.</doc>
 <msg timestamp="20191023 09:42:36.604" level="INFO">Length is 5</msg>
-<status status="PASS" starttime="20191023 09:42:36.602" endtime="20191023 09:42:36.604"></status>
+<status status="PASS" starttime="20191023 09:42:36.602" endtime="20191023 09:42:36.604"/>
 </kw>
 <kw name="Delete Session Records" library="cumulusci.robotframework.Salesforce">
 <doc>Deletes records that were created while running this test case.</doc>
@@ -1601,71 +1239,53 @@ support for overriding task options via kwargs.</doc>
 <msg timestamp="20191023 09:42:40.591" level="INFO">Deleting Contact with Id 0034F00000SaS3KQAV</msg>
 <msg timestamp="20191023 09:42:41.201" level="INFO">  Deleting Contact 0034F00000SaS2lQAF</msg>
 <msg timestamp="20191023 09:42:41.201" level="INFO">Deleting Contact with Id 0034F00000SaS2lQAF</msg>
-<status status="PASS" starttime="20191023 09:42:36.605" endtime="20191023 09:42:41.564"></status>
+<status status="PASS" starttime="20191023 09:42:36.605" endtime="20191023 09:42:41.564"/>
 </kw>
 <kw name="Salesforce Query" library="cumulusci.robotframework.Salesforce">
-<doc>Constructs and runs a simple SOQL query and returns the dict results</doc>
-<arguments>
+<var>@{query}</var>
 <arg>Contact</arg>
 <arg>LastName=${random string}</arg>
-</arguments>
-<assign>
-<var>@{query}</var>
-</assign>
+<doc>Constructs and runs a simple SOQL query and returns the dict results</doc>
 <msg timestamp="20191023 09:42:41.565" level="INFO">Running SOQL Query: SELECT Id FROM Contact WHERE LastName = 'nQpY3L2D'</msg>
 <msg timestamp="20191023 09:42:41.822" level="INFO">@{query} = [ ]</msg>
-<status status="PASS" starttime="20191023 09:42:41.564" endtime="20191023 09:42:41.823"></status>
+<status status="PASS" starttime="20191023 09:42:41.564" endtime="20191023 09:42:41.823"/>
 </kw>
 <kw name="Length Should Be" library="BuiltIn">
-<doc>Verifies that the length of the given item is correct.</doc>
-<arguments>
 <arg>${query}</arg>
 <arg>0</arg>
 <arg>Expected the query to return 0 records, but it returned ${query}</arg>
-</arguments>
+<doc>Verifies that the length of the given item is correct.</doc>
 <msg timestamp="20191023 09:42:41.824" level="INFO">Length is 0</msg>
-<status status="PASS" starttime="20191023 09:42:41.823" endtime="20191023 09:42:41.824"></status>
+<status status="PASS" starttime="20191023 09:42:41.823" endtime="20191023 09:42:41.824"/>
 </kw>
 <doc>Verify that 'Delete Session Records' deletes all session records
 This verifies that we fixed a bug which resulted in some records
 not being deleted.</doc>
-<tags>
 <tag>api</tag>
-</tags>
-<status status="PASS" starttime="20191023 09:42:27.840" endtime="20191023 09:42:41.825" critical="yes"></status>
+<status status="PASS" starttime="20191023 09:42:27.840" endtime="20191023 09:42:41.825"/>
 </test>
 <test id="s1-s2-s1-t7" name="Collection API Test">
-<kw name="Sleep" library="BuiltIn" type="setup">
-<doc>Pauses the test executed for the given time.</doc>
-<arguments>
+<kw name="Sleep" library="BuiltIn" type="SETUP">
 <arg>6</arg>
-</arguments>
+<doc>Pauses the test executed for the given time.</doc>
 <msg timestamp="20191023 09:42:47.838" level="INFO">Slept 6 seconds</msg>
-<status status="PASS" starttime="20191023 09:42:41.829" endtime="20191023 09:42:47.838"></status>
+<status status="PASS" starttime="20191023 09:42:41.829" endtime="20191023 09:42:47.838"/>
 </kw>
 <kw name="Generate Test Data" library="cumulusci.robotframework.Salesforce">
-<doc>Generate test data dictionaries. Usually used for later insertion into SF.</doc>
-<arguments>
+<var>@{objects}</var>
 <arg>Contact</arg>
 <arg>20</arg>
 <arg>FirstName=User {{number}}</arg>
 <arg>LastName={{fake.last_name}}</arg>
-</arguments>
-<assign>
-<var>@{objects}</var>
-</assign>
+<doc>Generate test data dictionaries. Usually used for later insertion into SF.</doc>
 <msg timestamp="20191023 09:42:47.887" level="INFO">@{objects} = [ {'attributes': {'type': 'Contact'}, 'FirstName': 'User 0', 'LastName': 'Murphy'} | {'attributes': {'type': 'Contact'}, 'FirstName': 'User 1', 'LastName': 'Griffin'} | {'attributes': {'type': 'Contac...</msg>
-<status status="PASS" starttime="20191023 09:42:47.838" endtime="20191023 09:42:47.887"></status>
+<status status="PASS" starttime="20191023 09:42:47.838" endtime="20191023 09:42:47.887"/>
 </kw>
 <kw name="Salesforce Collection Insert" library="cumulusci.robotframework.Salesforce">
+<var>@{records}</var>
+<arg>${objects}</arg>
 <doc>Inserts up to 200 records that were created with Generate Test Data.
 The 200 record limit is enforced by the Salesforce APIs</doc>
-<arguments>
-<arg>${objects}</arg>
-</arguments>
-<assign>
-<var>@{records}</var>
-</assign>
 <msg timestamp="20191023 09:42:49.052" level="INFO">Storing Contact 0034F00000SaS4XQAV to session records</msg>
 <msg timestamp="20191023 09:42:49.052" level="INFO">Storing Contact 0034F00000SaS4YQAV to session records</msg>
 <msg timestamp="20191023 09:42:49.052" level="INFO">Storing Contact 0034F00000SaS4ZQAV to session records</msg>
@@ -1687,520 +1307,410 @@ The 200 record limit is enforced by the Salesforce APIs</doc>
 <msg timestamp="20191023 09:42:49.053" level="INFO">Storing Contact 0034F00000SaS4pQAF to session records</msg>
 <msg timestamp="20191023 09:42:49.053" level="INFO">Storing Contact 0034F00000SaS4qQAF to session records</msg>
 <msg timestamp="20191023 09:42:49.053" level="INFO">@{records} = [ {'attributes': {'type': 'Contact'}, 'FirstName': 'User 0', 'LastName': 'Murphy', 'id': '0034F00000SaS4XQAV', ('status',): OrderedDict([('id', '0034F00000SaS4XQAV'), ('success', True), ('errors', [])...</msg>
-<status status="PASS" starttime="20191023 09:42:47.888" endtime="20191023 09:42:49.053"></status>
+<status status="PASS" starttime="20191023 09:42:47.888" endtime="20191023 09:42:49.053"/>
 </kw>
-<kw name="${record} IN [ @{records} ]" type="for">
-<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 0', 'LastName': 'Murphy', 'id': '0034F00000SaS4XQAV', ('status',): OrderedDict([('id', '0034F00000SaS4XQAV'), ('success', True), ('errors', [])])..." type="foritem">
+<kw name="${record} IN [ @{records} ]" type="FOR">
+<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 0', 'LastName': 'Murphy', 'id': '0034F00000SaS4XQAV', ('status',): OrderedDict([('id', '0034F00000SaS4XQAV'), ('success', True), ('errors', [])])..." type="FOR ITERATION">
 <kw name="Generate Random String" library="String">
-<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
-<assign>
 <var>${new_last_name}</var>
-</assign>
+<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
 <msg timestamp="20191023 09:42:49.054" level="INFO">${new_last_name} = V64kMv9d</msg>
-<status status="PASS" starttime="20191023 09:42:49.054" endtime="20191023 09:42:49.054"></status>
+<status status="PASS" starttime="20191023 09:42:49.054" endtime="20191023 09:42:49.054"/>
 </kw>
 <kw name="Set To Dictionary" library="Collections">
-<doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
-<arguments>
 <arg>${record}</arg>
 <arg>LastName</arg>
 <arg>${new_last_name}</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:42:49.054" endtime="20191023 09:42:49.054"></status>
+<doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
+<status status="PASS" starttime="20191023 09:42:49.054" endtime="20191023 09:42:49.054"/>
 </kw>
-<status status="PASS" starttime="20191023 09:42:49.053" endtime="20191023 09:42:49.054"></status>
+<status status="PASS" starttime="20191023 09:42:49.053" endtime="20191023 09:42:49.054"/>
 </kw>
-<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 1', 'LastName': 'Griffin', 'id': '0034F00000SaS4YQAV', ('status',): OrderedDict([('id', '0034F00000SaS4YQAV'), ('success', True), ('errors', [])]..." type="foritem">
+<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 1', 'LastName': 'Griffin', 'id': '0034F00000SaS4YQAV', ('status',): OrderedDict([('id', '0034F00000SaS4YQAV'), ('success', True), ('errors', [])]..." type="FOR ITERATION">
 <kw name="Generate Random String" library="String">
-<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
-<assign>
 <var>${new_last_name}</var>
-</assign>
+<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
 <msg timestamp="20191023 09:42:49.060" level="INFO">${new_last_name} = eaL68aeU</msg>
-<status status="PASS" starttime="20191023 09:42:49.055" endtime="20191023 09:42:49.060"></status>
+<status status="PASS" starttime="20191023 09:42:49.055" endtime="20191023 09:42:49.060"/>
 </kw>
 <kw name="Set To Dictionary" library="Collections">
-<doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
-<arguments>
 <arg>${record}</arg>
 <arg>LastName</arg>
 <arg>${new_last_name}</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:42:49.061" endtime="20191023 09:42:49.061"></status>
+<doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
+<status status="PASS" starttime="20191023 09:42:49.061" endtime="20191023 09:42:49.061"/>
 </kw>
-<status status="PASS" starttime="20191023 09:42:49.054" endtime="20191023 09:42:49.061"></status>
+<status status="PASS" starttime="20191023 09:42:49.054" endtime="20191023 09:42:49.061"/>
 </kw>
-<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 2', 'LastName': 'Silva', 'id': '0034F00000SaS4ZQAV', ('status',): OrderedDict([('id', '0034F00000SaS4ZQAV'), ('success', True), ('errors', [])])}" type="foritem">
+<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 2', 'LastName': 'Silva', 'id': '0034F00000SaS4ZQAV', ('status',): OrderedDict([('id', '0034F00000SaS4ZQAV'), ('success', True), ('errors', [])])}" type="FOR ITERATION">
 <kw name="Generate Random String" library="String">
-<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
-<assign>
 <var>${new_last_name}</var>
-</assign>
+<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
 <msg timestamp="20191023 09:42:49.062" level="INFO">${new_last_name} = ZNn0wA2j</msg>
-<status status="PASS" starttime="20191023 09:42:49.061" endtime="20191023 09:42:49.062"></status>
+<status status="PASS" starttime="20191023 09:42:49.061" endtime="20191023 09:42:49.062"/>
 </kw>
 <kw name="Set To Dictionary" library="Collections">
-<doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
-<arguments>
 <arg>${record}</arg>
 <arg>LastName</arg>
 <arg>${new_last_name}</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:42:49.062" endtime="20191023 09:42:49.062"></status>
+<doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
+<status status="PASS" starttime="20191023 09:42:49.062" endtime="20191023 09:42:49.062"/>
 </kw>
-<status status="PASS" starttime="20191023 09:42:49.061" endtime="20191023 09:42:49.062"></status>
+<status status="PASS" starttime="20191023 09:42:49.061" endtime="20191023 09:42:49.062"/>
 </kw>
-<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 3', 'LastName': 'Martinez', 'id': '0034F00000SaS4aQAF', ('status',): OrderedDict([('id', '0034F00000SaS4aQAF'), ('success', True), ('errors', [])..." type="foritem">
+<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 3', 'LastName': 'Martinez', 'id': '0034F00000SaS4aQAF', ('status',): OrderedDict([('id', '0034F00000SaS4aQAF'), ('success', True), ('errors', [])..." type="FOR ITERATION">
 <kw name="Generate Random String" library="String">
-<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
-<assign>
 <var>${new_last_name}</var>
-</assign>
+<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
 <msg timestamp="20191023 09:42:49.062" level="INFO">${new_last_name} = wYdA4CNM</msg>
-<status status="PASS" starttime="20191023 09:42:49.062" endtime="20191023 09:42:49.062"></status>
+<status status="PASS" starttime="20191023 09:42:49.062" endtime="20191023 09:42:49.062"/>
 </kw>
 <kw name="Set To Dictionary" library="Collections">
-<doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
-<arguments>
 <arg>${record}</arg>
 <arg>LastName</arg>
 <arg>${new_last_name}</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:42:49.062" endtime="20191023 09:42:49.063"></status>
+<doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
+<status status="PASS" starttime="20191023 09:42:49.062" endtime="20191023 09:42:49.063"/>
 </kw>
-<status status="PASS" starttime="20191023 09:42:49.062" endtime="20191023 09:42:49.063"></status>
+<status status="PASS" starttime="20191023 09:42:49.062" endtime="20191023 09:42:49.063"/>
 </kw>
-<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 4', 'LastName': 'Dunn', 'id': '0034F00000SaS4bQAF', ('status',): OrderedDict([('id', '0034F00000SaS4bQAF'), ('success', True), ('errors', [])])}" type="foritem">
+<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 4', 'LastName': 'Dunn', 'id': '0034F00000SaS4bQAF', ('status',): OrderedDict([('id', '0034F00000SaS4bQAF'), ('success', True), ('errors', [])])}" type="FOR ITERATION">
 <kw name="Generate Random String" library="String">
-<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
-<assign>
 <var>${new_last_name}</var>
-</assign>
+<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
 <msg timestamp="20191023 09:42:49.063" level="INFO">${new_last_name} = QqOquSfG</msg>
-<status status="PASS" starttime="20191023 09:42:49.063" endtime="20191023 09:42:49.063"></status>
+<status status="PASS" starttime="20191023 09:42:49.063" endtime="20191023 09:42:49.063"/>
 </kw>
 <kw name="Set To Dictionary" library="Collections">
-<doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
-<arguments>
 <arg>${record}</arg>
 <arg>LastName</arg>
 <arg>${new_last_name}</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:42:49.063" endtime="20191023 09:42:49.063"></status>
+<doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
+<status status="PASS" starttime="20191023 09:42:49.063" endtime="20191023 09:42:49.063"/>
 </kw>
-<status status="PASS" starttime="20191023 09:42:49.063" endtime="20191023 09:42:49.064"></status>
+<status status="PASS" starttime="20191023 09:42:49.063" endtime="20191023 09:42:49.064"/>
 </kw>
-<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 5', 'LastName': 'Chase', 'id': '0034F00000SaS4cQAF', ('status',): OrderedDict([('id', '0034F00000SaS4cQAF'), ('success', True), ('errors', [])])}" type="foritem">
+<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 5', 'LastName': 'Chase', 'id': '0034F00000SaS4cQAF', ('status',): OrderedDict([('id', '0034F00000SaS4cQAF'), ('success', True), ('errors', [])])}" type="FOR ITERATION">
 <kw name="Generate Random String" library="String">
-<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
-<assign>
 <var>${new_last_name}</var>
-</assign>
+<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
 <msg timestamp="20191023 09:42:49.064" level="INFO">${new_last_name} = 5aRsoLZn</msg>
-<status status="PASS" starttime="20191023 09:42:49.064" endtime="20191023 09:42:49.064"></status>
+<status status="PASS" starttime="20191023 09:42:49.064" endtime="20191023 09:42:49.064"/>
 </kw>
 <kw name="Set To Dictionary" library="Collections">
-<doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
-<arguments>
 <arg>${record}</arg>
 <arg>LastName</arg>
 <arg>${new_last_name}</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:42:49.065" endtime="20191023 09:42:49.065"></status>
+<doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
+<status status="PASS" starttime="20191023 09:42:49.065" endtime="20191023 09:42:49.065"/>
 </kw>
-<status status="PASS" starttime="20191023 09:42:49.064" endtime="20191023 09:42:49.065"></status>
+<status status="PASS" starttime="20191023 09:42:49.064" endtime="20191023 09:42:49.065"/>
 </kw>
-<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 6', 'LastName': 'Miller', 'id': '0034F00000SaS4dQAF', ('status',): OrderedDict([('id', '0034F00000SaS4dQAF'), ('success', True), ('errors', [])])..." type="foritem">
+<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 6', 'LastName': 'Miller', 'id': '0034F00000SaS4dQAF', ('status',): OrderedDict([('id', '0034F00000SaS4dQAF'), ('success', True), ('errors', [])])..." type="FOR ITERATION">
 <kw name="Generate Random String" library="String">
-<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
-<assign>
 <var>${new_last_name}</var>
-</assign>
+<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
 <msg timestamp="20191023 09:42:49.066" level="INFO">${new_last_name} = N9hqDM17</msg>
-<status status="PASS" starttime="20191023 09:42:49.065" endtime="20191023 09:42:49.066"></status>
+<status status="PASS" starttime="20191023 09:42:49.065" endtime="20191023 09:42:49.066"/>
 </kw>
 <kw name="Set To Dictionary" library="Collections">
-<doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
-<arguments>
 <arg>${record}</arg>
 <arg>LastName</arg>
 <arg>${new_last_name}</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:42:49.066" endtime="20191023 09:42:49.067"></status>
+<doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
+<status status="PASS" starttime="20191023 09:42:49.066" endtime="20191023 09:42:49.067"/>
 </kw>
-<status status="PASS" starttime="20191023 09:42:49.065" endtime="20191023 09:42:49.067"></status>
+<status status="PASS" starttime="20191023 09:42:49.065" endtime="20191023 09:42:49.067"/>
 </kw>
-<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 7', 'LastName': 'Wagner', 'id': '0034F00000SaS4eQAF', ('status',): OrderedDict([('id', '0034F00000SaS4eQAF'), ('success', True), ('errors', [])])..." type="foritem">
+<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 7', 'LastName': 'Wagner', 'id': '0034F00000SaS4eQAF', ('status',): OrderedDict([('id', '0034F00000SaS4eQAF'), ('success', True), ('errors', [])])..." type="FOR ITERATION">
 <kw name="Generate Random String" library="String">
-<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
-<assign>
 <var>${new_last_name}</var>
-</assign>
+<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
 <msg timestamp="20191023 09:42:49.067" level="INFO">${new_last_name} = qdYpQ3dG</msg>
-<status status="PASS" starttime="20191023 09:42:49.067" endtime="20191023 09:42:49.068"></status>
+<status status="PASS" starttime="20191023 09:42:49.067" endtime="20191023 09:42:49.068"/>
 </kw>
 <kw name="Set To Dictionary" library="Collections">
-<doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
-<arguments>
 <arg>${record}</arg>
 <arg>LastName</arg>
 <arg>${new_last_name}</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:42:49.068" endtime="20191023 09:42:49.068"></status>
+<doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
+<status status="PASS" starttime="20191023 09:42:49.068" endtime="20191023 09:42:49.068"/>
 </kw>
-<status status="PASS" starttime="20191023 09:42:49.067" endtime="20191023 09:42:49.068"></status>
+<status status="PASS" starttime="20191023 09:42:49.067" endtime="20191023 09:42:49.068"/>
 </kw>
-<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 8', 'LastName': 'Hansen', 'id': '0034F00000SaS4fQAF', ('status',): OrderedDict([('id', '0034F00000SaS4fQAF'), ('success', True), ('errors', [])])..." type="foritem">
+<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 8', 'LastName': 'Hansen', 'id': '0034F00000SaS4fQAF', ('status',): OrderedDict([('id', '0034F00000SaS4fQAF'), ('success', True), ('errors', [])])..." type="FOR ITERATION">
 <kw name="Generate Random String" library="String">
-<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
-<assign>
 <var>${new_last_name}</var>
-</assign>
+<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
 <msg timestamp="20191023 09:42:49.069" level="INFO">${new_last_name} = vfFR8WZp</msg>
-<status status="PASS" starttime="20191023 09:42:49.069" endtime="20191023 09:42:49.069"></status>
+<status status="PASS" starttime="20191023 09:42:49.069" endtime="20191023 09:42:49.069"/>
 </kw>
 <kw name="Set To Dictionary" library="Collections">
-<doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
-<arguments>
 <arg>${record}</arg>
 <arg>LastName</arg>
 <arg>${new_last_name}</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:42:49.069" endtime="20191023 09:42:49.069"></status>
+<doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
+<status status="PASS" starttime="20191023 09:42:49.069" endtime="20191023 09:42:49.069"/>
 </kw>
-<status status="PASS" starttime="20191023 09:42:49.068" endtime="20191023 09:42:49.070"></status>
+<status status="PASS" starttime="20191023 09:42:49.068" endtime="20191023 09:42:49.070"/>
 </kw>
-<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 9', 'LastName': 'Marks', 'id': '0034F00000SaS4gQAF', ('status',): OrderedDict([('id', '0034F00000SaS4gQAF'), ('success', True), ('errors', [])])}" type="foritem">
+<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 9', 'LastName': 'Marks', 'id': '0034F00000SaS4gQAF', ('status',): OrderedDict([('id', '0034F00000SaS4gQAF'), ('success', True), ('errors', [])])}" type="FOR ITERATION">
 <kw name="Generate Random String" library="String">
-<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
-<assign>
 <var>${new_last_name}</var>
-</assign>
+<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
 <msg timestamp="20191023 09:42:49.070" level="INFO">${new_last_name} = hMwUn0TH</msg>
-<status status="PASS" starttime="20191023 09:42:49.070" endtime="20191023 09:42:49.070"></status>
+<status status="PASS" starttime="20191023 09:42:49.070" endtime="20191023 09:42:49.070"/>
 </kw>
 <kw name="Set To Dictionary" library="Collections">
-<doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
-<arguments>
 <arg>${record}</arg>
 <arg>LastName</arg>
 <arg>${new_last_name}</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:42:49.070" endtime="20191023 09:42:49.071"></status>
+<doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
+<status status="PASS" starttime="20191023 09:42:49.070" endtime="20191023 09:42:49.071"/>
 </kw>
-<status status="PASS" starttime="20191023 09:42:49.070" endtime="20191023 09:42:49.071"></status>
+<status status="PASS" starttime="20191023 09:42:49.070" endtime="20191023 09:42:49.071"/>
 </kw>
-<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 10', 'LastName': 'Peck', 'id': '0034F00000SaS4hQAF', ('status',): OrderedDict([('id', '0034F00000SaS4hQAF'), ('success', True), ('errors', [])])}" type="foritem">
+<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 10', 'LastName': 'Peck', 'id': '0034F00000SaS4hQAF', ('status',): OrderedDict([('id', '0034F00000SaS4hQAF'), ('success', True), ('errors', [])])}" type="FOR ITERATION">
 <kw name="Generate Random String" library="String">
-<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
-<assign>
 <var>${new_last_name}</var>
-</assign>
+<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
 <msg timestamp="20191023 09:42:49.071" level="INFO">${new_last_name} = UVR0oysz</msg>
-<status status="PASS" starttime="20191023 09:42:49.071" endtime="20191023 09:42:49.071"></status>
+<status status="PASS" starttime="20191023 09:42:49.071" endtime="20191023 09:42:49.071"/>
 </kw>
 <kw name="Set To Dictionary" library="Collections">
-<doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
-<arguments>
 <arg>${record}</arg>
 <arg>LastName</arg>
 <arg>${new_last_name}</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:42:49.072" endtime="20191023 09:42:49.072"></status>
+<doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
+<status status="PASS" starttime="20191023 09:42:49.072" endtime="20191023 09:42:49.072"/>
 </kw>
-<status status="PASS" starttime="20191023 09:42:49.071" endtime="20191023 09:42:49.072"></status>
+<status status="PASS" starttime="20191023 09:42:49.071" endtime="20191023 09:42:49.072"/>
 </kw>
-<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 11', 'LastName': 'Bennett', 'id': '0034F00000SaS4iQAF', ('status',): OrderedDict([('id', '0034F00000SaS4iQAF'), ('success', True), ('errors', [])..." type="foritem">
+<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 11', 'LastName': 'Bennett', 'id': '0034F00000SaS4iQAF', ('status',): OrderedDict([('id', '0034F00000SaS4iQAF'), ('success', True), ('errors', [])..." type="FOR ITERATION">
 <kw name="Generate Random String" library="String">
-<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
-<assign>
 <var>${new_last_name}</var>
-</assign>
+<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
 <msg timestamp="20191023 09:42:49.073" level="INFO">${new_last_name} = X8EMiOGT</msg>
-<status status="PASS" starttime="20191023 09:42:49.072" endtime="20191023 09:42:49.073"></status>
+<status status="PASS" starttime="20191023 09:42:49.072" endtime="20191023 09:42:49.073"/>
 </kw>
 <kw name="Set To Dictionary" library="Collections">
-<doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
-<arguments>
 <arg>${record}</arg>
 <arg>LastName</arg>
 <arg>${new_last_name}</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:42:49.073" endtime="20191023 09:42:49.073"></status>
+<doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
+<status status="PASS" starttime="20191023 09:42:49.073" endtime="20191023 09:42:49.073"/>
 </kw>
-<status status="PASS" starttime="20191023 09:42:49.072" endtime="20191023 09:42:49.073"></status>
+<status status="PASS" starttime="20191023 09:42:49.072" endtime="20191023 09:42:49.073"/>
 </kw>
-<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 12', 'LastName': 'Lopez', 'id': '0034F00000SaS4jQAF', ('status',): OrderedDict([('id', '0034F00000SaS4jQAF'), ('success', True), ('errors', [])])..." type="foritem">
+<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 12', 'LastName': 'Lopez', 'id': '0034F00000SaS4jQAF', ('status',): OrderedDict([('id', '0034F00000SaS4jQAF'), ('success', True), ('errors', [])])..." type="FOR ITERATION">
 <kw name="Generate Random String" library="String">
-<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
-<assign>
 <var>${new_last_name}</var>
-</assign>
+<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
 <msg timestamp="20191023 09:42:49.074" level="INFO">${new_last_name} = 2SyU8Ktf</msg>
-<status status="PASS" starttime="20191023 09:42:49.073" endtime="20191023 09:42:49.074"></status>
+<status status="PASS" starttime="20191023 09:42:49.073" endtime="20191023 09:42:49.074"/>
 </kw>
 <kw name="Set To Dictionary" library="Collections">
-<doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
-<arguments>
 <arg>${record}</arg>
 <arg>LastName</arg>
 <arg>${new_last_name}</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:42:49.074" endtime="20191023 09:42:49.074"></status>
+<doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
+<status status="PASS" starttime="20191023 09:42:49.074" endtime="20191023 09:42:49.074"/>
 </kw>
-<status status="PASS" starttime="20191023 09:42:49.073" endtime="20191023 09:42:49.074"></status>
+<status status="PASS" starttime="20191023 09:42:49.073" endtime="20191023 09:42:49.074"/>
 </kw>
-<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 13', 'LastName': 'Mitchell', 'id': '0034F00000SaS4kQAF', ('status',): OrderedDict([('id', '0034F00000SaS4kQAF'), ('success', True), ('errors', []..." type="foritem">
+<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 13', 'LastName': 'Mitchell', 'id': '0034F00000SaS4kQAF', ('status',): OrderedDict([('id', '0034F00000SaS4kQAF'), ('success', True), ('errors', []..." type="FOR ITERATION">
 <kw name="Generate Random String" library="String">
-<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
-<assign>
 <var>${new_last_name}</var>
-</assign>
+<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
 <msg timestamp="20191023 09:42:49.075" level="INFO">${new_last_name} = dF6tKIKP</msg>
-<status status="PASS" starttime="20191023 09:42:49.074" endtime="20191023 09:42:49.075"></status>
+<status status="PASS" starttime="20191023 09:42:49.074" endtime="20191023 09:42:49.075"/>
 </kw>
 <kw name="Set To Dictionary" library="Collections">
-<doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
-<arguments>
 <arg>${record}</arg>
 <arg>LastName</arg>
 <arg>${new_last_name}</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:42:49.075" endtime="20191023 09:42:49.075"></status>
+<doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
+<status status="PASS" starttime="20191023 09:42:49.075" endtime="20191023 09:42:49.075"/>
 </kw>
-<status status="PASS" starttime="20191023 09:42:49.074" endtime="20191023 09:42:49.075"></status>
+<status status="PASS" starttime="20191023 09:42:49.074" endtime="20191023 09:42:49.075"/>
 </kw>
-<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 14', 'LastName': 'Goodman', 'id': '0034F00000SaS4lQAF', ('status',): OrderedDict([('id', '0034F00000SaS4lQAF'), ('success', True), ('errors', [])..." type="foritem">
+<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 14', 'LastName': 'Goodman', 'id': '0034F00000SaS4lQAF', ('status',): OrderedDict([('id', '0034F00000SaS4lQAF'), ('success', True), ('errors', [])..." type="FOR ITERATION">
 <kw name="Generate Random String" library="String">
-<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
-<assign>
 <var>${new_last_name}</var>
-</assign>
+<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
 <msg timestamp="20191023 09:42:49.076" level="INFO">${new_last_name} = PpNnPDTt</msg>
-<status status="PASS" starttime="20191023 09:42:49.075" endtime="20191023 09:42:49.076"></status>
+<status status="PASS" starttime="20191023 09:42:49.075" endtime="20191023 09:42:49.076"/>
 </kw>
 <kw name="Set To Dictionary" library="Collections">
-<doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
-<arguments>
 <arg>${record}</arg>
 <arg>LastName</arg>
 <arg>${new_last_name}</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:42:49.076" endtime="20191023 09:42:49.077"></status>
+<doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
+<status status="PASS" starttime="20191023 09:42:49.076" endtime="20191023 09:42:49.077"/>
 </kw>
-<status status="PASS" starttime="20191023 09:42:49.075" endtime="20191023 09:42:49.077"></status>
+<status status="PASS" starttime="20191023 09:42:49.075" endtime="20191023 09:42:49.077"/>
 </kw>
-<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 15', 'LastName': 'Boyd', 'id': '0034F00000SaS4mQAF', ('status',): OrderedDict([('id', '0034F00000SaS4mQAF'), ('success', True), ('errors', [])])}" type="foritem">
+<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 15', 'LastName': 'Boyd', 'id': '0034F00000SaS4mQAF', ('status',): OrderedDict([('id', '0034F00000SaS4mQAF'), ('success', True), ('errors', [])])}" type="FOR ITERATION">
 <kw name="Generate Random String" library="String">
-<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
-<assign>
 <var>${new_last_name}</var>
-</assign>
+<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
 <msg timestamp="20191023 09:42:49.078" level="INFO">${new_last_name} = tLRSCvkG</msg>
-<status status="PASS" starttime="20191023 09:42:49.077" endtime="20191023 09:42:49.078"></status>
+<status status="PASS" starttime="20191023 09:42:49.077" endtime="20191023 09:42:49.078"/>
 </kw>
 <kw name="Set To Dictionary" library="Collections">
-<doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
-<arguments>
 <arg>${record}</arg>
 <arg>LastName</arg>
 <arg>${new_last_name}</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:42:49.078" endtime="20191023 09:42:49.078"></status>
+<doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
+<status status="PASS" starttime="20191023 09:42:49.078" endtime="20191023 09:42:49.078"/>
 </kw>
-<status status="PASS" starttime="20191023 09:42:49.077" endtime="20191023 09:42:49.079"></status>
+<status status="PASS" starttime="20191023 09:42:49.077" endtime="20191023 09:42:49.079"/>
 </kw>
-<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 16', 'LastName': 'Davis', 'id': '0034F00000SaS4nQAF', ('status',): OrderedDict([('id', '0034F00000SaS4nQAF'), ('success', True), ('errors', [])])..." type="foritem">
+<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 16', 'LastName': 'Davis', 'id': '0034F00000SaS4nQAF', ('status',): OrderedDict([('id', '0034F00000SaS4nQAF'), ('success', True), ('errors', [])])..." type="FOR ITERATION">
 <kw name="Generate Random String" library="String">
-<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
-<assign>
 <var>${new_last_name}</var>
-</assign>
+<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
 <msg timestamp="20191023 09:42:49.079" level="INFO">${new_last_name} = GVNDvj57</msg>
-<status status="PASS" starttime="20191023 09:42:49.079" endtime="20191023 09:42:49.079"></status>
+<status status="PASS" starttime="20191023 09:42:49.079" endtime="20191023 09:42:49.079"/>
 </kw>
 <kw name="Set To Dictionary" library="Collections">
-<doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
-<arguments>
 <arg>${record}</arg>
 <arg>LastName</arg>
 <arg>${new_last_name}</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:42:49.079" endtime="20191023 09:42:49.080"></status>
+<doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
+<status status="PASS" starttime="20191023 09:42:49.079" endtime="20191023 09:42:49.080"/>
 </kw>
-<status status="PASS" starttime="20191023 09:42:49.079" endtime="20191023 09:42:49.080"></status>
+<status status="PASS" starttime="20191023 09:42:49.079" endtime="20191023 09:42:49.080"/>
 </kw>
-<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 17', 'LastName': 'Lawrence', 'id': '0034F00000SaS4oQAF', ('status',): OrderedDict([('id', '0034F00000SaS4oQAF'), ('success', True), ('errors', []..." type="foritem">
+<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 17', 'LastName': 'Lawrence', 'id': '0034F00000SaS4oQAF', ('status',): OrderedDict([('id', '0034F00000SaS4oQAF'), ('success', True), ('errors', []..." type="FOR ITERATION">
 <kw name="Generate Random String" library="String">
-<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
-<assign>
 <var>${new_last_name}</var>
-</assign>
+<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
 <msg timestamp="20191023 09:42:49.081" level="INFO">${new_last_name} = Pq3iap2e</msg>
-<status status="PASS" starttime="20191023 09:42:49.081" endtime="20191023 09:42:49.081"></status>
+<status status="PASS" starttime="20191023 09:42:49.081" endtime="20191023 09:42:49.081"/>
 </kw>
 <kw name="Set To Dictionary" library="Collections">
-<doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
-<arguments>
 <arg>${record}</arg>
 <arg>LastName</arg>
 <arg>${new_last_name}</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:42:49.082" endtime="20191023 09:42:49.082"></status>
+<doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
+<status status="PASS" starttime="20191023 09:42:49.082" endtime="20191023 09:42:49.082"/>
 </kw>
-<status status="PASS" starttime="20191023 09:42:49.080" endtime="20191023 09:42:49.082"></status>
+<status status="PASS" starttime="20191023 09:42:49.080" endtime="20191023 09:42:49.082"/>
 </kw>
-<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 18', 'LastName': 'Jones', 'id': '0034F00000SaS4pQAF', ('status',): OrderedDict([('id', '0034F00000SaS4pQAF'), ('success', True), ('errors', [])])..." type="foritem">
+<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 18', 'LastName': 'Jones', 'id': '0034F00000SaS4pQAF', ('status',): OrderedDict([('id', '0034F00000SaS4pQAF'), ('success', True), ('errors', [])])..." type="FOR ITERATION">
 <kw name="Generate Random String" library="String">
-<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
-<assign>
 <var>${new_last_name}</var>
-</assign>
+<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
 <msg timestamp="20191023 09:42:49.084" level="INFO">${new_last_name} = DKDzEqXS</msg>
-<status status="PASS" starttime="20191023 09:42:49.083" endtime="20191023 09:42:49.085"></status>
+<status status="PASS" starttime="20191023 09:42:49.083" endtime="20191023 09:42:49.085"/>
 </kw>
 <kw name="Set To Dictionary" library="Collections">
-<doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
-<arguments>
 <arg>${record}</arg>
 <arg>LastName</arg>
 <arg>${new_last_name}</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:42:49.085" endtime="20191023 09:42:49.085"></status>
+<doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
+<status status="PASS" starttime="20191023 09:42:49.085" endtime="20191023 09:42:49.085"/>
 </kw>
-<status status="PASS" starttime="20191023 09:42:49.082" endtime="20191023 09:42:49.085"></status>
+<status status="PASS" starttime="20191023 09:42:49.082" endtime="20191023 09:42:49.085"/>
 </kw>
-<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 19', 'LastName': 'Foster', 'id': '0034F00000SaS4qQAF', ('status',): OrderedDict([('id', '0034F00000SaS4qQAF'), ('success', True), ('errors', [])]..." type="foritem">
+<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 19', 'LastName': 'Foster', 'id': '0034F00000SaS4qQAF', ('status',): OrderedDict([('id', '0034F00000SaS4qQAF'), ('success', True), ('errors', [])]..." type="FOR ITERATION">
 <kw name="Generate Random String" library="String">
-<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
-<assign>
 <var>${new_last_name}</var>
-</assign>
+<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
 <msg timestamp="20191023 09:42:49.090" level="INFO">${new_last_name} = ezFvARbq</msg>
-<status status="PASS" starttime="20191023 09:42:49.085" endtime="20191023 09:42:49.090"></status>
+<status status="PASS" starttime="20191023 09:42:49.085" endtime="20191023 09:42:49.090"/>
 </kw>
 <kw name="Set To Dictionary" library="Collections">
-<doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
-<arguments>
 <arg>${record}</arg>
 <arg>LastName</arg>
 <arg>${new_last_name}</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:42:49.094" endtime="20191023 09:42:49.095"></status>
+<doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
+<status status="PASS" starttime="20191023 09:42:49.094" endtime="20191023 09:42:49.095"/>
 </kw>
-<status status="PASS" starttime="20191023 09:42:49.085" endtime="20191023 09:42:49.095"></status>
+<status status="PASS" starttime="20191023 09:42:49.085" endtime="20191023 09:42:49.095"/>
 </kw>
-<status status="PASS" starttime="20191023 09:42:49.053" endtime="20191023 09:42:49.095"></status>
+<status status="PASS" starttime="20191023 09:42:49.053" endtime="20191023 09:42:49.095"/>
 </kw>
 <kw name="Salesforce Collection Update" library="cumulusci.robotframework.Salesforce">
-<doc>Updates up to 200 records described as Robot/Python dictionaries</doc>
-<arguments>
 <arg>${records}</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:42:49.095" endtime="20191023 09:42:49.735"></status>
+<doc>Updates up to 200 records described as Robot/Python dictionaries</doc>
+<status status="PASS" starttime="20191023 09:42:49.095" endtime="20191023 09:42:49.735"/>
 </kw>
-<tags>
 <tag>api</tag>
-</tags>
-<status status="PASS" starttime="20191023 09:42:41.826" endtime="20191023 09:42:49.736" critical="yes"></status>
+<status status="PASS" starttime="20191023 09:42:41.826" endtime="20191023 09:42:49.736"/>
 </test>
 <test id="s1-s2-s1-t8" name="Collection API Errors Test">
-<kw name="Sleep" library="BuiltIn" type="setup">
-<doc>Pauses the test executed for the given time.</doc>
-<arguments>
+<kw name="Sleep" library="BuiltIn" type="SETUP">
 <arg>6</arg>
-</arguments>
+<doc>Pauses the test executed for the given time.</doc>
 <msg timestamp="20191023 09:42:55.739" level="INFO">Slept 6 seconds</msg>
-<status status="PASS" starttime="20191023 09:42:49.738" endtime="20191023 09:42:55.739"></status>
+<status status="PASS" starttime="20191023 09:42:49.738" endtime="20191023 09:42:55.739"/>
 </kw>
 <kw name="Generate Test Data" library="cumulusci.robotframework.Salesforce">
-<doc>Generate test data dictionaries. Usually used for later insertion into SF.</doc>
-<arguments>
+<var>@{objects}</var>
 <arg>Contact</arg>
 <arg>20</arg>
 <arg>FirstName=User {{number}}</arg>
 <arg>LastName={{fake.last_name}}</arg>
 <arg>Xyzzy=qwertz</arg>
-</arguments>
-<assign>
-<var>@{objects}</var>
-</assign>
+<doc>Generate test data dictionaries. Usually used for later insertion into SF.</doc>
 <msg timestamp="20191023 09:42:55.776" level="INFO">@{objects} = [ {'attributes': {'type': 'Contact'}, 'FirstName': 'User 0', 'LastName': 'Bates', 'Xyzzy': 'qwertz'} | {'attributes': {'type': 'Contact'}, 'FirstName': 'User 1', 'LastName': 'Raymond', 'Xyzzy': 'qwert...</msg>
-<status status="PASS" starttime="20191023 09:42:55.740" endtime="20191023 09:42:55.776"></status>
+<status status="PASS" starttime="20191023 09:42:55.740" endtime="20191023 09:42:55.776"/>
 </kw>
 <kw name="Run Keyword And Expect Error" library="BuiltIn">
-<doc>Runs the keyword and checks that the expected error occurred.</doc>
-<arguments>
 <arg>SalesforceMalformedRequest*</arg>
 <arg>Salesforce Collection Insert</arg>
 <arg>${objects}</arg>
-</arguments>
+<doc>Runs the keyword and checks that the expected error occurred.</doc>
 <kw name="Salesforce Collection Insert" library="cumulusci.robotframework.Salesforce">
+<arg>${objects}</arg>
 <doc>Inserts up to 200 records that were created with Generate Test Data.
 The 200 record limit is enforced by the Salesforce APIs</doc>
-<arguments>
-<arg>${objects}</arg>
-</arguments>
 <msg timestamp="20191023 09:42:55.938" level="FAIL">SalesforceMalformedRequest: Malformed request https://efficiency-fun-590-dev-ed.cs93.my.salesforce.com/services/data/v46.0/composite/sobjects. Response content: [{'message': "No such column 'Xyzzy' on sobject of type Contact", 'errorCode': 'INVALID_FIELD'}]</msg>
-<status status="FAIL" starttime="20191023 09:42:55.777" endtime="20191023 09:42:55.938"></status>
+<status status="FAIL" starttime="20191023 09:42:55.777" endtime="20191023 09:42:55.938"/>
 </kw>
-<status status="PASS" starttime="20191023 09:42:55.777" endtime="20191023 09:42:55.939"></status>
+<status status="PASS" starttime="20191023 09:42:55.777" endtime="20191023 09:42:55.939"/>
 </kw>
 <kw name="Generate Test Data" library="cumulusci.robotframework.Salesforce">
-<doc>Generate test data dictionaries. Usually used for later insertion into SF.</doc>
-<arguments>
+<var>@{objects}</var>
 <arg>Contact</arg>
 <arg>20</arg>
 <arg>FirstName=User {{number}}</arg>
 <arg>LastName=</arg>
-</arguments>
-<assign>
-<var>@{objects}</var>
-</assign>
+<doc>Generate test data dictionaries. Usually used for later insertion into SF.</doc>
 <msg timestamp="20191023 09:42:55.958" level="INFO">@{objects} = [ {'attributes': {'type': 'Contact'}, 'FirstName': 'User 0', 'LastName': ''} | {'attributes': {'type': 'Contact'}, 'FirstName': 'User 1', 'LastName': ''} | {'attributes': {'type': 'Contact'}, 'FirstNa...</msg>
-<status status="PASS" starttime="20191023 09:42:55.940" endtime="20191023 09:42:55.958"></status>
+<status status="PASS" starttime="20191023 09:42:55.940" endtime="20191023 09:42:55.958"/>
 </kw>
 <kw name="Run Keyword And Expect Error" library="BuiltIn">
-<doc>Runs the keyword and checks that the expected error occurred.</doc>
-<arguments>
 <arg>Error*</arg>
 <arg>Salesforce Collection Insert</arg>
 <arg>${objects}</arg>
-</arguments>
+<doc>Runs the keyword and checks that the expected error occurred.</doc>
 <kw name="Salesforce Collection Insert" library="cumulusci.robotframework.Salesforce">
+<arg>${objects}</arg>
 <doc>Inserts up to 200 records that were created with Generate Test Data.
 The 200 record limit is enforced by the Salesforce APIs</doc>
-<arguments>
-<arg>${objects}</arg>
-</arguments>
 <msg timestamp="20191023 09:42:56.209" level="FAIL">Error on Object 0: OrderedDict([('success', False), ('errors', [OrderedDict([('statusCode', 'REQUIRED_FIELD_MISSING'), ('message', 'Required fields are missing: [LastName]'), ('fields', ['LastName'])])])]) : {'attributes': {'type': 'Contact'}, 'FirstName': 'User 0', 'LastName': ''}</msg>
-<status status="FAIL" starttime="20191023 09:42:55.959" endtime="20191023 09:42:56.209"></status>
+<status status="FAIL" starttime="20191023 09:42:55.959" endtime="20191023 09:42:56.209"/>
 </kw>
-<status status="PASS" starttime="20191023 09:42:55.958" endtime="20191023 09:42:56.209"></status>
+<status status="PASS" starttime="20191023 09:42:55.958" endtime="20191023 09:42:56.209"/>
 </kw>
 <kw name="Generate Test Data" library="cumulusci.robotframework.Salesforce">
-<doc>Generate test data dictionaries. Usually used for later insertion into SF.</doc>
-<arguments>
+<var>@{objects}</var>
 <arg>Contact</arg>
 <arg>20</arg>
 <arg>FirstName=User {{number}}</arg>
 <arg>LastName={{fake.last_name}}</arg>
-</arguments>
-<assign>
-<var>@{objects}</var>
-</assign>
+<doc>Generate test data dictionaries. Usually used for later insertion into SF.</doc>
 <msg timestamp="20191023 09:42:56.233" level="INFO">@{objects} = [ {'attributes': {'type': 'Contact'}, 'FirstName': 'User 0', 'LastName': 'Gilbert'} | {'attributes': {'type': 'Contact'}, 'FirstName': 'User 1', 'LastName': 'Richardson'} | {'attributes': {'type': 'Co...</msg>
-<status status="PASS" starttime="20191023 09:42:56.209" endtime="20191023 09:42:56.233"></status>
+<status status="PASS" starttime="20191023 09:42:56.209" endtime="20191023 09:42:56.233"/>
 </kw>
 <kw name="Salesforce Collection Insert" library="cumulusci.robotframework.Salesforce">
+<var>${records}</var>
+<arg>${objects}</arg>
 <doc>Inserts up to 200 records that were created with Generate Test Data.
 The 200 record limit is enforced by the Salesforce APIs</doc>
-<arguments>
-<arg>${objects}</arg>
-</arguments>
-<assign>
-<var>${records}</var>
-</assign>
 <msg timestamp="20191023 09:42:56.710" level="INFO">Storing Contact 0034F00000SaS4rQAF to session records</msg>
 <msg timestamp="20191023 09:42:56.710" level="INFO">Storing Contact 0034F00000SaS4sQAF to session records</msg>
 <msg timestamp="20191023 09:42:56.710" level="INFO">Storing Contact 0034F00000SaS4tQAF to session records</msg>
@@ -2222,274 +1732,228 @@ The 200 record limit is enforced by the Salesforce APIs</doc>
 <msg timestamp="20191023 09:42:56.712" level="INFO">Storing Contact 0034F00000SaS59QAF to session records</msg>
 <msg timestamp="20191023 09:42:56.712" level="INFO">Storing Contact 0034F00000SaS5AQAV to session records</msg>
 <msg timestamp="20191023 09:42:56.712" level="INFO">${records} = [{'attributes': {'type': 'Contact'}, 'FirstName': 'User 0', 'LastName': 'Gilbert', 'id': '0034F00000SaS4rQAF', ('status',): OrderedDict([('id', '0034F00000SaS4rQAF'), ('success', True), ('errors', [])...</msg>
-<status status="PASS" starttime="20191023 09:42:56.233" endtime="20191023 09:42:56.712"></status>
+<status status="PASS" starttime="20191023 09:42:56.233" endtime="20191023 09:42:56.712"/>
 </kw>
-<kw name="${record} IN [ @{records} ]" type="for">
-<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 0', 'LastName': 'Gilbert', 'id': '0034F00000SaS4rQAF', ('status',): OrderedDict([('id', '0034F00000SaS4rQAF'), ('success', True), ('errors', [])]..." type="foritem">
+<kw name="${record} IN [ @{records} ]" type="FOR">
+<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 0', 'LastName': 'Gilbert', 'id': '0034F00000SaS4rQAF', ('status',): OrderedDict([('id', '0034F00000SaS4rQAF'), ('success', True), ('errors', [])]..." type="FOR ITERATION">
 <kw name="Set To Dictionary" library="Collections">
-<doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
-<arguments>
 <arg>${record}</arg>
 <arg>Age</arg>
 <arg>Iron</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:42:56.713" endtime="20191023 09:42:56.713"></status>
-</kw>
-<status status="PASS" starttime="20191023 09:42:56.713" endtime="20191023 09:42:56.713"></status>
-</kw>
-<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 1', 'LastName': 'Richardson', 'id': '0034F00000SaS4sQAF', ('status',): OrderedDict([('id', '0034F00000SaS4sQAF'), ('success', True), ('errors', [..." type="foritem">
-<kw name="Set To Dictionary" library="Collections">
 <doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
-<arguments>
+<status status="PASS" starttime="20191023 09:42:56.713" endtime="20191023 09:42:56.713"/>
+</kw>
+<status status="PASS" starttime="20191023 09:42:56.713" endtime="20191023 09:42:56.713"/>
+</kw>
+<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 1', 'LastName': 'Richardson', 'id': '0034F00000SaS4sQAF', ('status',): OrderedDict([('id', '0034F00000SaS4sQAF'), ('success', True), ('errors', [..." type="FOR ITERATION">
+<kw name="Set To Dictionary" library="Collections">
 <arg>${record}</arg>
 <arg>Age</arg>
 <arg>Iron</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:42:56.714" endtime="20191023 09:42:56.714"></status>
-</kw>
-<status status="PASS" starttime="20191023 09:42:56.713" endtime="20191023 09:42:56.714"></status>
-</kw>
-<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 2', 'LastName': 'Campos', 'id': '0034F00000SaS4tQAF', ('status',): OrderedDict([('id', '0034F00000SaS4tQAF'), ('success', True), ('errors', [])])..." type="foritem">
-<kw name="Set To Dictionary" library="Collections">
 <doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
-<arguments>
+<status status="PASS" starttime="20191023 09:42:56.714" endtime="20191023 09:42:56.714"/>
+</kw>
+<status status="PASS" starttime="20191023 09:42:56.713" endtime="20191023 09:42:56.714"/>
+</kw>
+<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 2', 'LastName': 'Campos', 'id': '0034F00000SaS4tQAF', ('status',): OrderedDict([('id', '0034F00000SaS4tQAF'), ('success', True), ('errors', [])])..." type="FOR ITERATION">
+<kw name="Set To Dictionary" library="Collections">
 <arg>${record}</arg>
 <arg>Age</arg>
 <arg>Iron</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:42:56.715" endtime="20191023 09:42:56.715"></status>
-</kw>
-<status status="PASS" starttime="20191023 09:42:56.714" endtime="20191023 09:42:56.715"></status>
-</kw>
-<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 3', 'LastName': 'Moore', 'id': '0034F00000SaS4uQAF', ('status',): OrderedDict([('id', '0034F00000SaS4uQAF'), ('success', True), ('errors', [])])}" type="foritem">
-<kw name="Set To Dictionary" library="Collections">
 <doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
-<arguments>
+<status status="PASS" starttime="20191023 09:42:56.715" endtime="20191023 09:42:56.715"/>
+</kw>
+<status status="PASS" starttime="20191023 09:42:56.714" endtime="20191023 09:42:56.715"/>
+</kw>
+<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 3', 'LastName': 'Moore', 'id': '0034F00000SaS4uQAF', ('status',): OrderedDict([('id', '0034F00000SaS4uQAF'), ('success', True), ('errors', [])])}" type="FOR ITERATION">
+<kw name="Set To Dictionary" library="Collections">
 <arg>${record}</arg>
 <arg>Age</arg>
 <arg>Iron</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:42:56.715" endtime="20191023 09:42:56.715"></status>
-</kw>
-<status status="PASS" starttime="20191023 09:42:56.715" endtime="20191023 09:42:56.715"></status>
-</kw>
-<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 4', 'LastName': 'Richardson', 'id': '0034F00000SaS4vQAF', ('status',): OrderedDict([('id', '0034F00000SaS4vQAF'), ('success', True), ('errors', [..." type="foritem">
-<kw name="Set To Dictionary" library="Collections">
 <doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
-<arguments>
+<status status="PASS" starttime="20191023 09:42:56.715" endtime="20191023 09:42:56.715"/>
+</kw>
+<status status="PASS" starttime="20191023 09:42:56.715" endtime="20191023 09:42:56.715"/>
+</kw>
+<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 4', 'LastName': 'Richardson', 'id': '0034F00000SaS4vQAF', ('status',): OrderedDict([('id', '0034F00000SaS4vQAF'), ('success', True), ('errors', [..." type="FOR ITERATION">
+<kw name="Set To Dictionary" library="Collections">
 <arg>${record}</arg>
 <arg>Age</arg>
 <arg>Iron</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:42:56.716" endtime="20191023 09:42:56.716"></status>
-</kw>
-<status status="PASS" starttime="20191023 09:42:56.716" endtime="20191023 09:42:56.716"></status>
-</kw>
-<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 5', 'LastName': 'Diaz', 'id': '0034F00000SaS4wQAF', ('status',): OrderedDict([('id', '0034F00000SaS4wQAF'), ('success', True), ('errors', [])])}" type="foritem">
-<kw name="Set To Dictionary" library="Collections">
 <doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
-<arguments>
+<status status="PASS" starttime="20191023 09:42:56.716" endtime="20191023 09:42:56.716"/>
+</kw>
+<status status="PASS" starttime="20191023 09:42:56.716" endtime="20191023 09:42:56.716"/>
+</kw>
+<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 5', 'LastName': 'Diaz', 'id': '0034F00000SaS4wQAF', ('status',): OrderedDict([('id', '0034F00000SaS4wQAF'), ('success', True), ('errors', [])])}" type="FOR ITERATION">
+<kw name="Set To Dictionary" library="Collections">
 <arg>${record}</arg>
 <arg>Age</arg>
 <arg>Iron</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:42:56.716" endtime="20191023 09:42:56.716"></status>
-</kw>
-<status status="PASS" starttime="20191023 09:42:56.716" endtime="20191023 09:42:56.716"></status>
-</kw>
-<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 6', 'LastName': 'Larson', 'id': '0034F00000SaS4xQAF', ('status',): OrderedDict([('id', '0034F00000SaS4xQAF'), ('success', True), ('errors', [])])..." type="foritem">
-<kw name="Set To Dictionary" library="Collections">
 <doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
-<arguments>
+<status status="PASS" starttime="20191023 09:42:56.716" endtime="20191023 09:42:56.716"/>
+</kw>
+<status status="PASS" starttime="20191023 09:42:56.716" endtime="20191023 09:42:56.716"/>
+</kw>
+<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 6', 'LastName': 'Larson', 'id': '0034F00000SaS4xQAF', ('status',): OrderedDict([('id', '0034F00000SaS4xQAF'), ('success', True), ('errors', [])])..." type="FOR ITERATION">
+<kw name="Set To Dictionary" library="Collections">
 <arg>${record}</arg>
 <arg>Age</arg>
 <arg>Iron</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:42:56.717" endtime="20191023 09:42:56.717"></status>
-</kw>
-<status status="PASS" starttime="20191023 09:42:56.716" endtime="20191023 09:42:56.717"></status>
-</kw>
-<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 7', 'LastName': 'Schmidt', 'id': '0034F00000SaS4yQAF', ('status',): OrderedDict([('id', '0034F00000SaS4yQAF'), ('success', True), ('errors', [])]..." type="foritem">
-<kw name="Set To Dictionary" library="Collections">
 <doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
-<arguments>
+<status status="PASS" starttime="20191023 09:42:56.717" endtime="20191023 09:42:56.717"/>
+</kw>
+<status status="PASS" starttime="20191023 09:42:56.716" endtime="20191023 09:42:56.717"/>
+</kw>
+<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 7', 'LastName': 'Schmidt', 'id': '0034F00000SaS4yQAF', ('status',): OrderedDict([('id', '0034F00000SaS4yQAF'), ('success', True), ('errors', [])]..." type="FOR ITERATION">
+<kw name="Set To Dictionary" library="Collections">
 <arg>${record}</arg>
 <arg>Age</arg>
 <arg>Iron</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:42:56.717" endtime="20191023 09:42:56.717"></status>
-</kw>
-<status status="PASS" starttime="20191023 09:42:56.717" endtime="20191023 09:42:56.717"></status>
-</kw>
-<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 8', 'LastName': 'Hernandez', 'id': '0034F00000SaS4zQAF', ('status',): OrderedDict([('id', '0034F00000SaS4zQAF'), ('success', True), ('errors', []..." type="foritem">
-<kw name="Set To Dictionary" library="Collections">
 <doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
-<arguments>
+<status status="PASS" starttime="20191023 09:42:56.717" endtime="20191023 09:42:56.717"/>
+</kw>
+<status status="PASS" starttime="20191023 09:42:56.717" endtime="20191023 09:42:56.717"/>
+</kw>
+<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 8', 'LastName': 'Hernandez', 'id': '0034F00000SaS4zQAF', ('status',): OrderedDict([('id', '0034F00000SaS4zQAF'), ('success', True), ('errors', []..." type="FOR ITERATION">
+<kw name="Set To Dictionary" library="Collections">
 <arg>${record}</arg>
 <arg>Age</arg>
 <arg>Iron</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:42:56.717" endtime="20191023 09:42:56.718"></status>
-</kw>
-<status status="PASS" starttime="20191023 09:42:56.717" endtime="20191023 09:42:56.718"></status>
-</kw>
-<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 9', 'LastName': 'Flores', 'id': '0034F00000SaS50QAF', ('status',): OrderedDict([('id', '0034F00000SaS50QAF'), ('success', True), ('errors', [])])..." type="foritem">
-<kw name="Set To Dictionary" library="Collections">
 <doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
-<arguments>
+<status status="PASS" starttime="20191023 09:42:56.717" endtime="20191023 09:42:56.718"/>
+</kw>
+<status status="PASS" starttime="20191023 09:42:56.717" endtime="20191023 09:42:56.718"/>
+</kw>
+<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 9', 'LastName': 'Flores', 'id': '0034F00000SaS50QAF', ('status',): OrderedDict([('id', '0034F00000SaS50QAF'), ('success', True), ('errors', [])])..." type="FOR ITERATION">
+<kw name="Set To Dictionary" library="Collections">
 <arg>${record}</arg>
 <arg>Age</arg>
 <arg>Iron</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:42:56.718" endtime="20191023 09:42:56.718"></status>
-</kw>
-<status status="PASS" starttime="20191023 09:42:56.718" endtime="20191023 09:42:56.718"></status>
-</kw>
-<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 10', 'LastName': 'Delacruz', 'id': '0034F00000SaS51QAF', ('status',): OrderedDict([('id', '0034F00000SaS51QAF'), ('success', True), ('errors', []..." type="foritem">
-<kw name="Set To Dictionary" library="Collections">
 <doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
-<arguments>
+<status status="PASS" starttime="20191023 09:42:56.718" endtime="20191023 09:42:56.718"/>
+</kw>
+<status status="PASS" starttime="20191023 09:42:56.718" endtime="20191023 09:42:56.718"/>
+</kw>
+<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 10', 'LastName': 'Delacruz', 'id': '0034F00000SaS51QAF', ('status',): OrderedDict([('id', '0034F00000SaS51QAF'), ('success', True), ('errors', []..." type="FOR ITERATION">
+<kw name="Set To Dictionary" library="Collections">
 <arg>${record}</arg>
 <arg>Age</arg>
 <arg>Iron</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:42:56.718" endtime="20191023 09:42:56.719"></status>
-</kw>
-<status status="PASS" starttime="20191023 09:42:56.718" endtime="20191023 09:42:56.719"></status>
-</kw>
-<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 11', 'LastName': 'Smith', 'id': '0034F00000SaS52QAF', ('status',): OrderedDict([('id', '0034F00000SaS52QAF'), ('success', True), ('errors', [])])..." type="foritem">
-<kw name="Set To Dictionary" library="Collections">
 <doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
-<arguments>
+<status status="PASS" starttime="20191023 09:42:56.718" endtime="20191023 09:42:56.719"/>
+</kw>
+<status status="PASS" starttime="20191023 09:42:56.718" endtime="20191023 09:42:56.719"/>
+</kw>
+<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 11', 'LastName': 'Smith', 'id': '0034F00000SaS52QAF', ('status',): OrderedDict([('id', '0034F00000SaS52QAF'), ('success', True), ('errors', [])])..." type="FOR ITERATION">
+<kw name="Set To Dictionary" library="Collections">
 <arg>${record}</arg>
 <arg>Age</arg>
 <arg>Iron</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:42:56.719" endtime="20191023 09:42:56.719"></status>
-</kw>
-<status status="PASS" starttime="20191023 09:42:56.719" endtime="20191023 09:42:56.719"></status>
-</kw>
-<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 12', 'LastName': 'Cohen', 'id': '0034F00000SaS53QAF', ('status',): OrderedDict([('id', '0034F00000SaS53QAF'), ('success', True), ('errors', [])])..." type="foritem">
-<kw name="Set To Dictionary" library="Collections">
 <doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
-<arguments>
+<status status="PASS" starttime="20191023 09:42:56.719" endtime="20191023 09:42:56.719"/>
+</kw>
+<status status="PASS" starttime="20191023 09:42:56.719" endtime="20191023 09:42:56.719"/>
+</kw>
+<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 12', 'LastName': 'Cohen', 'id': '0034F00000SaS53QAF', ('status',): OrderedDict([('id', '0034F00000SaS53QAF'), ('success', True), ('errors', [])])..." type="FOR ITERATION">
+<kw name="Set To Dictionary" library="Collections">
 <arg>${record}</arg>
 <arg>Age</arg>
 <arg>Iron</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:42:56.719" endtime="20191023 09:42:56.719"></status>
-</kw>
-<status status="PASS" starttime="20191023 09:42:56.719" endtime="20191023 09:42:56.720"></status>
-</kw>
-<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 13', 'LastName': 'English', 'id': '0034F00000SaS54QAF', ('status',): OrderedDict([('id', '0034F00000SaS54QAF'), ('success', True), ('errors', [])..." type="foritem">
-<kw name="Set To Dictionary" library="Collections">
 <doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
-<arguments>
+<status status="PASS" starttime="20191023 09:42:56.719" endtime="20191023 09:42:56.719"/>
+</kw>
+<status status="PASS" starttime="20191023 09:42:56.719" endtime="20191023 09:42:56.720"/>
+</kw>
+<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 13', 'LastName': 'English', 'id': '0034F00000SaS54QAF', ('status',): OrderedDict([('id', '0034F00000SaS54QAF'), ('success', True), ('errors', [])..." type="FOR ITERATION">
+<kw name="Set To Dictionary" library="Collections">
 <arg>${record}</arg>
 <arg>Age</arg>
 <arg>Iron</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:42:56.720" endtime="20191023 09:42:56.720"></status>
-</kw>
-<status status="PASS" starttime="20191023 09:42:56.720" endtime="20191023 09:42:56.720"></status>
-</kw>
-<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 14', 'LastName': 'Reid', 'id': '0034F00000SaS55QAF', ('status',): OrderedDict([('id', '0034F00000SaS55QAF'), ('success', True), ('errors', [])])}" type="foritem">
-<kw name="Set To Dictionary" library="Collections">
 <doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
-<arguments>
+<status status="PASS" starttime="20191023 09:42:56.720" endtime="20191023 09:42:56.720"/>
+</kw>
+<status status="PASS" starttime="20191023 09:42:56.720" endtime="20191023 09:42:56.720"/>
+</kw>
+<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 14', 'LastName': 'Reid', 'id': '0034F00000SaS55QAF', ('status',): OrderedDict([('id', '0034F00000SaS55QAF'), ('success', True), ('errors', [])])}" type="FOR ITERATION">
+<kw name="Set To Dictionary" library="Collections">
 <arg>${record}</arg>
 <arg>Age</arg>
 <arg>Iron</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:42:56.720" endtime="20191023 09:42:56.721"></status>
-</kw>
-<status status="PASS" starttime="20191023 09:42:56.720" endtime="20191023 09:42:56.721"></status>
-</kw>
-<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 15', 'LastName': 'Salas', 'id': '0034F00000SaS56QAF', ('status',): OrderedDict([('id', '0034F00000SaS56QAF'), ('success', True), ('errors', [])])..." type="foritem">
-<kw name="Set To Dictionary" library="Collections">
 <doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
-<arguments>
+<status status="PASS" starttime="20191023 09:42:56.720" endtime="20191023 09:42:56.721"/>
+</kw>
+<status status="PASS" starttime="20191023 09:42:56.720" endtime="20191023 09:42:56.721"/>
+</kw>
+<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 15', 'LastName': 'Salas', 'id': '0034F00000SaS56QAF', ('status',): OrderedDict([('id', '0034F00000SaS56QAF'), ('success', True), ('errors', [])])..." type="FOR ITERATION">
+<kw name="Set To Dictionary" library="Collections">
 <arg>${record}</arg>
 <arg>Age</arg>
 <arg>Iron</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:42:56.721" endtime="20191023 09:42:56.721"></status>
-</kw>
-<status status="PASS" starttime="20191023 09:42:56.721" endtime="20191023 09:42:56.721"></status>
-</kw>
-<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 16', 'LastName': 'Johnson', 'id': '0034F00000SaS57QAF', ('status',): OrderedDict([('id', '0034F00000SaS57QAF'), ('success', True), ('errors', [])..." type="foritem">
-<kw name="Set To Dictionary" library="Collections">
 <doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
-<arguments>
+<status status="PASS" starttime="20191023 09:42:56.721" endtime="20191023 09:42:56.721"/>
+</kw>
+<status status="PASS" starttime="20191023 09:42:56.721" endtime="20191023 09:42:56.721"/>
+</kw>
+<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 16', 'LastName': 'Johnson', 'id': '0034F00000SaS57QAF', ('status',): OrderedDict([('id', '0034F00000SaS57QAF'), ('success', True), ('errors', [])..." type="FOR ITERATION">
+<kw name="Set To Dictionary" library="Collections">
 <arg>${record}</arg>
 <arg>Age</arg>
 <arg>Iron</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:42:56.721" endtime="20191023 09:42:56.721"></status>
-</kw>
-<status status="PASS" starttime="20191023 09:42:56.721" endtime="20191023 09:42:56.722"></status>
-</kw>
-<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 17', 'LastName': 'Donovan', 'id': '0034F00000SaS58QAF', ('status',): OrderedDict([('id', '0034F00000SaS58QAF'), ('success', True), ('errors', [])..." type="foritem">
-<kw name="Set To Dictionary" library="Collections">
 <doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
-<arguments>
+<status status="PASS" starttime="20191023 09:42:56.721" endtime="20191023 09:42:56.721"/>
+</kw>
+<status status="PASS" starttime="20191023 09:42:56.721" endtime="20191023 09:42:56.722"/>
+</kw>
+<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 17', 'LastName': 'Donovan', 'id': '0034F00000SaS58QAF', ('status',): OrderedDict([('id', '0034F00000SaS58QAF'), ('success', True), ('errors', [])..." type="FOR ITERATION">
+<kw name="Set To Dictionary" library="Collections">
 <arg>${record}</arg>
 <arg>Age</arg>
 <arg>Iron</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:42:56.722" endtime="20191023 09:42:56.722"></status>
-</kw>
-<status status="PASS" starttime="20191023 09:42:56.722" endtime="20191023 09:42:56.722"></status>
-</kw>
-<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 18', 'LastName': 'Curtis', 'id': '0034F00000SaS59QAF', ('status',): OrderedDict([('id', '0034F00000SaS59QAF'), ('success', True), ('errors', [])]..." type="foritem">
-<kw name="Set To Dictionary" library="Collections">
 <doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
-<arguments>
+<status status="PASS" starttime="20191023 09:42:56.722" endtime="20191023 09:42:56.722"/>
+</kw>
+<status status="PASS" starttime="20191023 09:42:56.722" endtime="20191023 09:42:56.722"/>
+</kw>
+<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 18', 'LastName': 'Curtis', 'id': '0034F00000SaS59QAF', ('status',): OrderedDict([('id', '0034F00000SaS59QAF'), ('success', True), ('errors', [])]..." type="FOR ITERATION">
+<kw name="Set To Dictionary" library="Collections">
 <arg>${record}</arg>
 <arg>Age</arg>
 <arg>Iron</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:42:56.722" endtime="20191023 09:42:56.722"></status>
-</kw>
-<status status="PASS" starttime="20191023 09:42:56.722" endtime="20191023 09:42:56.722"></status>
-</kw>
-<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 19', 'LastName': 'Haas', 'id': '0034F00000SaS5AQAV', ('status',): OrderedDict([('id', '0034F00000SaS5AQAV'), ('success', True), ('errors', [])])}" type="foritem">
-<kw name="Set To Dictionary" library="Collections">
 <doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
-<arguments>
+<status status="PASS" starttime="20191023 09:42:56.722" endtime="20191023 09:42:56.722"/>
+</kw>
+<status status="PASS" starttime="20191023 09:42:56.722" endtime="20191023 09:42:56.722"/>
+</kw>
+<kw name="${record} = {'attributes': {'type': 'Contact'}, 'FirstName': 'User 19', 'LastName': 'Haas', 'id': '0034F00000SaS5AQAV', ('status',): OrderedDict([('id', '0034F00000SaS5AQAV'), ('success', True), ('errors', [])])}" type="FOR ITERATION">
+<kw name="Set To Dictionary" library="Collections">
 <arg>${record}</arg>
 <arg>Age</arg>
 <arg>Iron</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:42:56.722" endtime="20191023 09:42:56.723"></status>
+<doc>Adds the given ``key_value_pairs`` and ``items`` to the ``dictionary``.</doc>
+<status status="PASS" starttime="20191023 09:42:56.722" endtime="20191023 09:42:56.723"/>
 </kw>
-<status status="PASS" starttime="20191023 09:42:56.722" endtime="20191023 09:42:56.723"></status>
+<status status="PASS" starttime="20191023 09:42:56.722" endtime="20191023 09:42:56.723"/>
 </kw>
-<status status="PASS" starttime="20191023 09:42:56.712" endtime="20191023 09:42:56.723"></status>
+<status status="PASS" starttime="20191023 09:42:56.712" endtime="20191023 09:42:56.723"/>
 </kw>
 <kw name="Run Keyword And Expect Error" library="BuiltIn">
-<doc>Runs the keyword and checks that the expected error occurred.</doc>
-<arguments>
 <arg>SalesforceMalformedRequest*</arg>
 <arg>Salesforce Collection Update</arg>
 <arg>${objects}</arg>
-</arguments>
+<doc>Runs the keyword and checks that the expected error occurred.</doc>
 <kw name="Salesforce Collection Update" library="cumulusci.robotframework.Salesforce">
-<doc>Updates up to 200 records described as Robot/Python dictionaries</doc>
-<arguments>
 <arg>${objects}</arg>
-</arguments>
+<doc>Updates up to 200 records described as Robot/Python dictionaries</doc>
 <msg timestamp="20191023 09:42:56.893" level="FAIL">SalesforceMalformedRequest: Malformed request https://efficiency-fun-590-dev-ed.cs93.my.salesforce.com/services/data/v46.0/composite/sobjects. Response content: [{'message': "No such column 'Age' on sobject of type Contact", 'errorCode': 'INVALID_FIELD'}]</msg>
-<status status="FAIL" starttime="20191023 09:42:56.723" endtime="20191023 09:42:56.893"></status>
+<status status="FAIL" starttime="20191023 09:42:56.723" endtime="20191023 09:42:56.893"/>
 </kw>
-<status status="PASS" starttime="20191023 09:42:56.723" endtime="20191023 09:42:56.894"></status>
+<status status="PASS" starttime="20191023 09:42:56.723" endtime="20191023 09:42:56.894"/>
 </kw>
-<tags>
 <tag>api</tag>
-</tags>
-<status status="PASS" starttime="20191023 09:42:49.737" endtime="20191023 09:42:56.894" critical="yes"></status>
+<status status="PASS" starttime="20191023 09:42:49.737" endtime="20191023 09:42:56.894"/>
 </test>
-<kw name="Delete Session Records" library="cumulusci.robotframework.Salesforce" type="teardown">
+<kw name="Delete Session Records" library="cumulusci.robotframework.Salesforce" type="TEARDOWN">
 <doc>Deletes records that were created while running this test case.</doc>
 <msg timestamp="20191023 09:42:56.896" level="INFO">Deleting 40 records</msg>
 <msg timestamp="20191023 09:42:56.896" level="INFO">  Deleting Contact 0034F00000SaS5AQAV</msg>
@@ -2572,65 +2036,51 @@ The 200 record limit is enforced by the Salesforce APIs</doc>
 <msg timestamp="20191023 09:43:10.201" level="INFO">Deleting Contact with Id 0034F00000SaS4YQAV</msg>
 <msg timestamp="20191023 09:43:10.545" level="INFO">  Deleting Contact 0034F00000SaS4XQAV</msg>
 <msg timestamp="20191023 09:43:10.546" level="INFO">Deleting Contact with Id 0034F00000SaS4XQAV</msg>
-<status status="PASS" starttime="20191023 09:42:56.896" endtime="20191023 09:43:10.910"></status>
+<status status="PASS" starttime="20191023 09:42:56.896" endtime="20191023 09:43:10.910"/>
 </kw>
-<status status="PASS" starttime="20191023 09:41:53.229" endtime="20191023 09:43:10.911"></status>
+<status status="PASS" starttime="20191023 09:41:53.229" endtime="20191023 09:43:10.911"/>
 </suite>
 <suite id="s1-s2-s2" name="Browsers" source="/Users/pprescod/code/CumulusCI/cumulusci/robotframework/tests/salesforce/browsers.robot">
 <test id="s1-s2-s2-t1" name="Open Test Browser Twice">
 <kw name="Assert active browser count">
-<doc>Assert that an expected number of browsers are active</doc>
-<arguments>
 <arg>0</arg>
-</arguments>
+<doc>Assert that an expected number of browsers are active</doc>
 <kw name="Get Active Browser Ids" library="cumulusci.robotframework.Salesforce">
-<doc>Return the id of all open browser ids</doc>
-<assign>
 <var>@{browsers}</var>
-</assign>
+<doc>Return the id of all open browser ids</doc>
 <msg timestamp="20191023 09:43:10.929" level="INFO">@{browsers} = [ ]</msg>
-<status status="PASS" starttime="20191023 09:43:10.928" endtime="20191023 09:43:10.929"></status>
+<status status="PASS" starttime="20191023 09:43:10.928" endtime="20191023 09:43:10.929"/>
 </kw>
 <kw name="Get Length" library="BuiltIn">
-<doc>Returns and logs the length of the given item as an integer.</doc>
-<arguments>
-<arg>${browsers}</arg>
-</arguments>
-<assign>
 <var>${actual count}</var>
-</assign>
+<arg>${browsers}</arg>
+<doc>Returns and logs the length of the given item as an integer.</doc>
 <msg timestamp="20191023 09:43:10.929" level="INFO">Length is 0</msg>
 <msg timestamp="20191023 09:43:10.929" level="INFO">${actual count} = 0</msg>
-<status status="PASS" starttime="20191023 09:43:10.929" endtime="20191023 09:43:10.929"></status>
+<status status="PASS" starttime="20191023 09:43:10.929" endtime="20191023 09:43:10.929"/>
 </kw>
 <kw name="Length Should Be" library="BuiltIn">
-<doc>Verifies that the length of the given item is correct.</doc>
-<arguments>
 <arg>${browsers}</arg>
 <arg>${expected count}</arg>
 <arg>Expected to find ${expected count} open browsers, found ${actual count}</arg>
-</arguments>
+<doc>Verifies that the length of the given item is correct.</doc>
 <msg timestamp="20191023 09:43:10.929" level="INFO">Length is 0</msg>
-<status status="PASS" starttime="20191023 09:43:10.929" endtime="20191023 09:43:10.929"></status>
+<status status="PASS" starttime="20191023 09:43:10.929" endtime="20191023 09:43:10.929"/>
 </kw>
-<status status="PASS" starttime="20191023 09:43:10.928" endtime="20191023 09:43:10.929"></status>
+<status status="PASS" starttime="20191023 09:43:10.928" endtime="20191023 09:43:10.929"/>
 </kw>
 <kw name="Open Test Browser" library="Salesforce">
 <doc>Opens a test browser to the org.</doc>
 <kw name="Login Url" library="cumulusci.robotframework.CumulusCI">
+<var>${login_url}</var>
 <doc>Returns the login url which will automatically log into the target
 Salesforce org.  By default, the org_name passed to the library
 constructor is used but this can be overridden with the org option
 to log into a different org.</doc>
-<assign>
-<var>${login_url}</var>
-</assign>
 <msg timestamp="20191023 09:43:10.930" level="INFO">${login_url} = https://efficiency-fun-590-dev-ed.cs93.my.salesforce.com/secur/frontdoor.jsp?sid=MASKED</msg>
-<status status="PASS" starttime="20191023 09:43:10.930" endtime="20191023 09:43:10.930"></status>
+<status status="PASS" starttime="20191023 09:43:10.930" endtime="20191023 09:43:10.930"/>
 </kw>
 <kw name="Run Keyword If" library="BuiltIn">
-<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
-<arguments>
 <arg>'${BROWSER}' == 'chrome'</arg>
 <arg>Open Test Browser Chrome</arg>
 <arg>${login_url}</arg>
@@ -2655,93 +2105,73 @@ to log into a different org.</doc>
 <arg>${login_url}</arg>
 <arg>${BROWSER}</arg>
 <arg>alias=${alias}</arg>
-</arguments>
+<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
 <kw name="Open Test Browser Chrome" library="Salesforce">
-<arguments>
 <arg>${login_url}</arg>
 <arg>alias=${alias}</arg>
-</arguments>
 <kw name="Get Chrome Options" library="Salesforce">
-<assign>
 <var>${options}</var>
-</assign>
 <kw name="Evaluate" library="BuiltIn">
-<doc>Evaluates the given expression in Python and returns the results.</doc>
-<arguments>
+<var>${options}</var>
 <arg>selenium.webdriver.ChromeOptions()</arg>
 <arg>modules=selenium</arg>
-</arguments>
-<assign>
-<var>${options}</var>
-</assign>
+<doc>Evaluates the given expression in Python and returns the results.</doc>
 <msg timestamp="20191023 09:43:10.932" level="INFO">${options} = &lt;selenium.webdriver.chrome.options.Options object at 0x10d85e7f0&gt;</msg>
-<status status="PASS" starttime="20191023 09:43:10.931" endtime="20191023 09:43:10.932"></status>
+<status status="PASS" starttime="20191023 09:43:10.931" endtime="20191023 09:43:10.932"/>
 </kw>
 <kw name="Run Keyword If" library="BuiltIn">
-<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
-<arguments>
 <arg>'${BROWSER}' == 'headlesschrome'</arg>
 <arg>Chrome Set Headless</arg>
 <arg>${options}</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:43:10.932" endtime="20191023 09:43:10.932"></status>
+<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
+<status status="PASS" starttime="20191023 09:43:10.932" endtime="20191023 09:43:10.932"/>
 </kw>
 <kw name="Run Keyword If" library="BuiltIn">
-<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
-<arguments>
 <arg>'${CHROME_BINARY}' != '${empty}'</arg>
 <arg>Chrome Set Binary</arg>
 <arg>${options}</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:43:10.932" endtime="20191023 09:43:10.933"></status>
+<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
+<status status="PASS" starttime="20191023 09:43:10.932" endtime="20191023 09:43:10.933"/>
 </kw>
 <kw name="Call Method" library="BuiltIn">
-<doc>Calls the named method of the given object with the provided arguments.</doc>
-<arguments>
 <arg>${options}</arg>
 <arg>add_argument</arg>
 <arg>--disable-notifications</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:43:10.933" endtime="20191023 09:43:10.933"></status>
+<doc>Calls the named method of the given object with the provided arguments.</doc>
+<status status="PASS" starttime="20191023 09:43:10.933" endtime="20191023 09:43:10.933"/>
 </kw>
 <msg timestamp="20191023 09:43:10.933" level="INFO">${options} = &lt;selenium.webdriver.chrome.options.Options object at 0x10d85e7f0&gt;</msg>
-<status status="PASS" starttime="20191023 09:43:10.931" endtime="20191023 09:43:10.933"></status>
+<status status="PASS" starttime="20191023 09:43:10.931" endtime="20191023 09:43:10.933"/>
 </kw>
 <kw name="Create Webdriver With Retry" library="cumulusci.robotframework.Salesforce">
-<doc>Call the Create Webdriver keyword.</doc>
-<arguments>
 <arg>Chrome</arg>
 <arg>options=${options}</arg>
 <arg>alias=${alias}</arg>
-</arguments>
+<doc>Call the Create Webdriver keyword.</doc>
 <msg timestamp="20191023 09:43:10.934" level="INFO">Creating an instance of the Chrome WebDriver.</msg>
 <msg timestamp="20191023 09:43:15.641" level="FAIL">SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </msg>
-<status status="FAIL" starttime="20191023 09:43:10.933" endtime="20191023 09:43:15.642"></status>
+<status status="FAIL" starttime="20191023 09:43:10.933" endtime="20191023 09:43:15.642"/>
 </kw>
-<status status="FAIL" starttime="20191023 09:43:10.931" endtime="20191023 09:43:15.643"></status>
+<status status="FAIL" starttime="20191023 09:43:10.931" endtime="20191023 09:43:15.643"/>
 </kw>
-<status status="FAIL" starttime="20191023 09:43:10.930" endtime="20191023 09:43:15.643"></status>
+<status status="FAIL" starttime="20191023 09:43:10.930" endtime="20191023 09:43:15.643"/>
 </kw>
-<status status="FAIL" starttime="20191023 09:43:10.930" endtime="20191023 09:43:15.643"></status>
+<status status="FAIL" starttime="20191023 09:43:10.930" endtime="20191023 09:43:15.643"/>
 </kw>
-<kw name="Close All Browsers" library="SeleniumLibrary" type="teardown">
+<kw name="Close All Browsers" library="SeleniumLibrary" type="TEARDOWN">
 <doc>Closes all open browsers and resets the browser cache.</doc>
-<status status="PASS" starttime="20191023 09:43:15.644" endtime="20191023 09:43:15.645"></status>
+<status status="PASS" starttime="20191023 09:43:15.644" endtime="20191023 09:43:15.645"/>
 </kw>
 <doc>Verify that we can open two browsers in a single test</doc>
-<tags>
 <tag>issue:1068</tag>
-</tags>
-<status status="FAIL" starttime="20191023 09:43:10.928" endtime="20191023 09:43:15.645" critical="yes">SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
+<status status="FAIL" starttime="20191023 09:43:10.928" endtime="20191023 09:43:15.645">SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </status>
 </test>
 <test id="s1-s2-s2-t2" name="Browser aliases">
-<kw name="Run Keywords" library="BuiltIn" type="setup">
-<doc>Executes all the given keywords in a sequence.</doc>
-<arguments>
+<kw name="Run Keywords" library="BuiltIn" type="SETUP">
 <arg>Open test browser</arg>
 <arg>alias=browser1</arg>
 <arg>AND</arg>
@@ -2750,26 +2180,20 @@ to log into a different org.</doc>
 <arg>AND</arg>
 <arg>Go to</arg>
 <arg>about:blank</arg>
-</arguments>
+<doc>Executes all the given keywords in a sequence.</doc>
 <kw name="Open Test Browser" library="Salesforce">
-<doc>Opens a test browser to the org.</doc>
-<arguments>
 <arg>alias=browser1</arg>
-</arguments>
+<doc>Opens a test browser to the org.</doc>
 <kw name="Login Url" library="cumulusci.robotframework.CumulusCI">
+<var>${login_url}</var>
 <doc>Returns the login url which will automatically log into the target
 Salesforce org.  By default, the org_name passed to the library
 constructor is used but this can be overridden with the org option
 to log into a different org.</doc>
-<assign>
-<var>${login_url}</var>
-</assign>
 <msg timestamp="20191023 09:43:15.654" level="INFO">${login_url} = https://efficiency-fun-590-dev-ed.cs93.my.salesforce.com/secur/frontdoor.jsp?sid=MASKED</msg>
-<status status="PASS" starttime="20191023 09:43:15.652" endtime="20191023 09:43:15.655"></status>
+<status status="PASS" starttime="20191023 09:43:15.652" endtime="20191023 09:43:15.655"/>
 </kw>
 <kw name="Run Keyword If" library="BuiltIn">
-<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
-<arguments>
 <arg>'${BROWSER}' == 'chrome'</arg>
 <arg>Open Test Browser Chrome</arg>
 <arg>${login_url}</arg>
@@ -2794,88 +2218,70 @@ to log into a different org.</doc>
 <arg>${login_url}</arg>
 <arg>${BROWSER}</arg>
 <arg>alias=${alias}</arg>
-</arguments>
+<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
 <kw name="Open Test Browser Chrome" library="Salesforce">
-<arguments>
 <arg>${login_url}</arg>
 <arg>alias=${alias}</arg>
-</arguments>
 <kw name="Get Chrome Options" library="Salesforce">
-<assign>
 <var>${options}</var>
-</assign>
 <kw name="Evaluate" library="BuiltIn">
-<doc>Evaluates the given expression in Python and returns the results.</doc>
-<arguments>
+<var>${options}</var>
 <arg>selenium.webdriver.ChromeOptions()</arg>
 <arg>modules=selenium</arg>
-</arguments>
-<assign>
-<var>${options}</var>
-</assign>
+<doc>Evaluates the given expression in Python and returns the results.</doc>
 <msg timestamp="20191023 09:43:15.659" level="INFO">${options} = &lt;selenium.webdriver.chrome.options.Options object at 0x10d896080&gt;</msg>
-<status status="PASS" starttime="20191023 09:43:15.658" endtime="20191023 09:43:15.659"></status>
+<status status="PASS" starttime="20191023 09:43:15.658" endtime="20191023 09:43:15.659"/>
 </kw>
 <kw name="Run Keyword If" library="BuiltIn">
-<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
-<arguments>
 <arg>'${BROWSER}' == 'headlesschrome'</arg>
 <arg>Chrome Set Headless</arg>
 <arg>${options}</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:43:15.659" endtime="20191023 09:43:15.659"></status>
+<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
+<status status="PASS" starttime="20191023 09:43:15.659" endtime="20191023 09:43:15.659"/>
 </kw>
 <kw name="Run Keyword If" library="BuiltIn">
-<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
-<arguments>
 <arg>'${CHROME_BINARY}' != '${empty}'</arg>
 <arg>Chrome Set Binary</arg>
 <arg>${options}</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:43:15.661" endtime="20191023 09:43:15.662"></status>
+<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
+<status status="PASS" starttime="20191023 09:43:15.661" endtime="20191023 09:43:15.662"/>
 </kw>
 <kw name="Call Method" library="BuiltIn">
-<doc>Calls the named method of the given object with the provided arguments.</doc>
-<arguments>
 <arg>${options}</arg>
 <arg>add_argument</arg>
 <arg>--disable-notifications</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:43:15.662" endtime="20191023 09:43:15.663"></status>
+<doc>Calls the named method of the given object with the provided arguments.</doc>
+<status status="PASS" starttime="20191023 09:43:15.662" endtime="20191023 09:43:15.663"/>
 </kw>
 <msg timestamp="20191023 09:43:15.663" level="INFO">${options} = &lt;selenium.webdriver.chrome.options.Options object at 0x10d896080&gt;</msg>
-<status status="PASS" starttime="20191023 09:43:15.658" endtime="20191023 09:43:15.663"></status>
+<status status="PASS" starttime="20191023 09:43:15.658" endtime="20191023 09:43:15.663"/>
 </kw>
 <kw name="Create Webdriver With Retry" library="cumulusci.robotframework.Salesforce">
-<doc>Call the Create Webdriver keyword.</doc>
-<arguments>
 <arg>Chrome</arg>
 <arg>options=${options}</arg>
 <arg>alias=${alias}</arg>
-</arguments>
+<doc>Call the Create Webdriver keyword.</doc>
 <msg timestamp="20191023 09:43:15.664" level="INFO">Creating an instance of the Chrome WebDriver.</msg>
 <msg timestamp="20191023 09:43:20.476" level="FAIL">SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </msg>
-<status status="FAIL" starttime="20191023 09:43:15.663" endtime="20191023 09:43:20.476"></status>
+<status status="FAIL" starttime="20191023 09:43:15.663" endtime="20191023 09:43:20.476"/>
 </kw>
-<status status="FAIL" starttime="20191023 09:43:15.657" endtime="20191023 09:43:20.476"></status>
+<status status="FAIL" starttime="20191023 09:43:15.657" endtime="20191023 09:43:20.476"/>
 </kw>
-<status status="FAIL" starttime="20191023 09:43:15.656" endtime="20191023 09:43:20.476"></status>
+<status status="FAIL" starttime="20191023 09:43:15.656" endtime="20191023 09:43:20.476"/>
 </kw>
-<status status="FAIL" starttime="20191023 09:43:15.649" endtime="20191023 09:43:20.476"></status>
+<status status="FAIL" starttime="20191023 09:43:15.649" endtime="20191023 09:43:20.476"/>
 </kw>
-<status status="FAIL" starttime="20191023 09:43:15.648" endtime="20191023 09:43:20.476"></status>
+<status status="FAIL" starttime="20191023 09:43:15.648" endtime="20191023 09:43:20.476"/>
 </kw>
-<kw name="Close All Browsers" library="SeleniumLibrary" type="teardown">
+<kw name="Close All Browsers" library="SeleniumLibrary" type="TEARDOWN">
 <doc>Closes all open browsers and resets the browser cache.</doc>
-<status status="PASS" starttime="20191023 09:43:20.477" endtime="20191023 09:43:20.478"></status>
+<status status="PASS" starttime="20191023 09:43:20.477" endtime="20191023 09:43:20.478"/>
 </kw>
 <doc>Verify that aliases are properly handled in Open Test Browser</doc>
-<tags>
 <tag>issue:1068</tag>
-</tags>
-<status status="FAIL" starttime="20191023 09:43:15.647" endtime="20191023 09:43:20.478" critical="yes">Setup failed:
+<status status="FAIL" starttime="20191023 09:43:15.647" endtime="20191023 09:43:20.478">Setup failed:
 SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </status>
@@ -2884,19 +2290,15 @@ SessionNotCreatedException: Message: session not created: Chrome version must be
 <kw name="Open Test Browser" library="Salesforce">
 <doc>Opens a test browser to the org.</doc>
 <kw name="Login Url" library="cumulusci.robotframework.CumulusCI">
+<var>${login_url}</var>
 <doc>Returns the login url which will automatically log into the target
 Salesforce org.  By default, the org_name passed to the library
 constructor is used but this can be overridden with the org option
 to log into a different org.</doc>
-<assign>
-<var>${login_url}</var>
-</assign>
 <msg timestamp="20191023 09:43:20.481" level="INFO">${login_url} = https://efficiency-fun-590-dev-ed.cs93.my.salesforce.com/secur/frontdoor.jsp?sid=MASKED</msg>
-<status status="PASS" starttime="20191023 09:43:20.481" endtime="20191023 09:43:20.481"></status>
+<status status="PASS" starttime="20191023 09:43:20.481" endtime="20191023 09:43:20.481"/>
 </kw>
 <kw name="Run Keyword If" library="BuiltIn">
-<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
-<arguments>
 <arg>'${BROWSER}' == 'chrome'</arg>
 <arg>Open Test Browser Chrome</arg>
 <arg>${login_url}</arg>
@@ -2921,106 +2323,84 @@ to log into a different org.</doc>
 <arg>${login_url}</arg>
 <arg>${BROWSER}</arg>
 <arg>alias=${alias}</arg>
-</arguments>
+<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
 <kw name="Open Test Browser Chrome" library="Salesforce">
-<arguments>
 <arg>${login_url}</arg>
 <arg>alias=${alias}</arg>
-</arguments>
 <kw name="Get Chrome Options" library="Salesforce">
-<assign>
 <var>${options}</var>
-</assign>
 <kw name="Evaluate" library="BuiltIn">
-<doc>Evaluates the given expression in Python and returns the results.</doc>
-<arguments>
+<var>${options}</var>
 <arg>selenium.webdriver.ChromeOptions()</arg>
 <arg>modules=selenium</arg>
-</arguments>
-<assign>
-<var>${options}</var>
-</assign>
+<doc>Evaluates the given expression in Python and returns the results.</doc>
 <msg timestamp="20191023 09:43:20.486" level="INFO">${options} = &lt;selenium.webdriver.chrome.options.Options object at 0x10d85bda0&gt;</msg>
-<status status="PASS" starttime="20191023 09:43:20.484" endtime="20191023 09:43:20.486"></status>
+<status status="PASS" starttime="20191023 09:43:20.484" endtime="20191023 09:43:20.486"/>
 </kw>
 <kw name="Run Keyword If" library="BuiltIn">
-<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
-<arguments>
 <arg>'${BROWSER}' == 'headlesschrome'</arg>
 <arg>Chrome Set Headless</arg>
 <arg>${options}</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:43:20.486" endtime="20191023 09:43:20.488"></status>
+<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
+<status status="PASS" starttime="20191023 09:43:20.486" endtime="20191023 09:43:20.488"/>
 </kw>
 <kw name="Run Keyword If" library="BuiltIn">
-<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
-<arguments>
 <arg>'${CHROME_BINARY}' != '${empty}'</arg>
 <arg>Chrome Set Binary</arg>
 <arg>${options}</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:43:20.491" endtime="20191023 09:43:20.492"></status>
+<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
+<status status="PASS" starttime="20191023 09:43:20.491" endtime="20191023 09:43:20.492"/>
 </kw>
 <kw name="Call Method" library="BuiltIn">
-<doc>Calls the named method of the given object with the provided arguments.</doc>
-<arguments>
 <arg>${options}</arg>
 <arg>add_argument</arg>
 <arg>--disable-notifications</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:43:20.493" endtime="20191023 09:43:20.493"></status>
+<doc>Calls the named method of the given object with the provided arguments.</doc>
+<status status="PASS" starttime="20191023 09:43:20.493" endtime="20191023 09:43:20.493"/>
 </kw>
 <msg timestamp="20191023 09:43:20.493" level="INFO">${options} = &lt;selenium.webdriver.chrome.options.Options object at 0x10d85bda0&gt;</msg>
-<status status="PASS" starttime="20191023 09:43:20.483" endtime="20191023 09:43:20.493"></status>
+<status status="PASS" starttime="20191023 09:43:20.483" endtime="20191023 09:43:20.493"/>
 </kw>
 <kw name="Create Webdriver With Retry" library="cumulusci.robotframework.Salesforce">
-<doc>Call the Create Webdriver keyword.</doc>
-<arguments>
 <arg>Chrome</arg>
 <arg>options=${options}</arg>
 <arg>alias=${alias}</arg>
-</arguments>
+<doc>Call the Create Webdriver keyword.</doc>
 <msg timestamp="20191023 09:43:20.494" level="INFO">Creating an instance of the Chrome WebDriver.</msg>
 <msg timestamp="20191023 09:43:23.514" level="FAIL">SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </msg>
-<status status="FAIL" starttime="20191023 09:43:20.493" endtime="20191023 09:43:23.514"></status>
+<status status="FAIL" starttime="20191023 09:43:20.493" endtime="20191023 09:43:23.514"/>
 </kw>
-<status status="FAIL" starttime="20191023 09:43:20.482" endtime="20191023 09:43:23.515"></status>
+<status status="FAIL" starttime="20191023 09:43:20.482" endtime="20191023 09:43:23.515"/>
 </kw>
-<status status="FAIL" starttime="20191023 09:43:20.481" endtime="20191023 09:43:23.515"></status>
+<status status="FAIL" starttime="20191023 09:43:20.481" endtime="20191023 09:43:23.515"/>
 </kw>
-<status status="FAIL" starttime="20191023 09:43:20.480" endtime="20191023 09:43:23.515"></status>
+<status status="FAIL" starttime="20191023 09:43:20.480" endtime="20191023 09:43:23.515"/>
 </kw>
-<kw name="Close All Browsers" library="SeleniumLibrary" type="teardown">
+<kw name="Close All Browsers" library="SeleniumLibrary" type="TEARDOWN">
 <doc>Closes all open browsers and resets the browser cache.</doc>
-<status status="PASS" starttime="20191023 09:43:23.516" endtime="20191023 09:43:23.516"></status>
+<status status="PASS" starttime="20191023 09:43:23.516" endtime="20191023 09:43:23.516"/>
 </kw>
 <doc>Verify that we automatically resize browser to minimum supported size</doc>
-<status status="FAIL" starttime="20191023 09:43:20.479" endtime="20191023 09:43:23.517" critical="yes">SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
+<status status="FAIL" starttime="20191023 09:43:20.479" endtime="20191023 09:43:23.517">SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </status>
 </test>
 <test id="s1-s2-s2-t4" name="Explicit browser size">
 <kw name="Open Test Browser" library="Salesforce">
-<doc>Opens a test browser to the org.</doc>
-<arguments>
 <arg>size=1400x1200</arg>
-</arguments>
+<doc>Opens a test browser to the org.</doc>
 <kw name="Login Url" library="cumulusci.robotframework.CumulusCI">
+<var>${login_url}</var>
 <doc>Returns the login url which will automatically log into the target
 Salesforce org.  By default, the org_name passed to the library
 constructor is used but this can be overridden with the org option
 to log into a different org.</doc>
-<assign>
-<var>${login_url}</var>
-</assign>
 <msg timestamp="20191023 09:43:23.525" level="INFO">${login_url} = https://efficiency-fun-590-dev-ed.cs93.my.salesforce.com/secur/frontdoor.jsp?sid=MASKED</msg>
-<status status="PASS" starttime="20191023 09:43:23.524" endtime="20191023 09:43:23.525"></status>
+<status status="PASS" starttime="20191023 09:43:23.524" endtime="20191023 09:43:23.525"/>
 </kw>
 <kw name="Run Keyword If" library="BuiltIn">
-<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
-<arguments>
 <arg>'${BROWSER}' == 'chrome'</arg>
 <arg>Open Test Browser Chrome</arg>
 <arg>${login_url}</arg>
@@ -3045,118 +2425,94 @@ to log into a different org.</doc>
 <arg>${login_url}</arg>
 <arg>${BROWSER}</arg>
 <arg>alias=${alias}</arg>
-</arguments>
+<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
 <kw name="Open Test Browser Chrome" library="Salesforce">
-<arguments>
 <arg>${login_url}</arg>
 <arg>alias=${alias}</arg>
-</arguments>
 <kw name="Get Chrome Options" library="Salesforce">
-<assign>
 <var>${options}</var>
-</assign>
 <kw name="Evaluate" library="BuiltIn">
-<doc>Evaluates the given expression in Python and returns the results.</doc>
-<arguments>
+<var>${options}</var>
 <arg>selenium.webdriver.ChromeOptions()</arg>
 <arg>modules=selenium</arg>
-</arguments>
-<assign>
-<var>${options}</var>
-</assign>
+<doc>Evaluates the given expression in Python and returns the results.</doc>
 <msg timestamp="20191023 09:43:23.528" level="INFO">${options} = &lt;selenium.webdriver.chrome.options.Options object at 0x10d7584e0&gt;</msg>
-<status status="PASS" starttime="20191023 09:43:23.527" endtime="20191023 09:43:23.528"></status>
+<status status="PASS" starttime="20191023 09:43:23.527" endtime="20191023 09:43:23.528"/>
 </kw>
 <kw name="Run Keyword If" library="BuiltIn">
-<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
-<arguments>
 <arg>'${BROWSER}' == 'headlesschrome'</arg>
 <arg>Chrome Set Headless</arg>
 <arg>${options}</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:43:23.528" endtime="20191023 09:43:23.529"></status>
+<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
+<status status="PASS" starttime="20191023 09:43:23.528" endtime="20191023 09:43:23.529"/>
 </kw>
 <kw name="Run Keyword If" library="BuiltIn">
-<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
-<arguments>
 <arg>'${CHROME_BINARY}' != '${empty}'</arg>
 <arg>Chrome Set Binary</arg>
 <arg>${options}</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:43:23.529" endtime="20191023 09:43:23.529"></status>
+<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
+<status status="PASS" starttime="20191023 09:43:23.529" endtime="20191023 09:43:23.529"/>
 </kw>
 <kw name="Call Method" library="BuiltIn">
-<doc>Calls the named method of the given object with the provided arguments.</doc>
-<arguments>
 <arg>${options}</arg>
 <arg>add_argument</arg>
 <arg>--disable-notifications</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:43:23.529" endtime="20191023 09:43:23.530"></status>
+<doc>Calls the named method of the given object with the provided arguments.</doc>
+<status status="PASS" starttime="20191023 09:43:23.529" endtime="20191023 09:43:23.530"/>
 </kw>
 <msg timestamp="20191023 09:43:23.530" level="INFO">${options} = &lt;selenium.webdriver.chrome.options.Options object at 0x10d7584e0&gt;</msg>
-<status status="PASS" starttime="20191023 09:43:23.527" endtime="20191023 09:43:23.530"></status>
+<status status="PASS" starttime="20191023 09:43:23.527" endtime="20191023 09:43:23.530"/>
 </kw>
 <kw name="Create Webdriver With Retry" library="cumulusci.robotframework.Salesforce">
-<doc>Call the Create Webdriver keyword.</doc>
-<arguments>
 <arg>Chrome</arg>
 <arg>options=${options}</arg>
 <arg>alias=${alias}</arg>
-</arguments>
+<doc>Call the Create Webdriver keyword.</doc>
 <msg timestamp="20191023 09:43:23.531" level="INFO">Creating an instance of the Chrome WebDriver.</msg>
 <msg timestamp="20191023 09:43:27.363" level="FAIL">SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </msg>
-<status status="FAIL" starttime="20191023 09:43:23.530" endtime="20191023 09:43:27.364"></status>
+<status status="FAIL" starttime="20191023 09:43:23.530" endtime="20191023 09:43:27.364"/>
 </kw>
-<status status="FAIL" starttime="20191023 09:43:23.526" endtime="20191023 09:43:27.364"></status>
+<status status="FAIL" starttime="20191023 09:43:23.526" endtime="20191023 09:43:27.364"/>
 </kw>
-<status status="FAIL" starttime="20191023 09:43:23.525" endtime="20191023 09:43:27.364"></status>
+<status status="FAIL" starttime="20191023 09:43:23.525" endtime="20191023 09:43:27.364"/>
 </kw>
-<status status="FAIL" starttime="20191023 09:43:23.521" endtime="20191023 09:43:27.364"></status>
+<status status="FAIL" starttime="20191023 09:43:23.521" endtime="20191023 09:43:27.364"/>
 </kw>
-<kw name="Close All Browsers" library="SeleniumLibrary" type="teardown">
+<kw name="Close All Browsers" library="SeleniumLibrary" type="TEARDOWN">
 <doc>Closes all open browsers and resets the browser cache.</doc>
-<status status="PASS" starttime="20191023 09:43:27.365" endtime="20191023 09:43:27.366"></status>
+<status status="PASS" starttime="20191023 09:43:27.365" endtime="20191023 09:43:27.366"/>
 </kw>
 <doc>Verify we can set an explicit browser size when opening the window</doc>
-<status status="FAIL" starttime="20191023 09:43:23.518" endtime="20191023 09:43:27.366" critical="yes">SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
+<status status="FAIL" starttime="20191023 09:43:23.518" endtime="20191023 09:43:27.366">SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </status>
 </test>
 <test id="s1-s2-s2-t5" name="Open Test Browser calls Log Browser Capabilities">
 <kw name="Reset Robot Log Cache" library="TestListener">
-<status status="PASS" starttime="20191023 09:43:27.368" endtime="20191023 09:43:27.368"></status>
+<status status="PASS" starttime="20191023 09:43:27.368" endtime="20191023 09:43:27.368"/>
 </kw>
 <kw name="Set Test Variable" library="BuiltIn">
-<doc>Makes a variable available everywhere within the scope of the current test.</doc>
-<arguments>
 <arg>${BROWSER}</arg>
 <arg>headlesschrome</arg>
-</arguments>
+<doc>Makes a variable available everywhere within the scope of the current test.</doc>
 <msg timestamp="20191023 09:43:27.369" level="INFO">${BROWSER} = headlesschrome</msg>
-<status status="PASS" starttime="20191023 09:43:27.369" endtime="20191023 09:43:27.369"></status>
+<status status="PASS" starttime="20191023 09:43:27.369" endtime="20191023 09:43:27.369"/>
 </kw>
 <kw name="Open Test Browser" library="Salesforce">
-<doc>Opens a test browser to the org.</doc>
-<arguments>
 <arg>alias=chrome</arg>
-</arguments>
+<doc>Opens a test browser to the org.</doc>
 <kw name="Login Url" library="cumulusci.robotframework.CumulusCI">
+<var>${login_url}</var>
 <doc>Returns the login url which will automatically log into the target
 Salesforce org.  By default, the org_name passed to the library
 constructor is used but this can be overridden with the org option
 to log into a different org.</doc>
-<assign>
-<var>${login_url}</var>
-</assign>
 <msg timestamp="20191023 09:43:27.371" level="INFO">${login_url} = https://efficiency-fun-590-dev-ed.cs93.my.salesforce.com/secur/frontdoor.jsp?sid=MASKED</msg>
-<status status="PASS" starttime="20191023 09:43:27.370" endtime="20191023 09:43:27.371"></status>
+<status status="PASS" starttime="20191023 09:43:27.370" endtime="20191023 09:43:27.371"/>
 </kw>
 <kw name="Run Keyword If" library="BuiltIn">
-<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
-<arguments>
 <arg>'${BROWSER}' == 'chrome'</arg>
 <arg>Open Test Browser Chrome</arg>
 <arg>${login_url}</arg>
@@ -3181,143 +2537,115 @@ to log into a different org.</doc>
 <arg>${login_url}</arg>
 <arg>${BROWSER}</arg>
 <arg>alias=${alias}</arg>
-</arguments>
+<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
 <kw name="Open Test Browser Chrome" library="Salesforce">
-<arguments>
 <arg>${login_url}</arg>
 <arg>alias=${alias}</arg>
-</arguments>
 <kw name="Get Chrome Options" library="Salesforce">
-<assign>
 <var>${options}</var>
-</assign>
 <kw name="Evaluate" library="BuiltIn">
-<doc>Evaluates the given expression in Python and returns the results.</doc>
-<arguments>
+<var>${options}</var>
 <arg>selenium.webdriver.ChromeOptions()</arg>
 <arg>modules=selenium</arg>
-</arguments>
-<assign>
-<var>${options}</var>
-</assign>
+<doc>Evaluates the given expression in Python and returns the results.</doc>
 <msg timestamp="20191023 09:43:27.374" level="INFO">${options} = &lt;selenium.webdriver.chrome.options.Options object at 0x10d703f98&gt;</msg>
-<status status="PASS" starttime="20191023 09:43:27.373" endtime="20191023 09:43:27.374"></status>
+<status status="PASS" starttime="20191023 09:43:27.373" endtime="20191023 09:43:27.374"/>
 </kw>
 <kw name="Run Keyword If" library="BuiltIn">
-<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
-<arguments>
 <arg>'${BROWSER}' == 'headlesschrome'</arg>
 <arg>Chrome Set Headless</arg>
 <arg>${options}</arg>
-</arguments>
+<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
 <kw name="Chrome Set Headless" library="Salesforce">
-<arguments>
 <arg>${options}</arg>
-</arguments>
 <kw name="Call Method" library="BuiltIn">
-<doc>Calls the named method of the given object with the provided arguments.</doc>
-<arguments>
 <arg>${options}</arg>
 <arg>set_headless</arg>
 <arg>${true}</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:43:27.375" endtime="20191023 09:43:27.376"></status>
+<doc>Calls the named method of the given object with the provided arguments.</doc>
+<status status="PASS" starttime="20191023 09:43:27.375" endtime="20191023 09:43:27.376"/>
 </kw>
 <kw name="Call Method" library="BuiltIn">
-<doc>Calls the named method of the given object with the provided arguments.</doc>
-<arguments>
 <arg>${options}</arg>
 <arg>add_argument</arg>
 <arg>--disable-dev-shm-usage</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:43:27.376" endtime="20191023 09:43:27.377"></status>
+<doc>Calls the named method of the given object with the provided arguments.</doc>
+<status status="PASS" starttime="20191023 09:43:27.376" endtime="20191023 09:43:27.377"/>
 </kw>
 <kw name="Call Method" library="BuiltIn">
-<doc>Calls the named method of the given object with the provided arguments.</doc>
-<arguments>
 <arg>${options}</arg>
 <arg>add_argument</arg>
 <arg>--disable-background-timer-throttling</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:43:27.377" endtime="20191023 09:43:27.377"></status>
+<doc>Calls the named method of the given object with the provided arguments.</doc>
+<status status="PASS" starttime="20191023 09:43:27.377" endtime="20191023 09:43:27.377"/>
 </kw>
-<status status="PASS" starttime="20191023 09:43:27.375" endtime="20191023 09:43:27.377"></status>
+<status status="PASS" starttime="20191023 09:43:27.375" endtime="20191023 09:43:27.377"/>
 </kw>
-<status status="PASS" starttime="20191023 09:43:27.374" endtime="20191023 09:43:27.377"></status>
+<status status="PASS" starttime="20191023 09:43:27.374" endtime="20191023 09:43:27.377"/>
 </kw>
 <kw name="Run Keyword If" library="BuiltIn">
-<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
-<arguments>
 <arg>'${CHROME_BINARY}' != '${empty}'</arg>
 <arg>Chrome Set Binary</arg>
 <arg>${options}</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:43:27.378" endtime="20191023 09:43:27.378"></status>
+<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
+<status status="PASS" starttime="20191023 09:43:27.378" endtime="20191023 09:43:27.378"/>
 </kw>
 <kw name="Call Method" library="BuiltIn">
-<doc>Calls the named method of the given object with the provided arguments.</doc>
-<arguments>
 <arg>${options}</arg>
 <arg>add_argument</arg>
 <arg>--disable-notifications</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:43:27.378" endtime="20191023 09:43:27.379"></status>
+<doc>Calls the named method of the given object with the provided arguments.</doc>
+<status status="PASS" starttime="20191023 09:43:27.378" endtime="20191023 09:43:27.379"/>
 </kw>
 <msg timestamp="20191023 09:43:27.379" level="INFO">${options} = &lt;selenium.webdriver.chrome.options.Options object at 0x10d703f98&gt;</msg>
-<status status="PASS" starttime="20191023 09:43:27.373" endtime="20191023 09:43:27.379"></status>
+<status status="PASS" starttime="20191023 09:43:27.373" endtime="20191023 09:43:27.379"/>
 </kw>
 <kw name="Create Webdriver With Retry" library="cumulusci.robotframework.Salesforce">
-<doc>Call the Create Webdriver keyword.</doc>
-<arguments>
 <arg>Chrome</arg>
 <arg>options=${options}</arg>
 <arg>alias=${alias}</arg>
-</arguments>
+<doc>Call the Create Webdriver keyword.</doc>
 <msg timestamp="20191023 09:43:27.380" level="INFO">Creating an instance of the Chrome WebDriver.</msg>
 <msg timestamp="20191023 09:43:28.766" level="FAIL">SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </msg>
-<status status="FAIL" starttime="20191023 09:43:27.379" endtime="20191023 09:43:28.766"></status>
+<status status="FAIL" starttime="20191023 09:43:27.379" endtime="20191023 09:43:28.766"/>
 </kw>
-<status status="FAIL" starttime="20191023 09:43:27.372" endtime="20191023 09:43:28.766"></status>
+<status status="FAIL" starttime="20191023 09:43:27.372" endtime="20191023 09:43:28.766"/>
 </kw>
-<status status="FAIL" starttime="20191023 09:43:27.371" endtime="20191023 09:43:28.766"></status>
+<status status="FAIL" starttime="20191023 09:43:27.371" endtime="20191023 09:43:28.766"/>
 </kw>
-<status status="FAIL" starttime="20191023 09:43:27.370" endtime="20191023 09:43:28.767"></status>
+<status status="FAIL" starttime="20191023 09:43:27.370" endtime="20191023 09:43:28.767"/>
 </kw>
-<kw name="Close All Browsers" library="SeleniumLibrary" type="teardown">
+<kw name="Close All Browsers" library="SeleniumLibrary" type="TEARDOWN">
 <doc>Closes all open browsers and resets the browser cache.</doc>
-<status status="PASS" starttime="20191023 09:43:28.767" endtime="20191023 09:43:28.768"></status>
+<status status="PASS" starttime="20191023 09:43:28.767" endtime="20191023 09:43:28.768"/>
 </kw>
 <doc>Verify that browser capabilities are logged when we call
 Open Test Browser</doc>
-<status status="FAIL" starttime="20191023 09:43:27.367" endtime="20191023 09:43:28.768" critical="yes">SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
+<status status="FAIL" starttime="20191023 09:43:27.367" endtime="20191023 09:43:28.768">SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </status>
 </test>
-<kw name="Close All Browsers" library="SeleniumLibrary" type="teardown">
+<kw name="Close All Browsers" library="SeleniumLibrary" type="TEARDOWN">
 <doc>Closes all open browsers and resets the browser cache.</doc>
-<status status="PASS" starttime="20191023 09:43:28.774" endtime="20191023 09:43:28.775"></status>
+<status status="PASS" starttime="20191023 09:43:28.774" endtime="20191023 09:43:28.775"/>
 </kw>
-<status status="FAIL" starttime="20191023 09:43:10.918" endtime="20191023 09:43:28.775"></status>
+<status status="FAIL" starttime="20191023 09:43:10.918" endtime="20191023 09:43:28.775"/>
 </suite>
 <suite id="s1-s2-s3" name="Create Contact" source="/Users/pprescod/code/CumulusCI/cumulusci/robotframework/tests/salesforce/create_contact.robot">
-<kw name="Open Test Browser" library="Salesforce" type="setup">
+<kw name="Open Test Browser" library="Salesforce" type="SETUP">
 <doc>Opens a test browser to the org.</doc>
 <kw name="Login Url" library="cumulusci.robotframework.CumulusCI">
+<var>${login_url}</var>
 <doc>Returns the login url which will automatically log into the target
 Salesforce org.  By default, the org_name passed to the library
 constructor is used but this can be overridden with the org option
 to log into a different org.</doc>
-<assign>
-<var>${login_url}</var>
-</assign>
 <msg timestamp="20191023 09:43:28.798" level="INFO">${login_url} = https://efficiency-fun-590-dev-ed.cs93.my.salesforce.com/secur/frontdoor.jsp?sid=MASKED</msg>
-<status status="PASS" starttime="20191023 09:43:28.798" endtime="20191023 09:43:28.798"></status>
+<status status="PASS" starttime="20191023 09:43:28.798" endtime="20191023 09:43:28.798"/>
 </kw>
 <kw name="Run Keyword If" library="BuiltIn">
-<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
-<arguments>
 <arg>'${BROWSER}' == 'chrome'</arg>
 <arg>Open Test Browser Chrome</arg>
 <arg>${login_url}</arg>
@@ -3342,103 +2670,87 @@ to log into a different org.</doc>
 <arg>${login_url}</arg>
 <arg>${BROWSER}</arg>
 <arg>alias=${alias}</arg>
-</arguments>
+<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
 <kw name="Open Test Browser Chrome" library="Salesforce">
-<arguments>
 <arg>${login_url}</arg>
 <arg>alias=${alias}</arg>
-</arguments>
 <kw name="Get Chrome Options" library="Salesforce">
-<assign>
 <var>${options}</var>
-</assign>
 <kw name="Evaluate" library="BuiltIn">
-<doc>Evaluates the given expression in Python and returns the results.</doc>
-<arguments>
+<var>${options}</var>
 <arg>selenium.webdriver.ChromeOptions()</arg>
 <arg>modules=selenium</arg>
-</arguments>
-<assign>
-<var>${options}</var>
-</assign>
+<doc>Evaluates the given expression in Python and returns the results.</doc>
 <msg timestamp="20191023 09:43:28.832" level="INFO">${options} = &lt;selenium.webdriver.chrome.options.Options object at 0x10d425400&gt;</msg>
-<status status="PASS" starttime="20191023 09:43:28.831" endtime="20191023 09:43:28.832"></status>
+<status status="PASS" starttime="20191023 09:43:28.831" endtime="20191023 09:43:28.832"/>
 </kw>
 <kw name="Run Keyword If" library="BuiltIn">
-<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
-<arguments>
 <arg>'${BROWSER}' == 'headlesschrome'</arg>
 <arg>Chrome Set Headless</arg>
 <arg>${options}</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:43:28.832" endtime="20191023 09:43:28.833"></status>
+<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
+<status status="PASS" starttime="20191023 09:43:28.832" endtime="20191023 09:43:28.833"/>
 </kw>
 <kw name="Run Keyword If" library="BuiltIn">
-<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
-<arguments>
 <arg>'${CHROME_BINARY}' != '${empty}'</arg>
 <arg>Chrome Set Binary</arg>
 <arg>${options}</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:43:28.833" endtime="20191023 09:43:28.834"></status>
+<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
+<status status="PASS" starttime="20191023 09:43:28.833" endtime="20191023 09:43:28.834"/>
 </kw>
 <kw name="Call Method" library="BuiltIn">
-<doc>Calls the named method of the given object with the provided arguments.</doc>
-<arguments>
 <arg>${options}</arg>
 <arg>add_argument</arg>
 <arg>--disable-notifications</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:43:28.834" endtime="20191023 09:43:28.834"></status>
+<doc>Calls the named method of the given object with the provided arguments.</doc>
+<status status="PASS" starttime="20191023 09:43:28.834" endtime="20191023 09:43:28.834"/>
 </kw>
 <msg timestamp="20191023 09:43:28.835" level="INFO">${options} = &lt;selenium.webdriver.chrome.options.Options object at 0x10d425400&gt;</msg>
-<status status="PASS" starttime="20191023 09:43:28.831" endtime="20191023 09:43:28.835"></status>
+<status status="PASS" starttime="20191023 09:43:28.831" endtime="20191023 09:43:28.835"/>
 </kw>
 <kw name="Create Webdriver With Retry" library="cumulusci.robotframework.Salesforce">
-<doc>Call the Create Webdriver keyword.</doc>
-<arguments>
 <arg>Chrome</arg>
 <arg>options=${options}</arg>
 <arg>alias=${alias}</arg>
-</arguments>
+<doc>Call the Create Webdriver keyword.</doc>
 <msg timestamp="20191023 09:43:28.836" level="INFO">Creating an instance of the Chrome WebDriver.</msg>
 <msg timestamp="20191023 09:43:31.434" level="FAIL">SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </msg>
-<status status="FAIL" starttime="20191023 09:43:28.835" endtime="20191023 09:43:31.435"></status>
+<status status="FAIL" starttime="20191023 09:43:28.835" endtime="20191023 09:43:31.435"/>
 </kw>
-<status status="FAIL" starttime="20191023 09:43:28.799" endtime="20191023 09:43:31.435"></status>
+<status status="FAIL" starttime="20191023 09:43:28.799" endtime="20191023 09:43:31.435"/>
 </kw>
-<status status="FAIL" starttime="20191023 09:43:28.799" endtime="20191023 09:43:31.435"></status>
+<status status="FAIL" starttime="20191023 09:43:28.799" endtime="20191023 09:43:31.435"/>
 </kw>
-<status status="FAIL" starttime="20191023 09:43:28.797" endtime="20191023 09:43:31.435"></status>
+<status status="FAIL" starttime="20191023 09:43:28.797" endtime="20191023 09:43:31.435"/>
 </kw>
 <test id="s1-s2-s3-t1" name="Via API">
-<status status="FAIL" starttime="20191023 09:43:31.435" endtime="20191023 09:43:31.436" critical="yes">Parent suite setup failed:
+<status status="FAIL" starttime="20191023 09:43:31.435" endtime="20191023 09:43:31.436">Parent suite setup failed:
 SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </status>
 </test>
 <test id="s1-s2-s3-t2" name="Via UI">
-<status status="FAIL" starttime="20191023 09:43:31.437" endtime="20191023 09:43:31.437" critical="yes">Parent suite setup failed:
+<status status="FAIL" starttime="20191023 09:43:31.437" endtime="20191023 09:43:31.437">Parent suite setup failed:
 SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </status>
 </test>
-<kw name="Delete Records and Close Browser" library="Salesforce" type="teardown">
+<kw name="Delete Records and Close Browser" library="Salesforce" type="TEARDOWN">
 <doc>This will close all open browser windows and then delete
 all records created with the Salesforce API during this
 testing session.</doc>
 <kw name="Close All Browsers" library="SeleniumLibrary">
 <doc>Closes all open browsers and resets the browser cache.</doc>
-<status status="PASS" starttime="20191023 09:43:31.439" endtime="20191023 09:43:31.439"></status>
+<status status="PASS" starttime="20191023 09:43:31.439" endtime="20191023 09:43:31.439"/>
 </kw>
 <kw name="Delete Session Records" library="cumulusci.robotframework.Salesforce">
 <doc>Deletes records that were created while running this test case.</doc>
 <msg timestamp="20191023 09:43:31.439" level="INFO">Deleting 0 records</msg>
-<status status="PASS" starttime="20191023 09:43:31.439" endtime="20191023 09:43:31.439"></status>
+<status status="PASS" starttime="20191023 09:43:31.439" endtime="20191023 09:43:31.439"/>
 </kw>
-<status status="PASS" starttime="20191023 09:43:31.438" endtime="20191023 09:43:31.440"></status>
+<status status="PASS" starttime="20191023 09:43:31.438" endtime="20191023 09:43:31.440"/>
 </kw>
 <status status="FAIL" starttime="20191023 09:43:28.781" endtime="20191023 09:43:31.440">Suite setup failed:
 SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
@@ -3447,80 +2759,64 @@ SessionNotCreatedException: Message: session not created: Chrome version must be
 </suite>
 <suite id="s1-s2-s4" name="Pageobjects" source="/Users/pprescod/code/CumulusCI/cumulusci/robotframework/tests/salesforce/pageobjects">
 <suite id="s1-s2-s4-s1" name="Pageobjects" source="/Users/pprescod/code/CumulusCI/cumulusci/robotframework/tests/salesforce/pageobjects/pageobjects.robot">
-<kw name="Run Keywords" library="BuiltIn" type="setup">
-<doc>Executes all the given keywords in a sequence.</doc>
-<arguments>
+<kw name="Run Keywords" library="BuiltIn" type="SETUP">
 <arg>Create test data</arg>
 <arg>AND</arg>
 <arg>Open Test Browser</arg>
-</arguments>
+<doc>Executes all the given keywords in a sequence.</doc>
 <kw name="Create Test Data">
 <doc>Create a Contact for Connor MacLeod if there isn't one. If there's
 already more than one, it's a fatal error since some tests depend
 on their being only one.</doc>
 <kw name="Salesforce Query" library="cumulusci.robotframework.Salesforce">
-<doc>Constructs and runs a simple SOQL query and returns the dict results</doc>
-<arguments>
+<var>${result}</var>
 <arg>Contact</arg>
 <arg>Firstname=Connor</arg>
 <arg>LastName=MacLeod</arg>
-</arguments>
-<assign>
-<var>${result}</var>
-</assign>
+<doc>Constructs and runs a simple SOQL query and returns the dict results</doc>
 <msg timestamp="20191023 09:43:31.471" level="INFO">Running SOQL Query: SELECT Id FROM Contact WHERE Firstname = 'Connor' AND LastName = 'MacLeod'</msg>
 <msg timestamp="20191023 09:43:31.710" level="INFO">${result} = []</msg>
-<status status="PASS" starttime="20191023 09:43:31.471" endtime="20191023 09:43:31.710"></status>
+<status status="PASS" starttime="20191023 09:43:31.471" endtime="20191023 09:43:31.710"/>
 </kw>
 <kw name="Run Keyword If" library="BuiltIn">
-<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
-<arguments>
 <arg>len($result) &gt; 1</arg>
 <arg>Fatal Error</arg>
 <arg>Expected to find only one contact named Connor MacLeod, found several</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:43:31.710" endtime="20191023 09:43:31.711"></status>
+<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
+<status status="PASS" starttime="20191023 09:43:31.710" endtime="20191023 09:43:31.711"/>
 </kw>
 <kw name="Run Keyword If" library="BuiltIn">
-<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
-<arguments>
 <arg>len($result) == 0</arg>
 <arg>Salesforce Insert</arg>
 <arg>Contact</arg>
 <arg>FirstName=Connor</arg>
 <arg>LastName=MacLeod</arg>
-</arguments>
+<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
 <kw name="Salesforce Insert" library="cumulusci.robotframework.Salesforce">
-<doc>Inserts a Salesforce object setting fields using kwargs and returns the id</doc>
-<arguments>
 <arg>Contact</arg>
 <arg>FirstName=Connor</arg>
 <arg>LastName=MacLeod</arg>
-</arguments>
+<doc>Inserts a Salesforce object setting fields using kwargs and returns the id</doc>
 <msg timestamp="20191023 09:43:31.712" level="INFO">Inserting Contact with values {'FirstName': 'Connor', 'LastName': 'MacLeod'}</msg>
 <msg timestamp="20191023 09:43:32.045" level="INFO">Storing Contact 0034F00000SaS5BQAV to session records</msg>
-<status status="PASS" starttime="20191023 09:43:31.712" endtime="20191023 09:43:32.045"></status>
+<status status="PASS" starttime="20191023 09:43:31.712" endtime="20191023 09:43:32.045"/>
 </kw>
-<status status="PASS" starttime="20191023 09:43:31.711" endtime="20191023 09:43:32.045"></status>
+<status status="PASS" starttime="20191023 09:43:31.711" endtime="20191023 09:43:32.045"/>
 </kw>
-<status status="PASS" starttime="20191023 09:43:31.471" endtime="20191023 09:43:32.045"></status>
+<status status="PASS" starttime="20191023 09:43:31.471" endtime="20191023 09:43:32.045"/>
 </kw>
 <kw name="Open Test Browser" library="Salesforce">
 <doc>Opens a test browser to the org.</doc>
 <kw name="Login Url" library="cumulusci.robotframework.CumulusCI">
+<var>${login_url}</var>
 <doc>Returns the login url which will automatically log into the target
 Salesforce org.  By default, the org_name passed to the library
 constructor is used but this can be overridden with the org option
 to log into a different org.</doc>
-<assign>
-<var>${login_url}</var>
-</assign>
 <msg timestamp="20191023 09:43:32.046" level="INFO">${login_url} = https://efficiency-fun-590-dev-ed.cs93.my.salesforce.com/secur/frontdoor.jsp?sid=MASKED</msg>
-<status status="PASS" starttime="20191023 09:43:32.046" endtime="20191023 09:43:32.046"></status>
+<status status="PASS" starttime="20191023 09:43:32.046" endtime="20191023 09:43:32.046"/>
 </kw>
 <kw name="Run Keyword If" library="BuiltIn">
-<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
-<arguments>
 <arg>'${BROWSER}' == 'chrome'</arg>
 <arg>Open Test Browser Chrome</arg>
 <arg>${login_url}</arg>
@@ -3545,96 +2841,80 @@ to log into a different org.</doc>
 <arg>${login_url}</arg>
 <arg>${BROWSER}</arg>
 <arg>alias=${alias}</arg>
-</arguments>
+<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
 <kw name="Open Test Browser Chrome" library="Salesforce">
-<arguments>
 <arg>${login_url}</arg>
 <arg>alias=${alias}</arg>
-</arguments>
 <kw name="Get Chrome Options" library="Salesforce">
-<assign>
 <var>${options}</var>
-</assign>
 <kw name="Evaluate" library="BuiltIn">
-<doc>Evaluates the given expression in Python and returns the results.</doc>
-<arguments>
+<var>${options}</var>
 <arg>selenium.webdriver.ChromeOptions()</arg>
 <arg>modules=selenium</arg>
-</arguments>
-<assign>
-<var>${options}</var>
-</assign>
+<doc>Evaluates the given expression in Python and returns the results.</doc>
 <msg timestamp="20191023 09:43:32.048" level="INFO">${options} = &lt;selenium.webdriver.chrome.options.Options object at 0x10d57acf8&gt;</msg>
-<status status="PASS" starttime="20191023 09:43:32.048" endtime="20191023 09:43:32.048"></status>
+<status status="PASS" starttime="20191023 09:43:32.048" endtime="20191023 09:43:32.048"/>
 </kw>
 <kw name="Run Keyword If" library="BuiltIn">
-<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
-<arguments>
 <arg>'${BROWSER}' == 'headlesschrome'</arg>
 <arg>Chrome Set Headless</arg>
 <arg>${options}</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:43:32.048" endtime="20191023 09:43:32.048"></status>
+<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
+<status status="PASS" starttime="20191023 09:43:32.048" endtime="20191023 09:43:32.048"/>
 </kw>
 <kw name="Run Keyword If" library="BuiltIn">
-<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
-<arguments>
 <arg>'${CHROME_BINARY}' != '${empty}'</arg>
 <arg>Chrome Set Binary</arg>
 <arg>${options}</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:43:32.048" endtime="20191023 09:43:32.049"></status>
+<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
+<status status="PASS" starttime="20191023 09:43:32.048" endtime="20191023 09:43:32.049"/>
 </kw>
 <kw name="Call Method" library="BuiltIn">
-<doc>Calls the named method of the given object with the provided arguments.</doc>
-<arguments>
 <arg>${options}</arg>
 <arg>add_argument</arg>
 <arg>--disable-notifications</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:43:32.049" endtime="20191023 09:43:32.049"></status>
+<doc>Calls the named method of the given object with the provided arguments.</doc>
+<status status="PASS" starttime="20191023 09:43:32.049" endtime="20191023 09:43:32.049"/>
 </kw>
 <msg timestamp="20191023 09:43:32.049" level="INFO">${options} = &lt;selenium.webdriver.chrome.options.Options object at 0x10d57acf8&gt;</msg>
-<status status="PASS" starttime="20191023 09:43:32.047" endtime="20191023 09:43:32.050"></status>
+<status status="PASS" starttime="20191023 09:43:32.047" endtime="20191023 09:43:32.050"/>
 </kw>
 <kw name="Create Webdriver With Retry" library="cumulusci.robotframework.Salesforce">
-<doc>Call the Create Webdriver keyword.</doc>
-<arguments>
 <arg>Chrome</arg>
 <arg>options=${options}</arg>
 <arg>alias=${alias}</arg>
-</arguments>
+<doc>Call the Create Webdriver keyword.</doc>
 <msg timestamp="20191023 09:43:32.050" level="INFO">Creating an instance of the Chrome WebDriver.</msg>
 <msg timestamp="20191023 09:43:34.482" level="FAIL">SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </msg>
-<status status="FAIL" starttime="20191023 09:43:32.050" endtime="20191023 09:43:34.482"></status>
+<status status="FAIL" starttime="20191023 09:43:32.050" endtime="20191023 09:43:34.482"/>
 </kw>
-<status status="FAIL" starttime="20191023 09:43:32.047" endtime="20191023 09:43:34.483"></status>
+<status status="FAIL" starttime="20191023 09:43:32.047" endtime="20191023 09:43:34.483"/>
 </kw>
-<status status="FAIL" starttime="20191023 09:43:32.046" endtime="20191023 09:43:34.483"></status>
+<status status="FAIL" starttime="20191023 09:43:32.046" endtime="20191023 09:43:34.483"/>
 </kw>
-<status status="FAIL" starttime="20191023 09:43:32.045" endtime="20191023 09:43:34.483"></status>
+<status status="FAIL" starttime="20191023 09:43:32.045" endtime="20191023 09:43:34.483"/>
 </kw>
-<status status="FAIL" starttime="20191023 09:43:31.470" endtime="20191023 09:43:34.483"></status>
+<status status="FAIL" starttime="20191023 09:43:31.470" endtime="20191023 09:43:34.483"/>
 </kw>
 <test id="s1-s2-s4-s1-t1" name="Load page object, using defined page object">
 <doc>If we can't do this, all hope is lost!</doc>
-<status status="FAIL" starttime="20191023 09:43:34.484" endtime="20191023 09:43:34.485" critical="yes">Parent suite setup failed:
+<status status="FAIL" starttime="20191023 09:43:34.484" endtime="20191023 09:43:34.485">Parent suite setup failed:
 SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </status>
 </test>
 <test id="s1-s2-s4-s1-t2" name="Go to page automatically loads page object">
 <doc>Verify that 'go to page' automatically loads the page object</doc>
-<status status="FAIL" starttime="20191023 09:43:34.485" endtime="20191023 09:43:34.486" critical="yes">Parent suite setup failed:
+<status status="FAIL" starttime="20191023 09:43:34.485" endtime="20191023 09:43:34.486">Parent suite setup failed:
 SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </status>
 </test>
 <test id="s1-s2-s4-s1-t3" name="Go to page and current page should be, using defined page object">
 <doc>Verify we can go to an implemented page object</doc>
-<status status="FAIL" starttime="20191023 09:43:34.487" endtime="20191023 09:43:34.487" critical="yes">Parent suite setup failed:
+<status status="FAIL" starttime="20191023 09:43:34.487" endtime="20191023 09:43:34.487">Parent suite setup failed:
 SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </status>
@@ -3643,7 +2923,7 @@ SessionNotCreatedException: Message: session not created: Chrome version must be
 <doc>Verify we can go to a page object for which there is
 no explicit definition, but for which there is a generic
 (base) class.</doc>
-<status status="FAIL" starttime="20191023 09:43:34.488" endtime="20191023 09:43:34.489" critical="yes">Parent suite setup failed:
+<status status="FAIL" starttime="20191023 09:43:34.488" endtime="20191023 09:43:34.489">Parent suite setup failed:
 SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </status>
@@ -3655,7 +2935,7 @@ prevented this from working. What was happening is that we
 were giving the library a generic name like "DetailPage"
 rather than a name that included the object type such as
 "ContactDetailPage".</doc>
-<status status="FAIL" starttime="20191023 09:43:34.489" endtime="20191023 09:43:34.491" critical="yes">Parent suite setup failed:
+<status status="FAIL" starttime="20191023 09:43:34.489" endtime="20191023 09:43:34.491">Parent suite setup failed:
 SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </status>
@@ -3663,14 +2943,14 @@ SessionNotCreatedException: Message: session not created: Chrome version must be
 <test id="s1-s2-s4-s1-t6" name="Get page object">
 <doc>Verify that we can call the `get page object` keyword and that
 it returns a page object</doc>
-<status status="FAIL" starttime="20191023 09:43:34.492" endtime="20191023 09:43:34.493" critical="yes">Parent suite setup failed:
+<status status="FAIL" starttime="20191023 09:43:34.492" endtime="20191023 09:43:34.493">Parent suite setup failed:
 SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </status>
 </test>
 <test id="s1-s2-s4-s1-t7" name="Call keyword of defined page object">
 <doc>Verify we can call a keyword in a defined page object</doc>
-<status status="FAIL" starttime="20191023 09:43:34.493" endtime="20191023 09:43:34.494" critical="yes">Parent suite setup failed:
+<status status="FAIL" starttime="20191023 09:43:34.493" endtime="20191023 09:43:34.494">Parent suite setup failed:
 SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </status>
@@ -3678,7 +2958,7 @@ SessionNotCreatedException: Message: session not created: Chrome version must be
 <test id="s1-s2-s4-s1-t8" name="Load page object, using generic page object">
 <doc>Verify that 'load page object' works when using a generic
 page object</doc>
-<status status="FAIL" starttime="20191023 09:43:34.494" endtime="20191023 09:43:34.495" critical="yes">Parent suite setup failed:
+<status status="FAIL" starttime="20191023 09:43:34.494" endtime="20191023 09:43:34.495">Parent suite setup failed:
 SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </status>
@@ -3686,7 +2966,7 @@ SessionNotCreatedException: Message: session not created: Chrome version must be
 <test id="s1-s2-s4-s1-t9" name="Current page should be, using generic page object">
 <doc>Verify that 'current page should be' works when
 using a generic page object</doc>
-<status status="FAIL" starttime="20191023 09:43:34.496" endtime="20191023 09:43:34.497" critical="yes">Parent suite setup failed:
+<status status="FAIL" starttime="20191023 09:43:34.496" endtime="20191023 09:43:34.497">Parent suite setup failed:
 SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </status>
@@ -3694,7 +2974,7 @@ SessionNotCreatedException: Message: session not created: Chrome version must be
 <test id="s1-s2-s4-s1-t10" name="Current page should be throws appropriate error">
 <doc>Verifies the error that is thrown when 'current page should be'
 is false</doc>
-<status status="FAIL" starttime="20191023 09:43:34.497" endtime="20191023 09:43:34.498" critical="yes">Parent suite setup failed:
+<status status="FAIL" starttime="20191023 09:43:34.497" endtime="20191023 09:43:34.498">Parent suite setup failed:
 SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </status>
@@ -3702,14 +2982,14 @@ SessionNotCreatedException: Message: session not created: Chrome version must be
 <test id="s1-s2-s4-s1-t11" name="Error when no page object can be found">
 <doc>Verify we get an error if no page object exists, and
 there is no suitable base class</doc>
-<status status="FAIL" starttime="20191023 09:43:34.499" endtime="20191023 09:43:34.500" critical="yes">Parent suite setup failed:
+<status status="FAIL" starttime="20191023 09:43:34.499" endtime="20191023 09:43:34.500">Parent suite setup failed:
 SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </status>
 </test>
 <test id="s1-s2-s4-s1-t12" name="Log page object keywords">
 <doc>Verify that 'log page object keywords' doesn't throw an error</doc>
-<status status="FAIL" starttime="20191023 09:43:34.500" endtime="20191023 09:43:34.501" critical="yes">Parent suite setup failed:
+<status status="FAIL" starttime="20191023 09:43:34.500" endtime="20191023 09:43:34.501">Parent suite setup failed:
 SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </status>
@@ -3717,10 +2997,8 @@ SessionNotCreatedException: Message: session not created: Chrome version must be
 <test id="s1-s2-s4-s1-t13" name="Load multiple page objects in library search order">
 <doc>Loading a page object inserts it at the start of the
 library search order. Verify that that happens properly.</doc>
-<tags>
 <tag>bryan</tag>
-</tags>
-<status status="FAIL" starttime="20191023 09:43:34.502" endtime="20191023 09:43:34.503" critical="yes">Parent suite setup failed:
+<status status="FAIL" starttime="20191023 09:43:34.502" endtime="20191023 09:43:34.503">Parent suite setup failed:
 SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </status>
@@ -3728,7 +3006,7 @@ SessionNotCreatedException: Message: session not created: Chrome version must be
 <test id="s1-s2-s4-s1-t14" name="Base class: HomePage">
 <doc>Verify we can go to the generic Home page
 (assuming we don't have an explicit TaskHomePage)</doc>
-<status status="FAIL" starttime="20191023 09:43:34.504" endtime="20191023 09:43:34.504" critical="yes">Parent suite setup failed:
+<status status="FAIL" starttime="20191023 09:43:34.504" endtime="20191023 09:43:34.504">Parent suite setup failed:
 SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </status>
@@ -3736,7 +3014,7 @@ SessionNotCreatedException: Message: session not created: Chrome version must be
 <test id="s1-s2-s4-s1-t15" name="Base class: ListingPage">
 <doc>Verify we can go to the generic Listing page
 (assuming we don't have an explicit TaskListingPage)</doc>
-<status status="FAIL" starttime="20191023 09:43:34.505" endtime="20191023 09:43:34.505" critical="yes">Parent suite setup failed:
+<status status="FAIL" starttime="20191023 09:43:34.505" endtime="20191023 09:43:34.505">Parent suite setup failed:
 SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </status>
@@ -3744,70 +3022,64 @@ SessionNotCreatedException: Message: session not created: Chrome version must be
 <test id="s1-s2-s4-s1-t16" name="Base class: DetailPage">
 <doc>Verify we can go to the generic Detail page
 (assuming we don't have an explicit TaskDetailPage)</doc>
-<status status="FAIL" starttime="20191023 09:43:34.506" endtime="20191023 09:43:34.506" critical="yes">Parent suite setup failed:
+<status status="FAIL" starttime="20191023 09:43:34.506" endtime="20191023 09:43:34.506">Parent suite setup failed:
 SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </status>
 </test>
 <test id="s1-s2-s4-s1-t17" name="Base class: DetailPage with no matches">
-<status status="FAIL" starttime="20191023 09:43:34.507" endtime="20191023 09:43:34.508" critical="yes">Parent suite setup failed:
+<status status="FAIL" starttime="20191023 09:43:34.507" endtime="20191023 09:43:34.508">Parent suite setup failed:
 SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </status>
 </test>
 <test id="s1-s2-s4-s1-t18" name="Base class: DetailPage with more than one match">
-<status status="FAIL" starttime="20191023 09:43:34.508" endtime="20191023 09:43:34.509" critical="yes">Parent suite setup failed:
+<status status="FAIL" starttime="20191023 09:43:34.508" endtime="20191023 09:43:34.509">Parent suite setup failed:
 SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </status>
 </test>
-<kw name="Delete Records and Close Browser" library="Salesforce" type="teardown">
+<kw name="Delete Records and Close Browser" library="Salesforce" type="TEARDOWN">
 <doc>This will close all open browser windows and then delete
 all records created with the Salesforce API during this
 testing session.</doc>
 <kw name="Close All Browsers" library="SeleniumLibrary">
 <doc>Closes all open browsers and resets the browser cache.</doc>
-<status status="PASS" starttime="20191023 09:43:34.510" endtime="20191023 09:43:34.511"></status>
+<status status="PASS" starttime="20191023 09:43:34.510" endtime="20191023 09:43:34.511"/>
 </kw>
 <kw name="Delete Session Records" library="cumulusci.robotframework.Salesforce">
 <doc>Deletes records that were created while running this test case.</doc>
 <msg timestamp="20191023 09:43:34.511" level="INFO">Deleting 1 records</msg>
 <msg timestamp="20191023 09:43:34.511" level="INFO">  Deleting Contact 0034F00000SaS5BQAV</msg>
 <msg timestamp="20191023 09:43:34.511" level="INFO">Deleting Contact with Id 0034F00000SaS5BQAV</msg>
-<status status="PASS" starttime="20191023 09:43:34.511" endtime="20191023 09:43:35.107"></status>
+<status status="PASS" starttime="20191023 09:43:34.511" endtime="20191023 09:43:35.107"/>
 </kw>
-<status status="PASS" starttime="20191023 09:43:34.510" endtime="20191023 09:43:35.107"></status>
+<status status="PASS" starttime="20191023 09:43:34.510" endtime="20191023 09:43:35.107"/>
 </kw>
 <status status="FAIL" starttime="20191023 09:43:31.446" endtime="20191023 09:43:35.107">Suite setup failed:
 SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </status>
 </suite>
-<status status="FAIL" starttime="20191023 09:43:31.441" endtime="20191023 09:43:35.110"></status>
+<status status="FAIL" starttime="20191023 09:43:31.441" endtime="20191023 09:43:35.110"/>
 </suite>
 <suite id="s1-s2-s5" name="Populate" source="/Users/pprescod/code/CumulusCI/cumulusci/robotframework/tests/salesforce/populate.robot">
-<kw name="Run Keywords" library="BuiltIn" type="setup">
-<doc>Executes all the given keywords in a sequence.</doc>
-<arguments>
+<kw name="Run Keywords" library="BuiltIn" type="SETUP">
 <arg>Open test browser</arg>
 <arg>Create opportunity</arg>
-</arguments>
+<doc>Executes all the given keywords in a sequence.</doc>
 <kw name="Open Test Browser" library="Salesforce">
 <doc>Opens a test browser to the org.</doc>
 <kw name="Login Url" library="cumulusci.robotframework.CumulusCI">
+<var>${login_url}</var>
 <doc>Returns the login url which will automatically log into the target
 Salesforce org.  By default, the org_name passed to the library
 constructor is used but this can be overridden with the org option
 to log into a different org.</doc>
-<assign>
-<var>${login_url}</var>
-</assign>
 <msg timestamp="20191023 09:43:35.125" level="INFO">${login_url} = https://efficiency-fun-590-dev-ed.cs93.my.salesforce.com/secur/frontdoor.jsp?sid=MASKED</msg>
-<status status="PASS" starttime="20191023 09:43:35.125" endtime="20191023 09:43:35.125"></status>
+<status status="PASS" starttime="20191023 09:43:35.125" endtime="20191023 09:43:35.125"/>
 </kw>
 <kw name="Run Keyword If" library="BuiltIn">
-<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
-<arguments>
 <arg>'${BROWSER}' == 'chrome'</arg>
 <arg>Open Test Browser Chrome</arg>
 <arg>${login_url}</arg>
@@ -3832,103 +3104,87 @@ to log into a different org.</doc>
 <arg>${login_url}</arg>
 <arg>${BROWSER}</arg>
 <arg>alias=${alias}</arg>
-</arguments>
+<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
 <kw name="Open Test Browser Chrome" library="Salesforce">
-<arguments>
 <arg>${login_url}</arg>
 <arg>alias=${alias}</arg>
-</arguments>
 <kw name="Get Chrome Options" library="Salesforce">
-<assign>
 <var>${options}</var>
-</assign>
 <kw name="Evaluate" library="BuiltIn">
-<doc>Evaluates the given expression in Python and returns the results.</doc>
-<arguments>
+<var>${options}</var>
 <arg>selenium.webdriver.ChromeOptions()</arg>
 <arg>modules=selenium</arg>
-</arguments>
-<assign>
-<var>${options}</var>
-</assign>
+<doc>Evaluates the given expression in Python and returns the results.</doc>
 <msg timestamp="20191023 09:43:35.126" level="INFO">${options} = &lt;selenium.webdriver.chrome.options.Options object at 0x10d755160&gt;</msg>
-<status status="PASS" starttime="20191023 09:43:35.126" endtime="20191023 09:43:35.126"></status>
+<status status="PASS" starttime="20191023 09:43:35.126" endtime="20191023 09:43:35.126"/>
 </kw>
 <kw name="Run Keyword If" library="BuiltIn">
-<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
-<arguments>
 <arg>'${BROWSER}' == 'headlesschrome'</arg>
 <arg>Chrome Set Headless</arg>
 <arg>${options}</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:43:35.126" endtime="20191023 09:43:35.127"></status>
+<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
+<status status="PASS" starttime="20191023 09:43:35.126" endtime="20191023 09:43:35.127"/>
 </kw>
 <kw name="Run Keyword If" library="BuiltIn">
-<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
-<arguments>
 <arg>'${CHROME_BINARY}' != '${empty}'</arg>
 <arg>Chrome Set Binary</arg>
 <arg>${options}</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:43:35.127" endtime="20191023 09:43:35.127"></status>
+<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
+<status status="PASS" starttime="20191023 09:43:35.127" endtime="20191023 09:43:35.127"/>
 </kw>
 <kw name="Call Method" library="BuiltIn">
-<doc>Calls the named method of the given object with the provided arguments.</doc>
-<arguments>
 <arg>${options}</arg>
 <arg>add_argument</arg>
 <arg>--disable-notifications</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:43:35.127" endtime="20191023 09:43:35.127"></status>
+<doc>Calls the named method of the given object with the provided arguments.</doc>
+<status status="PASS" starttime="20191023 09:43:35.127" endtime="20191023 09:43:35.127"/>
 </kw>
 <msg timestamp="20191023 09:43:35.127" level="INFO">${options} = &lt;selenium.webdriver.chrome.options.Options object at 0x10d755160&gt;</msg>
-<status status="PASS" starttime="20191023 09:43:35.126" endtime="20191023 09:43:35.128"></status>
+<status status="PASS" starttime="20191023 09:43:35.126" endtime="20191023 09:43:35.128"/>
 </kw>
 <kw name="Create Webdriver With Retry" library="cumulusci.robotframework.Salesforce">
-<doc>Call the Create Webdriver keyword.</doc>
-<arguments>
 <arg>Chrome</arg>
 <arg>options=${options}</arg>
 <arg>alias=${alias}</arg>
-</arguments>
+<doc>Call the Create Webdriver keyword.</doc>
 <msg timestamp="20191023 09:43:35.128" level="INFO">Creating an instance of the Chrome WebDriver.</msg>
 <msg timestamp="20191023 09:43:37.731" level="FAIL">SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </msg>
-<status status="FAIL" starttime="20191023 09:43:35.128" endtime="20191023 09:43:37.731"></status>
+<status status="FAIL" starttime="20191023 09:43:35.128" endtime="20191023 09:43:37.731"/>
 </kw>
-<status status="FAIL" starttime="20191023 09:43:35.126" endtime="20191023 09:43:37.732"></status>
+<status status="FAIL" starttime="20191023 09:43:35.126" endtime="20191023 09:43:37.732"/>
 </kw>
-<status status="FAIL" starttime="20191023 09:43:35.125" endtime="20191023 09:43:37.732"></status>
+<status status="FAIL" starttime="20191023 09:43:35.125" endtime="20191023 09:43:37.732"/>
 </kw>
-<status status="FAIL" starttime="20191023 09:43:35.124" endtime="20191023 09:43:37.732"></status>
+<status status="FAIL" starttime="20191023 09:43:35.124" endtime="20191023 09:43:37.732"/>
 </kw>
-<status status="FAIL" starttime="20191023 09:43:35.124" endtime="20191023 09:43:37.732"></status>
+<status status="FAIL" starttime="20191023 09:43:35.124" endtime="20191023 09:43:37.732"/>
 </kw>
 <test id="s1-s2-s5-t1" name="Test Populate ability to clear a field">
 <doc>We've had problems with the populate keyword not always
 clearing the field before inserting text. This will try
 to set various fields to a new value and verify that the
 new value overwrites the old rather than append to it</doc>
-<status status="FAIL" starttime="20191023 09:43:37.733" endtime="20191023 09:43:37.734" critical="yes">Parent suite setup failed:
+<status status="FAIL" starttime="20191023 09:43:37.733" endtime="20191023 09:43:37.734">Parent suite setup failed:
 SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </status>
 </test>
-<kw name="Delete Records and Close Browser" library="Salesforce" type="teardown">
+<kw name="Delete Records and Close Browser" library="Salesforce" type="TEARDOWN">
 <doc>This will close all open browser windows and then delete
 all records created with the Salesforce API during this
 testing session.</doc>
 <kw name="Close All Browsers" library="SeleniumLibrary">
 <doc>Closes all open browsers and resets the browser cache.</doc>
-<status status="PASS" starttime="20191023 09:43:37.736" endtime="20191023 09:43:37.736"></status>
+<status status="PASS" starttime="20191023 09:43:37.736" endtime="20191023 09:43:37.736"/>
 </kw>
 <kw name="Delete Session Records" library="cumulusci.robotframework.Salesforce">
 <doc>Deletes records that were created while running this test case.</doc>
 <msg timestamp="20191023 09:43:37.737" level="INFO">Deleting 0 records</msg>
-<status status="PASS" starttime="20191023 09:43:37.737" endtime="20191023 09:43:37.737"></status>
+<status status="PASS" starttime="20191023 09:43:37.737" endtime="20191023 09:43:37.737"/>
 </kw>
-<status status="PASS" starttime="20191023 09:43:37.735" endtime="20191023 09:43:37.737"></status>
+<status status="PASS" starttime="20191023 09:43:37.735" endtime="20191023 09:43:37.737"/>
 </kw>
 <doc>This suite tests the `Populate Field` keyword.
 Specifically, it verifies that the keyword properly
@@ -3944,22 +3200,18 @@ SessionNotCreatedException: Message: session not created: Chrome version must be
 </status>
 </suite>
 <suite id="s1-s2-s6" name="Ui" source="/Users/pprescod/code/CumulusCI/cumulusci/robotframework/tests/salesforce/ui.robot">
-<kw name="Open Test Browser" library="Salesforce" type="setup">
+<kw name="Open Test Browser" library="Salesforce" type="SETUP">
 <doc>Opens a test browser to the org.</doc>
 <kw name="Login Url" library="cumulusci.robotframework.CumulusCI">
+<var>${login_url}</var>
 <doc>Returns the login url which will automatically log into the target
 Salesforce org.  By default, the org_name passed to the library
 constructor is used but this can be overridden with the org option
 to log into a different org.</doc>
-<assign>
-<var>${login_url}</var>
-</assign>
 <msg timestamp="20191023 09:43:37.752" level="INFO">${login_url} = https://efficiency-fun-590-dev-ed.cs93.my.salesforce.com/secur/frontdoor.jsp?sid=MASKED</msg>
-<status status="PASS" starttime="20191023 09:43:37.752" endtime="20191023 09:43:37.752"></status>
+<status status="PASS" starttime="20191023 09:43:37.752" endtime="20191023 09:43:37.752"/>
 </kw>
 <kw name="Run Keyword If" library="BuiltIn">
-<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
-<arguments>
 <arg>'${BROWSER}' == 'chrome'</arg>
 <arg>Open Test Browser Chrome</arg>
 <arg>${login_url}</arg>
@@ -3984,279 +3236,254 @@ to log into a different org.</doc>
 <arg>${login_url}</arg>
 <arg>${BROWSER}</arg>
 <arg>alias=${alias}</arg>
-</arguments>
+<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
 <kw name="Open Test Browser Chrome" library="Salesforce">
-<arguments>
 <arg>${login_url}</arg>
 <arg>alias=${alias}</arg>
-</arguments>
 <kw name="Get Chrome Options" library="Salesforce">
-<assign>
 <var>${options}</var>
-</assign>
 <kw name="Evaluate" library="BuiltIn">
-<doc>Evaluates the given expression in Python and returns the results.</doc>
-<arguments>
+<var>${options}</var>
 <arg>selenium.webdriver.ChromeOptions()</arg>
 <arg>modules=selenium</arg>
-</arguments>
-<assign>
-<var>${options}</var>
-</assign>
+<doc>Evaluates the given expression in Python and returns the results.</doc>
 <msg timestamp="20191023 09:43:37.755" level="INFO">${options} = &lt;selenium.webdriver.chrome.options.Options object at 0x10d896828&gt;</msg>
-<status status="PASS" starttime="20191023 09:43:37.754" endtime="20191023 09:43:37.755"></status>
+<status status="PASS" starttime="20191023 09:43:37.754" endtime="20191023 09:43:37.755"/>
 </kw>
 <kw name="Run Keyword If" library="BuiltIn">
-<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
-<arguments>
 <arg>'${BROWSER}' == 'headlesschrome'</arg>
 <arg>Chrome Set Headless</arg>
 <arg>${options}</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:43:37.755" endtime="20191023 09:43:37.756"></status>
+<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
+<status status="PASS" starttime="20191023 09:43:37.755" endtime="20191023 09:43:37.756"/>
 </kw>
 <kw name="Run Keyword If" library="BuiltIn">
-<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
-<arguments>
 <arg>'${CHROME_BINARY}' != '${empty}'</arg>
 <arg>Chrome Set Binary</arg>
 <arg>${options}</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:43:37.756" endtime="20191023 09:43:37.756"></status>
+<doc>Runs the given keyword with the given arguments, if ``condition`` is true.</doc>
+<status status="PASS" starttime="20191023 09:43:37.756" endtime="20191023 09:43:37.756"/>
 </kw>
 <kw name="Call Method" library="BuiltIn">
-<doc>Calls the named method of the given object with the provided arguments.</doc>
-<arguments>
 <arg>${options}</arg>
 <arg>add_argument</arg>
 <arg>--disable-notifications</arg>
-</arguments>
-<status status="PASS" starttime="20191023 09:43:37.756" endtime="20191023 09:43:37.757"></status>
+<doc>Calls the named method of the given object with the provided arguments.</doc>
+<status status="PASS" starttime="20191023 09:43:37.756" endtime="20191023 09:43:37.757"/>
 </kw>
 <msg timestamp="20191023 09:43:37.757" level="INFO">${options} = &lt;selenium.webdriver.chrome.options.Options object at 0x10d896828&gt;</msg>
-<status status="PASS" starttime="20191023 09:43:37.754" endtime="20191023 09:43:37.757"></status>
+<status status="PASS" starttime="20191023 09:43:37.754" endtime="20191023 09:43:37.757"/>
 </kw>
 <kw name="Create Webdriver With Retry" library="cumulusci.robotframework.Salesforce">
-<doc>Call the Create Webdriver keyword.</doc>
-<arguments>
 <arg>Chrome</arg>
 <arg>options=${options}</arg>
 <arg>alias=${alias}</arg>
-</arguments>
+<doc>Call the Create Webdriver keyword.</doc>
 <msg timestamp="20191023 09:43:37.757" level="INFO">Creating an instance of the Chrome WebDriver.</msg>
 <msg timestamp="20191023 09:43:40.241" level="FAIL">SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </msg>
-<status status="FAIL" starttime="20191023 09:43:37.757" endtime="20191023 09:43:40.242"></status>
+<status status="FAIL" starttime="20191023 09:43:37.757" endtime="20191023 09:43:40.242"/>
 </kw>
-<status status="FAIL" starttime="20191023 09:43:37.753" endtime="20191023 09:43:40.242"></status>
+<status status="FAIL" starttime="20191023 09:43:37.753" endtime="20191023 09:43:40.242"/>
 </kw>
-<status status="FAIL" starttime="20191023 09:43:37.752" endtime="20191023 09:43:40.242"></status>
+<status status="FAIL" starttime="20191023 09:43:37.752" endtime="20191023 09:43:40.242"/>
 </kw>
-<status status="FAIL" starttime="20191023 09:43:37.752" endtime="20191023 09:43:40.243"></status>
+<status status="FAIL" starttime="20191023 09:43:37.752" endtime="20191023 09:43:40.243"/>
 </kw>
 <test id="s1-s2-s6-t1" name="Click Modal Button">
-<status status="FAIL" starttime="20191023 09:43:40.243" endtime="20191023 09:43:40.244" critical="yes">Parent suite setup failed:
+<status status="FAIL" starttime="20191023 09:43:40.243" endtime="20191023 09:43:40.244">Parent suite setup failed:
 SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </status>
 </test>
 <test id="s1-s2-s6-t2" name="Click Object Button">
-<status status="FAIL" starttime="20191023 09:43:40.245" endtime="20191023 09:43:40.245" critical="yes">Parent suite setup failed:
+<status status="FAIL" starttime="20191023 09:43:40.245" endtime="20191023 09:43:40.245">Parent suite setup failed:
 SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </status>
 </test>
 <test id="s1-s2-s6-t3" name="Click Related List Button">
-<status status="FAIL" starttime="20191023 09:43:40.246" endtime="20191023 09:43:40.247" critical="yes">Parent suite setup failed:
+<status status="FAIL" starttime="20191023 09:43:40.246" endtime="20191023 09:43:40.247">Parent suite setup failed:
 SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </status>
 </test>
 <test id="s1-s2-s6-t4" name="Close Modal">
-<status status="FAIL" starttime="20191023 09:43:40.247" endtime="20191023 09:43:40.248" critical="yes">Parent suite setup failed:
+<status status="FAIL" starttime="20191023 09:43:40.247" endtime="20191023 09:43:40.248">Parent suite setup failed:
 SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </status>
 </test>
 <test id="s1-s2-s6-t5" name="Current App Should Be">
-<status status="FAIL" starttime="20191023 09:43:40.248" endtime="20191023 09:43:40.249" critical="yes">Parent suite setup failed:
+<status status="FAIL" starttime="20191023 09:43:40.248" endtime="20191023 09:43:40.249">Parent suite setup failed:
 SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </status>
 </test>
 <test id="s1-s2-s6-t6" name="Select App Launcher Tab">
 <doc>Verify that 'Select App Launcher Tab' works</doc>
-<status status="FAIL" starttime="20191023 09:43:40.249" endtime="20191023 09:43:40.250" critical="yes">Parent suite setup failed:
+<status status="FAIL" starttime="20191023 09:43:40.249" endtime="20191023 09:43:40.250">Parent suite setup failed:
 SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </status>
 </test>
 <test id="s1-s2-s6-t7" name="Get Current Record Id">
-<status status="FAIL" starttime="20191023 09:43:40.251" endtime="20191023 09:43:40.251" critical="yes">Parent suite setup failed:
+<status status="FAIL" starttime="20191023 09:43:40.251" endtime="20191023 09:43:40.251">Parent suite setup failed:
 SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </status>
 </test>
 <test id="s1-s2-s6-t8" name="Get Related List Count">
-<status status="FAIL" starttime="20191023 09:43:40.251" endtime="20191023 09:43:40.252" critical="yes">Parent suite setup failed:
+<status status="FAIL" starttime="20191023 09:43:40.251" endtime="20191023 09:43:40.252">Parent suite setup failed:
 SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </status>
 </test>
 <test id="s1-s2-s6-t9" name="Go To Setup Home">
-<status status="FAIL" starttime="20191023 09:43:40.252" endtime="20191023 09:43:40.253" critical="yes">Parent suite setup failed:
+<status status="FAIL" starttime="20191023 09:43:40.252" endtime="20191023 09:43:40.253">Parent suite setup failed:
 SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </status>
 </test>
 <test id="s1-s2-s6-t10" name="Go To Setup Object Manager">
-<status status="FAIL" starttime="20191023 09:43:40.254" endtime="20191023 09:43:40.254" critical="yes">Parent suite setup failed:
+<status status="FAIL" starttime="20191023 09:43:40.254" endtime="20191023 09:43:40.254">Parent suite setup failed:
 SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </status>
 </test>
 <test id="s1-s2-s6-t11" name="Go To Object Home">
-<tags>
 <tag>smoke</tag>
-</tags>
-<status status="FAIL" starttime="20191023 09:43:40.255" endtime="20191023 09:43:40.255" critical="yes">Parent suite setup failed:
+<status status="FAIL" starttime="20191023 09:43:40.255" endtime="20191023 09:43:40.255">Parent suite setup failed:
 SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </status>
 </test>
 <test id="s1-s2-s6-t12" name="Go To Object List">
-<tags>
 <tag>smoke</tag>
-</tags>
-<status status="FAIL" starttime="20191023 09:43:40.256" endtime="20191023 09:43:40.257" critical="yes">Parent suite setup failed:
+<status status="FAIL" starttime="20191023 09:43:40.256" endtime="20191023 09:43:40.257">Parent suite setup failed:
 SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </status>
 </test>
 <test id="s1-s2-s6-t13" name="Go To Object List With Filter">
-<tags>
 <tag>smoke</tag>
-</tags>
-<status status="FAIL" starttime="20191023 09:43:40.258" endtime="20191023 09:43:40.259" critical="yes">Parent suite setup failed:
+<status status="FAIL" starttime="20191023 09:43:40.258" endtime="20191023 09:43:40.259">Parent suite setup failed:
 SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </status>
 </test>
 <test id="s1-s2-s6-t14" name="Go To Record Home">
-<tags>
 <tag>smoke</tag>
-</tags>
-<status status="FAIL" starttime="20191023 09:43:40.259" endtime="20191023 09:43:40.260" critical="yes">Parent suite setup failed:
+<status status="FAIL" starttime="20191023 09:43:40.259" endtime="20191023 09:43:40.260">Parent suite setup failed:
 SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </status>
 </test>
 <test id="s1-s2-s6-t15" name="Header Field Should Have Value">
-<status status="FAIL" starttime="20191023 09:43:40.260" endtime="20191023 09:43:40.261" critical="yes">Parent suite setup failed:
+<status status="FAIL" starttime="20191023 09:43:40.260" endtime="20191023 09:43:40.261">Parent suite setup failed:
 SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </status>
 </test>
 <test id="s1-s2-s6-t16" name="Header Field Should Not Have Value">
-<status status="FAIL" starttime="20191023 09:43:40.261" endtime="20191023 09:43:40.262" critical="yes">Parent suite setup failed:
+<status status="FAIL" starttime="20191023 09:43:40.261" endtime="20191023 09:43:40.262">Parent suite setup failed:
 SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </status>
 </test>
 <test id="s1-s2-s6-t17" name="Header Field Should Have Link">
-<status status="FAIL" starttime="20191023 09:43:40.263" endtime="20191023 09:43:40.264" critical="yes">Parent suite setup failed:
+<status status="FAIL" starttime="20191023 09:43:40.263" endtime="20191023 09:43:40.264">Parent suite setup failed:
 SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </status>
 </test>
 <test id="s1-s2-s6-t18" name="Header Field Should Not Have Link">
-<status status="FAIL" starttime="20191023 09:43:40.265" endtime="20191023 09:43:40.266" critical="yes">Parent suite setup failed:
+<status status="FAIL" starttime="20191023 09:43:40.265" endtime="20191023 09:43:40.266">Parent suite setup failed:
 SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </status>
 </test>
 <test id="s1-s2-s6-t19" name="Click Header Field Link">
-<status status="FAIL" starttime="20191023 09:43:40.267" endtime="20191023 09:43:40.267" critical="yes">Parent suite setup failed:
+<status status="FAIL" starttime="20191023 09:43:40.267" endtime="20191023 09:43:40.267">Parent suite setup failed:
 SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </status>
 </test>
 <test id="s1-s2-s6-t20" name="Open App Launcher">
-<status status="FAIL" starttime="20191023 09:43:40.268" endtime="20191023 09:43:40.268" critical="yes">Parent suite setup failed:
+<status status="FAIL" starttime="20191023 09:43:40.268" endtime="20191023 09:43:40.268">Parent suite setup failed:
 SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </status>
 </test>
 <test id="s1-s2-s6-t21" name="Populate Field">
-<status status="FAIL" starttime="20191023 09:43:40.269" endtime="20191023 09:43:40.271" critical="yes">Parent suite setup failed:
+<status status="FAIL" starttime="20191023 09:43:40.269" endtime="20191023 09:43:40.271">Parent suite setup failed:
 SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </status>
 </test>
 <test id="s1-s2-s6-t22" name="Populate Lookup Field">
-<status status="FAIL" starttime="20191023 09:43:40.271" endtime="20191023 09:43:40.272" critical="yes">Parent suite setup failed:
+<status status="FAIL" starttime="20191023 09:43:40.271" endtime="20191023 09:43:40.272">Parent suite setup failed:
 SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </status>
 </test>
 <test id="s1-s2-s6-t23" name="Populate Form">
-<status status="FAIL" starttime="20191023 09:43:40.273" endtime="20191023 09:43:40.274" critical="yes">Parent suite setup failed:
+<status status="FAIL" starttime="20191023 09:43:40.273" endtime="20191023 09:43:40.274">Parent suite setup failed:
 SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </status>
 </test>
-<kw name="Delete Records and Close Browser" library="Salesforce" type="teardown">
+<kw name="Delete Records and Close Browser" library="Salesforce" type="TEARDOWN">
 <doc>This will close all open browser windows and then delete
 all records created with the Salesforce API during this
 testing session.</doc>
 <kw name="Close All Browsers" library="SeleniumLibrary">
 <doc>Closes all open browsers and resets the browser cache.</doc>
-<status status="PASS" starttime="20191023 09:43:40.276" endtime="20191023 09:43:40.276"></status>
+<status status="PASS" starttime="20191023 09:43:40.276" endtime="20191023 09:43:40.276"/>
 </kw>
 <kw name="Delete Session Records" library="cumulusci.robotframework.Salesforce">
 <doc>Deletes records that were created while running this test case.</doc>
 <msg timestamp="20191023 09:43:40.276" level="INFO">Deleting 0 records</msg>
-<status status="PASS" starttime="20191023 09:43:40.276" endtime="20191023 09:43:40.276"></status>
+<status status="PASS" starttime="20191023 09:43:40.276" endtime="20191023 09:43:40.276"/>
 </kw>
-<status status="PASS" starttime="20191023 09:43:40.275" endtime="20191023 09:43:40.276"></status>
+<status status="PASS" starttime="20191023 09:43:40.275" endtime="20191023 09:43:40.276"/>
 </kw>
 <status status="FAIL" starttime="20191023 09:43:37.739" endtime="20191023 09:43:40.276">Suite setup failed:
 SessionNotCreatedException: Message: session not created: Chrome version must be between 71 and 75
   (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
 </status>
 </suite>
-<status status="FAIL" starttime="20191023 09:41:53.227" endtime="20191023 09:43:40.282"></status>
+<status status="FAIL" starttime="20191023 09:41:53.227" endtime="20191023 09:43:40.282"/>
 </suite>
-<status status="FAIL" starttime="20191023 09:38:43.625" endtime="20191023 09:43:40.292"></status>
+<status status="FAIL" starttime="20191023 09:38:43.625" endtime="20191023 09:43:40.292"/>
 </suite>
 <statistics>
 <total>
-<stat pass="24" fail="49">Critical Tests</stat>
-<stat pass="24" fail="49">All Tests</stat>
+<stat pass="24" fail="49" skip="0">All Tests</stat>
 </total>
 <tag>
-<stat pass="8" fail="0">api</stat>
-<stat pass="0" fail="1">bryan</stat>
-<stat pass="3" fail="0">bulkdata</stat>
-<stat pass="0" fail="2">issue:1068</stat>
-<stat pass="1" fail="0">Runme</stat>
-<stat pass="0" fail="4">smoke</stat>
+<stat pass="8" fail="0" skip="0">api</stat>
+<stat pass="0" fail="1" skip="0">bryan</stat>
+<stat pass="3" fail="0" skip="0">bulkdata</stat>
+<stat pass="0" fail="2" skip="0">issue:1068</stat>
+<stat pass="1" fail="0" skip="0">Runme</stat>
+<stat pass="0" fail="4" skip="0">smoke</stat>
 </tag>
 <suite>
-<stat pass="24" fail="49" id="s1" name="Tests">Tests</stat>
-<stat pass="16" fail="0" id="s1-s1" name="Cumulusci">Tests.Cumulusci</stat>
-<stat pass="9" fail="0" id="s1-s1-s1" name="Base">Tests.Cumulusci.Base</stat>
-<stat pass="3" fail="0" id="s1-s1-s2" name="Bulkdata">Tests.Cumulusci.Bulkdata</stat>
-<stat pass="4" fail="0" id="s1-s1-s3" name="Communities">Tests.Cumulusci.Communities</stat>
-<stat pass="8" fail="49" id="s1-s2" name="Salesforce">Tests.Salesforce</stat>
-<stat pass="8" fail="0" id="s1-s2-s1" name="Api">Tests.Salesforce.Api</stat>
-<stat pass="0" fail="5" id="s1-s2-s2" name="Browsers">Tests.Salesforce.Browsers</stat>
-<stat pass="0" fail="2" id="s1-s2-s3" name="Create Contact">Tests.Salesforce.Create Contact</stat>
-<stat pass="0" fail="18" id="s1-s2-s4" name="Pageobjects">Tests.Salesforce.Pageobjects</stat>
-<stat pass="0" fail="18" id="s1-s2-s4-s1" name="Pageobjects">Tests.Salesforce.Pageobjects.Pageobjects</stat>
-<stat pass="0" fail="1" id="s1-s2-s5" name="Populate">Tests.Salesforce.Populate</stat>
-<stat pass="0" fail="23" id="s1-s2-s6" name="Ui">Tests.Salesforce.Ui</stat>
+<stat pass="24" fail="49" skip="0" id="s1" name="Nested">Nested</stat>
+<stat pass="16" fail="0" skip="0" id="s1-s1" name="Cumulusci">Nested.Cumulusci</stat>
+<stat pass="9" fail="0" skip="0" id="s1-s1-s1" name="Base">Nested.Cumulusci.Base</stat>
+<stat pass="3" fail="0" skip="0" id="s1-s1-s2" name="Bulkdata">Nested.Cumulusci.Bulkdata</stat>
+<stat pass="4" fail="0" skip="0" id="s1-s1-s3" name="Communities">Nested.Cumulusci.Communities</stat>
+<stat pass="8" fail="49" skip="0" id="s1-s2" name="Salesforce">Nested.Salesforce</stat>
+<stat pass="8" fail="0" skip="0" id="s1-s2-s1" name="Api">Nested.Salesforce.Api</stat>
+<stat pass="0" fail="5" skip="0" id="s1-s2-s2" name="Browsers">Nested.Salesforce.Browsers</stat>
+<stat pass="0" fail="2" skip="0" id="s1-s2-s3" name="Create Contact">Nested.Salesforce.Create Contact</stat>
+<stat pass="0" fail="18" skip="0" id="s1-s2-s4" name="Pageobjects">Nested.Salesforce.Pageobjects</stat>
+<stat pass="0" fail="18" skip="0" id="s1-s2-s4-s1" name="Pageobjects">Nested.Salesforce.Pageobjects.Pageobjects</stat>
+<stat pass="0" fail="1" skip="0" id="s1-s2-s5" name="Populate">Nested.Salesforce.Populate</stat>
+<stat pass="0" fail="23" skip="0" id="s1-s2-s6" name="Ui">Nested.Salesforce.Ui</stat>
 </suite>
 </statistics>
 <errors>

--- a/metaci/testresults/tests/robot_with_setup_teardown.xml
+++ b/metaci/testresults/tests/robot_with_setup_teardown.xml
@@ -1,216 +1,164 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<robot rpa="false">
-<suite id="s1" name="Api" source="">
-<test id="s1-t1" name="FakeTestResult2">
-<kw name="Sleep" library="BuiltIn" type="setup">
-<doc>Pauses the test executed for the given time.</doc>
-<arguments>
-<arg>6</arg>
-</arguments>
-<status status="PASS" starttime="20191021 01:00:00.000" endtime="20191021 01:00:06.00"></status>
-</kw>
-<kw name="Create Contact">
-<assign>
-<var>&amp;{contact}</var>
-</assign>
-<kw name="Generate Random String" library="String">
-<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
-<assign>
-<var>${first_name}</var>
-</assign>
-<msg timestamp="20191021 15:29:11.360" level="INFO">${first_name} = 9xPGOPDZ</msg>
-<status status="PASS" starttime="20191021 15:29:11.360" endtime="20191021 15:29:11.360"></status>
-</kw>
-<kw name="Generate Random String" library="String">
-<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
-<assign>
-<var>${last_name}</var>
-</assign>
-<msg timestamp="20191021 15:29:11.361" level="INFO">${last_name} = 08V1Y8CO</msg>
-<status status="PASS" starttime="20191021 15:29:11.360" endtime="20191021 15:29:11.361"></status>
-</kw>
-<kw name="Salesforce Insert" library="cumulusci.robotframework.Salesforce">
-<doc>Inserts a Salesforce object setting fields using kwargs and returns the id</doc>
-<arguments>
-<arg>Contact</arg>
-<arg>FirstName=${first_name}</arg>
-<arg>LastName=${last_name}</arg>
-</arguments>
-<assign>
-<var>${contact_id}</var>
-</assign>
-<msg timestamp="20191021 15:29:11.361" level="INFO">Inserting Contact with values {'FirstName': '9xPGOPDZ', 'LastName': '08V1Y8CO'}</msg>
-<msg timestamp="20191021 15:29:12.330" level="INFO">Storing Contact 0034F00000SYtgTQAT to session records</msg>
-<msg timestamp="20191021 15:29:12.331" level="INFO">${contact_id} = 0034F00000SYtgTQAT</msg>
-<status status="PASS" starttime="REMOVED_FOR_CLARITY" endtime="REMOVED_FOR_CLARITY"></status>
-</kw>
-<kw name="Salesforce Get" library="cumulusci.robotframework.Salesforce">
-<doc>Gets a Salesforce object by id and returns the dict result</doc>
-<arguments>
-<arg>Contact</arg>
-<arg>${contact_id}</arg>
-</arguments>
-<assign>
-<var>&amp;{contact}</var>
-</assign>
-<msg timestamp="REMOVED_FOR_CLARITY" level="INFO">Getting Contact with Id 0034F00000SYtgTQAT</msg>
-<msg timestamp="REMOVED_FOR_CLARITY" level="INFO">&amp;{contact} = { attributes={'type': 'Contact', 'url': '/services/data/v46.0/sobjects/Contact/0034F00000SYtgTQAT'} | Id=0034F00000SYtgTQAT | IsDeleted=False | MasterRecordId=None | AccountId=None | LastName=08V1Y8CO...</msg>
-<status status="PASS" starttime="REMOVED_FOR_CLARITY" endtime="REMOVED_FOR_CLARITY"></status>
-</kw>
-<msg timestamp="REMOVED_FOR_CLARITY" level="INFO">&amp;{contact} = { attributes={'type': 'Contact', 'url': '/services/data/v46.0/sobjects/Contact/0034F00000SYtgTQAT'} | Id=0034F00000SYtgTQAT | IsDeleted=False | MasterRecordId=None | AccountId=None | LastName=08V1Y8CO...</msg>
-<status status="PASS" starttime="20191021 01:00:07.000" endtime="20191021 01:00:20.000"></status>
-</kw>
-<tags>
-<tag>api</tag>
-<tag>Runme</tag>
-</tags>
-<kw name="Do Some Cleanup" library="cumulusci.robotframework.Salesforce" type="teardown">
-<doc>Cleanup the stuff.</doc>
-<status status="PASS" starttime="20191021 01:00:20.001" endtime="20191021 01:00:21.000"></status>
-</kw>
-<status status="PASS" starttime="20191021 01:00:00.000" endtime="20191021 01:00:21.001" critical="yes"></status>
-</test>
-<test id="s1-t1" name="FakeTestResult_setup_no_teardown">
-<kw name="Sleep" library="BuiltIn" type="setup">
-<doc>Pauses the test executed for the given time.</doc>
-<arguments>
-<arg>6</arg>
-</arguments>
-<status status="PASS" starttime="20191021 01:00:00.000" endtime="20191021 01:00:06.00"></status>
-</kw>
-<kw name="Create Contact">
-<assign>
-<var>&amp;{contact}</var>
-</assign>
-<kw name="Generate Random String" library="String">
-<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
-<assign>
-<var>${first_name}</var>
-</assign>
-<msg timestamp="20191021 15:29:11.360" level="INFO">${first_name} = 9xPGOPDZ</msg>
-<status status="PASS" starttime="20191021 15:29:11.360" endtime="20191021 15:29:11.360"></status>
-</kw>
-<kw name="Generate Random String" library="String">
-<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
-<assign>
-<var>${last_name}</var>
-</assign>
-<msg timestamp="20191021 15:29:11.361" level="INFO">${last_name} = 08V1Y8CO</msg>
-<status status="PASS" starttime="20191021 15:29:11.360" endtime="20191021 15:29:11.361"></status>
-</kw>
-<kw name="Salesforce Insert" library="cumulusci.robotframework.Salesforce">
-<doc>Inserts a Salesforce object setting fields using kwargs and returns the id</doc>
-<arguments>
-<arg>Contact</arg>
-<arg>FirstName=${first_name}</arg>
-<arg>LastName=${last_name}</arg>
-</arguments>
-<assign>
-<var>${contact_id}</var>
-</assign>
-<msg timestamp="20191021 15:29:11.361" level="INFO">Inserting Contact with values {'FirstName': '9xPGOPDZ', 'LastName': '08V1Y8CO'}</msg>
-<msg timestamp="20191021 15:29:12.330" level="INFO">Storing Contact 0034F00000SYtgTQAT to session records</msg>
-<msg timestamp="20191021 15:29:12.331" level="INFO">${contact_id} = 0034F00000SYtgTQAT</msg>
-<status status="PASS" starttime="REMOVED_FOR_CLARITY" endtime="REMOVED_FOR_CLARITY"></status>
-</kw>
-<kw name="Salesforce Get" library="cumulusci.robotframework.Salesforce">
-<doc>Gets a Salesforce object by id and returns the dict result</doc>
-<arguments>
-<arg>Contact</arg>
-<arg>${contact_id}</arg>
-</arguments>
-<assign>
-<var>&amp;{contact}</var>
-</assign>
-<msg timestamp="REMOVED_FOR_CLARITY" level="INFO">Getting Contact with Id 0034F00000SYtgTQAT</msg>
-<msg timestamp="REMOVED_FOR_CLARITY" level="INFO">&amp;{contact} = { attributes={'type': 'Contact', 'url': '/services/data/v46.0/sobjects/Contact/0034F00000SYtgTQAT'} | Id=0034F00000SYtgTQAT | IsDeleted=False | MasterRecordId=None | AccountId=None | LastName=08V1Y8CO...</msg>
-<status status="PASS" starttime="REMOVED_FOR_CLARITY" endtime="REMOVED_FOR_CLARITY"></status>
-</kw>
-<msg timestamp="REMOVED_FOR_CLARITY" level="INFO">&amp;{contact} = { attributes={'type': 'Contact', 'url': '/services/data/v46.0/sobjects/Contact/0034F00000SYtgTQAT'} | Id=0034F00000SYtgTQAT | IsDeleted=False | MasterRecordId=None | AccountId=None | LastName=08V1Y8CO...</msg>
-<status status="PASS" starttime="20191021 01:00:07.000" endtime="20191021 01:00:20.000"></status>
-</kw>
-<tags>
-<tag>api</tag>
-<tag>Runme</tag>
-</tags>
-<status status="PASS" starttime="20191021 01:00:00.000" endtime="20191021 01:00:21.001" critical="yes"></status>
-</test>        
-<test id="s1-t1" name="FakeTestResult_teardown_no_setup">
-<kw name="Create Contact">
-<assign>
-<var>&amp;{contact}</var>
-</assign>
-<kw name="Generate Random String" library="String">
-<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
-<assign>
-<var>${first_name}</var>
-</assign>
-<msg timestamp="20191021 15:29:11.360" level="INFO">${first_name} = 9xPGOPDZ</msg>
-<status status="PASS" starttime="20191021 15:29:11.360" endtime="20191021 15:29:11.360"></status>
-</kw>
-<kw name="Generate Random String" library="String">
-<doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
-<assign>
-<var>${last_name}</var>
-</assign>
-<msg timestamp="20191021 15:29:11.361" level="INFO">${last_name} = 08V1Y8CO</msg>
-<status status="PASS" starttime="20191021 15:29:11.360" endtime="20191021 15:29:11.361"></status>
-</kw>
-<kw name="Salesforce Insert" library="cumulusci.robotframework.Salesforce">
-<doc>Inserts a Salesforce object setting fields using kwargs and returns the id</doc>
-<arguments>
-<arg>Contact</arg>
-<arg>FirstName=${first_name}</arg>
-<arg>LastName=${last_name}</arg>
-</arguments>
-<assign>
-<var>${contact_id}</var>
-</assign>
-<msg timestamp="20191021 15:29:11.361" level="INFO">Inserting Contact with values {'FirstName': '9xPGOPDZ', 'LastName': '08V1Y8CO'}</msg>
-<msg timestamp="20191021 15:29:12.330" level="INFO">Storing Contact 0034F00000SYtgTQAT to session records</msg>
-<msg timestamp="20191021 15:29:12.331" level="INFO">${contact_id} = 0034F00000SYtgTQAT</msg>
-<status status="PASS" starttime="REMOVED_FOR_CLARITY" endtime="REMOVED_FOR_CLARITY"></status>
-</kw>
-<kw name="Salesforce Get" library="cumulusci.robotframework.Salesforce">
-<doc>Gets a Salesforce object by id and returns the dict result</doc>
-<arguments>
-<arg>Contact</arg>
-<arg>${contact_id}</arg>
-</arguments>
-<assign>
-<var>&amp;{contact}</var>
-</assign>
-<msg timestamp="REMOVED_FOR_CLARITY" level="INFO">Getting Contact with Id 0034F00000SYtgTQAT</msg>
-<msg timestamp="REMOVED_FOR_CLARITY" level="INFO">&amp;{contact} = { attributes={'type': 'Contact', 'url': '/services/data/v46.0/sobjects/Contact/0034F00000SYtgTQAT'} | Id=0034F00000SYtgTQAT | IsDeleted=False | MasterRecordId=None | AccountId=None | LastName=08V1Y8CO...</msg>
-<status status="PASS" starttime="REMOVED_FOR_CLARITY" endtime="REMOVED_FOR_CLARITY"></status>
-</kw>
-<msg timestamp="REMOVED_FOR_CLARITY" level="INFO">&amp;{contact} = { attributes={'type': 'Contact', 'url': '/services/data/v46.0/sobjects/Contact/0034F00000SYtgTQAT'} | Id=0034F00000SYtgTQAT | IsDeleted=False | MasterRecordId=None | AccountId=None | LastName=08V1Y8CO...</msg>
-<status status="PASS" starttime="20191021 01:00:07.000" endtime="20191021 01:00:20.000"></status>
-</kw>
-<tags>
-<tag>api</tag>
-<tag>Runme</tag>
-</tags>
-<kw name="Do Some Cleanup" library="cumulusci.robotframework.Salesforce" type="teardown">
-<doc>Cleanup the stuff.</doc>
-<status status="PASS" starttime="20191021 01:00:20.001" endtime="20191021 01:00:21.000"></status>
-</kw>
-<status status="PASS" starttime="20191021 01:00:00.000" endtime="20191021 01:00:21.001" critical="yes"></status>
-</test>        
-<status status="PASS" starttime="20191021 01:00:00.000" endtime="20191021 01:00:21.002"></status>
-</suite>
-<statistics>
-<total>
-<stat pass="1" fail="0">Critical Tests</stat>
-<stat pass="1" fail="0">All Tests</stat>
-</total>
-<tag>
-<stat pass="1" fail="0">api</stat>
-<stat pass="1" fail="0">Runme</stat>
-</tag>
-<suite>
-<stat pass="1" fail="0" id="s1" name="Api">Api</stat>
-</suite>
-</statistics>
-<errors></errors>
+<?xml version="1.0" encoding="UTF-8"?>
+<robot generator="Rebot 4.0.1 (Python 3.8.9 on darwin)" generated="20210511 11:12:36.897" rpa="false" schemaversion="2">
+  <suite id="s1" name="Api" source="">
+    <test id="s1-t1" name="FakeTestResult2">
+      <kw name="Sleep" library="BuiltIn" type="SETUP">
+        <arg>6</arg>
+        <doc>Pauses the test executed for the given time.</doc>
+        <status status="PASS" starttime="20191021 01:00:00.000" endtime="20191021 01:00:06.00"/>
+      </kw>
+      <kw name="Create Contact">
+        <var>&amp;{contact}</var>
+        <kw name="Generate Random String" library="String">
+          <var>${first_name}</var>
+          <doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
+          <msg timestamp="20191021 15:29:11.360" level="INFO">${first_name} = 9xPGOPDZ</msg>
+          <status status="PASS" starttime="20191021 15:29:11.360" endtime="20191021 15:29:11.360"/>
+        </kw>
+        <kw name="Generate Random String" library="String">
+          <var>${last_name}</var>
+          <doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
+          <msg timestamp="20191021 15:29:11.361" level="INFO">${last_name} = 08V1Y8CO</msg>
+          <status status="PASS" starttime="20191021 15:29:11.360" endtime="20191021 15:29:11.361"/>
+        </kw>
+        <kw name="Salesforce Insert" library="cumulusci.robotframework.Salesforce">
+          <var>${contact_id}</var>
+          <arg>Contact</arg>
+          <arg>FirstName=${first_name}</arg>
+          <arg>LastName=${last_name}</arg>
+          <doc>Inserts a Salesforce object setting fields using kwargs and returns the id</doc>
+          <msg timestamp="20191021 15:29:11.361" level="INFO">Inserting Contact with values {'FirstName': '9xPGOPDZ', 'LastName': '08V1Y8CO'}</msg>
+          <msg timestamp="20191021 15:29:12.330" level="INFO">Storing Contact 0034F00000SYtgTQAT to session records</msg>
+          <msg timestamp="20191021 15:29:12.331" level="INFO">${contact_id} = 0034F00000SYtgTQAT</msg>
+          <status status="PASS" starttime="REMOVED_FOR_CLARITY" endtime="REMOVED_FOR_CLARITY"/>
+        </kw>
+        <kw name="Salesforce Get" library="cumulusci.robotframework.Salesforce">
+          <var>&amp;{contact}</var>
+          <arg>Contact</arg>
+          <arg>${contact_id}</arg>
+          <doc>Gets a Salesforce object by id and returns the dict result</doc>
+          <msg timestamp="REMOVED_FOR_CLARITY" level="INFO">Getting Contact with Id 0034F00000SYtgTQAT</msg>
+          <msg timestamp="REMOVED_FOR_CLARITY" level="INFO">&amp;{contact} = { attributes={'type': 'Contact', 'url': '/services/data/v46.0/sobjects/Contact/0034F00000SYtgTQAT'} | Id=0034F00000SYtgTQAT | IsDeleted=False | MasterRecordId=None | AccountId=None | LastName=08V1Y8CO...</msg>
+          <status status="PASS" starttime="REMOVED_FOR_CLARITY" endtime="REMOVED_FOR_CLARITY"/>
+        </kw>
+        <msg timestamp="REMOVED_FOR_CLARITY" level="INFO">&amp;{contact} = { attributes={'type': 'Contact', 'url': '/services/data/v46.0/sobjects/Contact/0034F00000SYtgTQAT'} | Id=0034F00000SYtgTQAT | IsDeleted=False | MasterRecordId=None | AccountId=None | LastName=08V1Y8CO...</msg>
+        <status status="PASS" starttime="20191021 01:00:07.000" endtime="20191021 01:00:20.000"/>
+      </kw>
+      <kw name="Do Some Cleanup" library="cumulusci.robotframework.Salesforce" type="TEARDOWN">
+        <doc>Cleanup the stuff.</doc>
+        <status status="PASS" starttime="20191021 01:00:20.001" endtime="20191021 01:00:21.000"/>
+      </kw>
+      <tag>api</tag>
+      <tag>Runme</tag>
+      <status status="PASS" starttime="20191021 01:00:00.000" endtime="20191021 01:00:21.001"/>
+    </test>
+    <test id="s1-t2" name="FakeTestResult_setup_no_teardown">
+      <kw name="Sleep" library="BuiltIn" type="SETUP">
+        <arg>6</arg>
+        <doc>Pauses the test executed for the given time.</doc>
+        <status status="PASS" starttime="20191021 01:00:00.000" endtime="20191021 01:00:06.00"/>
+      </kw>
+      <kw name="Create Contact">
+        <var>&amp;{contact}</var>
+        <kw name="Generate Random String" library="String">
+          <var>${first_name}</var>
+          <doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
+          <msg timestamp="20191021 15:29:11.360" level="INFO">${first_name} = 9xPGOPDZ</msg>
+          <status status="PASS" starttime="20191021 15:29:11.360" endtime="20191021 15:29:11.360"/>
+        </kw>
+        <kw name="Generate Random String" library="String">
+          <var>${last_name}</var>
+          <doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
+          <msg timestamp="20191021 15:29:11.361" level="INFO">${last_name} = 08V1Y8CO</msg>
+          <status status="PASS" starttime="20191021 15:29:11.360" endtime="20191021 15:29:11.361"/>
+        </kw>
+        <kw name="Salesforce Insert" library="cumulusci.robotframework.Salesforce">
+          <var>${contact_id}</var>
+          <arg>Contact</arg>
+          <arg>FirstName=${first_name}</arg>
+          <arg>LastName=${last_name}</arg>
+          <doc>Inserts a Salesforce object setting fields using kwargs and returns the id</doc>
+          <msg timestamp="20191021 15:29:11.361" level="INFO">Inserting Contact with values {'FirstName': '9xPGOPDZ', 'LastName': '08V1Y8CO'}</msg>
+          <msg timestamp="20191021 15:29:12.330" level="INFO">Storing Contact 0034F00000SYtgTQAT to session records</msg>
+          <msg timestamp="20191021 15:29:12.331" level="INFO">${contact_id} = 0034F00000SYtgTQAT</msg>
+          <status status="PASS" starttime="REMOVED_FOR_CLARITY" endtime="REMOVED_FOR_CLARITY"/>
+        </kw>
+        <kw name="Salesforce Get" library="cumulusci.robotframework.Salesforce">
+          <var>&amp;{contact}</var>
+          <arg>Contact</arg>
+          <arg>${contact_id}</arg>
+          <doc>Gets a Salesforce object by id and returns the dict result</doc>
+          <msg timestamp="REMOVED_FOR_CLARITY" level="INFO">Getting Contact with Id 0034F00000SYtgTQAT</msg>
+          <msg timestamp="REMOVED_FOR_CLARITY" level="INFO">&amp;{contact} = { attributes={'type': 'Contact', 'url': '/services/data/v46.0/sobjects/Contact/0034F00000SYtgTQAT'} | Id=0034F00000SYtgTQAT | IsDeleted=False | MasterRecordId=None | AccountId=None | LastName=08V1Y8CO...</msg>
+          <status status="PASS" starttime="REMOVED_FOR_CLARITY" endtime="REMOVED_FOR_CLARITY"/>
+        </kw>
+        <msg timestamp="REMOVED_FOR_CLARITY" level="INFO">&amp;{contact} = { attributes={'type': 'Contact', 'url': '/services/data/v46.0/sobjects/Contact/0034F00000SYtgTQAT'} | Id=0034F00000SYtgTQAT | IsDeleted=False | MasterRecordId=None | AccountId=None | LastName=08V1Y8CO...</msg>
+        <status status="PASS" starttime="20191021 01:00:07.000" endtime="20191021 01:00:20.000"/>
+      </kw>
+      <tag>api</tag>
+      <tag>Runme</tag>
+      <status status="PASS" starttime="20191021 01:00:00.000" endtime="20191021 01:00:21.001"/>
+    </test>
+    <test id="s1-t3" name="FakeTestResult_teardown_no_setup">
+      <kw name="Create Contact">
+        <var>&amp;{contact}</var>
+        <kw name="Generate Random String" library="String">
+          <var>${first_name}</var>
+          <doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
+          <msg timestamp="20191021 15:29:11.360" level="INFO">${first_name} = 9xPGOPDZ</msg>
+          <status status="PASS" starttime="20191021 15:29:11.360" endtime="20191021 15:29:11.360"/>
+        </kw>
+        <kw name="Generate Random String" library="String">
+          <var>${last_name}</var>
+          <doc>Generates a string with a desired ``length`` from the given ``chars``.</doc>
+          <msg timestamp="20191021 15:29:11.361" level="INFO">${last_name} = 08V1Y8CO</msg>
+          <status status="PASS" starttime="20191021 15:29:11.360" endtime="20191021 15:29:11.361"/>
+        </kw>
+        <kw name="Salesforce Insert" library="cumulusci.robotframework.Salesforce">
+          <var>${contact_id}</var>
+          <arg>Contact</arg>
+          <arg>FirstName=${first_name}</arg>
+          <arg>LastName=${last_name}</arg>
+          <doc>Inserts a Salesforce object setting fields using kwargs and returns the id</doc>
+          <msg timestamp="20191021 15:29:11.361" level="INFO">Inserting Contact with values {'FirstName': '9xPGOPDZ', 'LastName': '08V1Y8CO'}</msg>
+          <msg timestamp="20191021 15:29:12.330" level="INFO">Storing Contact 0034F00000SYtgTQAT to session records</msg>
+          <msg timestamp="20191021 15:29:12.331" level="INFO">${contact_id} = 0034F00000SYtgTQAT</msg>
+          <status status="PASS" starttime="REMOVED_FOR_CLARITY" endtime="REMOVED_FOR_CLARITY"/>
+        </kw>
+        <kw name="Salesforce Get" library="cumulusci.robotframework.Salesforce">
+          <var>&amp;{contact}</var>
+          <arg>Contact</arg>
+          <arg>${contact_id}</arg>
+          <doc>Gets a Salesforce object by id and returns the dict result</doc>
+          <msg timestamp="REMOVED_FOR_CLARITY" level="INFO">Getting Contact with Id 0034F00000SYtgTQAT</msg>
+          <msg timestamp="REMOVED_FOR_CLARITY" level="INFO">&amp;{contact} = { attributes={'type': 'Contact', 'url': '/services/data/v46.0/sobjects/Contact/0034F00000SYtgTQAT'} | Id=0034F00000SYtgTQAT | IsDeleted=False | MasterRecordId=None | AccountId=None | LastName=08V1Y8CO...</msg>
+          <status status="PASS" starttime="REMOVED_FOR_CLARITY" endtime="REMOVED_FOR_CLARITY"/>
+        </kw>
+        <msg timestamp="REMOVED_FOR_CLARITY" level="INFO">&amp;{contact} = { attributes={'type': 'Contact', 'url': '/services/data/v46.0/sobjects/Contact/0034F00000SYtgTQAT'} | Id=0034F00000SYtgTQAT | IsDeleted=False | MasterRecordId=None | AccountId=None | LastName=08V1Y8CO...</msg>
+        <status status="PASS" starttime="20191021 01:00:07.000" endtime="20191021 01:00:20.000"/>
+      </kw>
+      <kw name="Do Some Cleanup" library="cumulusci.robotframework.Salesforce" type="TEARDOWN">
+        <doc>Cleanup the stuff.</doc>
+        <status status="PASS" starttime="20191021 01:00:20.001" endtime="20191021 01:00:21.000"/>
+      </kw>
+      <tag>api</tag>
+      <tag>Runme</tag>
+      <status status="PASS" starttime="20191021 01:00:00.000" endtime="20191021 01:00:21.001"/>
+    </test>
+    <status status="PASS" starttime="20191021 01:00:00.000" endtime="20191021 01:00:21.002"/>
+  </suite>
+  <statistics>
+    <total>
+      <stat pass="3" fail="0" skip="0">All Tests</stat>
+    </total>
+    <tag>
+      <stat pass="3" fail="0" skip="0">api</stat>
+      <stat pass="3" fail="0" skip="0">Runme</stat>
+    </tag>
+    <suite>
+      <stat pass="3" fail="0" skip="0" id="s1" name="Api">Api</stat>
+    </suite>
+  </statistics>
+  <errors>
+  </errors>
 </robot>

--- a/metaci/testresults/tests/test_robot_importer.py
+++ b/metaci/testresults/tests/test_robot_importer.py
@@ -1,3 +1,4 @@
+import fnmatch
 import xml.etree.ElementTree as ET
 from datetime import datetime, timedelta
 from pathlib import Path, PurePath
@@ -242,10 +243,13 @@ def test_execution_errors():
     error_messages = [element.text for element in msg_elements]
 
     expected_error_messages = [
-        "Error in file 'example.robot' on line 2: Library setting requires value.",
-        "Error in file 'example.robot' on line 3: Resource setting requires value.",
+        # note: these are glob patterns, not regexes
+        "Error in file '*' on line 2: Library setting requires value.",
+        "Error in file '*' on line 3: Resource setting requires value.",
     ]
     assert len(error_messages) == len(expected_error_messages)
+    for pattern in expected_error_messages:
+        assert len(fnmatch.filter(error_messages, pattern)) == 1
 
 
 @pytest.mark.django_db

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -63,7 +63,7 @@ factory-boy==3.2.0
     # via
     #   -r requirements/dev.in
     #   pytest-factoryboy
-faker==8.1.1
+faker==8.1.3
     # via
     #   -c requirements/prod.txt
     #   factory-boy

--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -1,6 +1,6 @@
 ansi2html
 boto3
-cumulusci
+cumulusci==3.35.0.dev0
 django<3.2
 django-allauth
 django-anymail

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -114,7 +114,7 @@ djangorestframework==3.12.4
     #   sfdo-template-helpers
 docutils==0.16
     # via cumulusci
-faker==8.1.1
+faker==8.1.3
     # via
     #   cumulusci
     #   snowfakery
@@ -122,7 +122,7 @@ fs==2.4.13
     # via cumulusci
 github3.py==2.0.0
     # via cumulusci
-greenlet==1.0.0
+greenlet==1.1.0
     # via
     #   cumulusci
     #   sqlalchemy
@@ -288,9 +288,9 @@ six==1.15.0
     #   fs
     #   python-dateutil
     #   salesforce-bulk
-snowfakery==1.10
+snowfakery==1.11
     # via cumulusci
-sqlalchemy==1.4.11
+sqlalchemy==1.4.15
     # via
     #   cumulusci
     #   snowfakery

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -52,7 +52,7 @@ cryptography==3.4.7
     #   jwcrypto
     #   pyjwt
     #   sfdo-template-helpers
-cumulusci==3.34.1
+cumulusci==3.35.0.dev0
     # via -r requirements/prod.in
 defusedxml==0.7.1
     # via python3-openid
@@ -249,7 +249,7 @@ robotframework-requests==0.9.1
     # via cumulusci
 robotframework-seleniumlibrary==4.5.0
     # via cumulusci
-robotframework==3.2.2
+robotframework==4.0.2
     # via
     #   cumulusci
     #   robotframework-lint


### PR DESCRIPTION
This has some small changes to robot_importer to support changes in the output.xml schema for robot 4.x. I also converted all of the test xml files used by the robot importer tests. I did so by running robot's 'rebot' tool which has the ability to read the old format and write the new one. One test file also required a small tweak to work around a small bug (feature?) of rebot where it threw away an attribute that had an empty string as a value.

If you want to test this locally against robot 4, you'll need to upgrade your local version of CumulusCI to use robot 4 (see branch feature/robot_4) and then update `prod.in` to use the local version of CumulusCI (eg: replace `cumulusci` with  `-e /path/to/CumulusCI`)

Robot release notes for the output.xml changes can be found here: [Generated output.xml has been changed](https://github.com/robotframework/robotframework/blob/master/doc/releasenotes/rf-4.0.rst#generated-output-xml-has-been-changed)