### PR TITLE
W-9909544: Link to Access Release Cohort View

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,8 @@
 DJANGO_SECRET_KEY=
 
 # Encryption key for secrets stored in the database.
-# Generate a key using cryptography.fernet.Fernet.generate_key()
+# Generate a key using
+# python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
 DB_ENCRYPTION_KEYS=
 
 # Database connection

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -62,7 +62,14 @@ Node versions).
 To install the project-local version of Node (and `yarn`_)::
 
     bin/unpack-node
+
+Next you need to get that into your path. For a single terminal you can use
+
+    export PATH=$PATH:node/bin
     rehash
+
+Longer term, you should probably use direnv and .envrc to do the same on new
+terminals.
 
 If you can run ``which node`` and see a path inside your project directory ending with
 ``.../node/bin/node``, then you've got it set up right and can move on.

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -24,9 +24,11 @@ Please see `<./docs/configuring.rst>`_ for more details.
 
 To activate the configuration, run::
 
-    source env
+    source env ; rehash
 
 You must do this each time you open a new terminal before working on MetaCI.
+Longer term, you should probably use direnv and .envrc to do the same on new
+terminals so you do not forget to source env each time.
 
 
 Install MetaCI
@@ -63,16 +65,9 @@ To install the project-local version of Node (and `yarn`_)::
 
     bin/unpack-node
 
-Next you need to get that into your path. For a single terminal you can use
-
-    export PATH=$PATH:node/bin
-    rehash
-
-Longer term, you should probably use direnv and .envrc to do the same on new
-terminals.
-
 If you can run ``which node`` and see a path inside your project directory ending with
-``.../node/bin/node``, then you've got it set up right and can move on.
+``.../node/bin/node``, then you've got it set up right and can move on. Otherwise go
+back and check if your environment includes the PATH environment variable from env.example
 
 Then use ``yarn`` to install dependencies::
 

--- a/metaci/release/models.py
+++ b/metaci/release/models.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 from django.core.exceptions import ValidationError
 from django.db import models
+from django.urls import reverse
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from model_utils import Choices
@@ -32,6 +33,9 @@ class ReleaseCohort(models.Model):
 
     def __str__(self):
         return self.name
+
+    def get_absolute_url(self):
+        return reverse("cohort_detail", kwargs={"cohort_id": str(self.id)})
 
     def clean(self):
         now = datetime.datetime.now(tz=datetime.timezone.utc)

--- a/metaci/templates/layout_full.html
+++ b/metaci/templates/layout_full.html
@@ -72,6 +72,17 @@
         </a>
       </li>
       {% endif %}
+      {% if request.user.is_authenticated and perms.release.view_releasecohort %}
+      <li class="slds-dropdown-trigger slds-dropdown-trigger--click slds-p-right--large">
+        <a href="/cohorts/">
+        <div class="slds-media">
+          <div class="slds-media__body">
+            <h3 class="slds-text-heading--medium">Release Cohorts</h3>
+          </div>
+        </div>
+        </a>
+      </li>
+      {% endif %}
       {% if request.user.is_authenticated %}
       <li class="slds-dropdown-trigger slds-dropdown-trigger--click slds-p-horizontal--xx-small">
         <a href="/notifications">

--- a/metaci/tests/test_views.py
+++ b/metaci/tests/test_views.py
@@ -1,0 +1,37 @@
+import pytest
+from django.test import Client, TestCase
+from django.urls import reverse
+
+from metaci.conftest import StaffSuperuserFactory, UserFactory
+
+
+class TestRepositoryViews(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.superuser = StaffSuperuserFactory()
+        cls.user = UserFactory()
+        super().setUpTestData()
+
+    @pytest.mark.django_db
+    def test_cohorts_link_absent_for_anon_user(self):
+        self.client = Client()
+        url = reverse("repo_list")
+
+        response = self.client.get(url)
+        assert b"Release Cohorts" not in response.content
+
+    @pytest.mark.django_db
+    def test_cohorts_link_shows_for_superuser(self):
+        self.client.force_login(self.superuser)
+        url = reverse("repo_list")
+
+        response = self.client.get(url)
+        assert b"Release Cohorts" in response.content
+
+    @pytest.mark.django_db
+    def test_cohorts_link_absent_for_ordinary_user(self):
+        self.client.force_login(self.user)
+        url = reverse("repo_list")
+
+        response = self.client.get(url)
+        assert b"Release Cohorts" not in response.content


### PR DESCRIPTION
Add link to Release Cohort View to MetaCI

Note this PR has a few other cleanups:

 * minor updates to the setup docs
 * enables the Django feature to go from a model's admin page to its web view (`get_absolute_url`)
