### PR TITLE
Add restrictions on Release movement outside approvals

### DIFF
--- a/metaci/fixtures/factories.py
+++ b/metaci/fixtures/factories.py
@@ -247,6 +247,6 @@ class ReleaseCohortFactory(factory.django.DjangoModelFactory):
         model = ReleaseCohort
 
     name = fake_name()
-    status = "Active"
-    merge_freeze_start = datetime.now(tz=timezone.utc) - timedelta(days=1)
-    merge_freeze_end = datetime.now(tz=timezone.utc) + timedelta(days=1)
+    status = "Planned"
+    merge_freeze_start = datetime.now(tz=timezone.utc) + timedelta(days=1)
+    merge_freeze_end = datetime.now(tz=timezone.utc) + timedelta(days=2)

--- a/metaci/repository/tests/test_views.py
+++ b/metaci/repository/tests/test_views.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timezone, timedelta
 import json
 from unittest import mock
 from unittest.mock import patch
@@ -354,6 +355,12 @@ class TestRepositoryViews(TestCase):
     def test_handle_github_pr_webhook__freeze_on(self, smfs_mock, smfsc_mock):
         cohort = ReleaseCohortFactory()
         ReleaseFactory(release_cohort=cohort, repo=self.repo)
+
+        cohort.merge_freeze_start = datetime.now(tz=timezone.utc) - timedelta(
+            minutes=20
+        )
+        cohort.status = "Active"
+        cohort.save()
 
         payload = {
             "repository": {"id": self.repo.github_id},


### PR DESCRIPTION
Releases cannot be added to a Release Cohort after it leaves Planned stage.

Releases cannot be moved between Release Cohorts unless they are both in Planned stage.