### PR TITLE
Remove unneeded reference to cumulusci module that moved

### DIFF
--- a/metaci/users/management/commands/tests/test_packaging_org_users.py
+++ b/metaci/users/management/commands/tests/test_packaging_org_users.py
@@ -66,7 +66,6 @@ class TestPackagingOrgUsers(TestCase):
         OrgFactory(name="packaging", repo__name="RepoD")
         salesforce_client.query = fake_query
         c = Command()
-        print(sys.modules.keys())
         output = io.StringIO()
         c.handle(stream=output)
         assert json.loads(output.getvalue()) == {

--- a/metaci/users/management/commands/tests/test_packaging_org_users.py
+++ b/metaci/users/management/commands/tests/test_packaging_org_users.py
@@ -67,9 +67,8 @@ class TestPackagingOrgUsers(TestCase):
         salesforce_client.query = fake_query
         c = Command()
         print(sys.modules.keys())
-        with mock.patch("cumulusci.core.config.org_config.SKIP_REFRESH", True):
-            output = io.StringIO()
-            c.handle(stream=output)
+        output = io.StringIO()
+        c.handle(stream=output)
         assert json.loads(output.getvalue()) == {
             "orgs": [
                 {

--- a/metaci/users/management/commands/tests/test_packaging_org_users.py
+++ b/metaci/users/management/commands/tests/test_packaging_org_users.py
@@ -66,8 +66,8 @@ class TestPackagingOrgUsers(TestCase):
         OrgFactory(name="packaging", repo__name="RepoD")
         salesforce_client.query = fake_query
         c = Command()
-        OrgConfigModule = sys.modules["cumulusci.core.config.OrgConfig"]
-        with mock.patch.object(OrgConfigModule, "SKIP_REFRESH", True):
+        print(sys.modules.keys())
+        with mock.patch("cumulusci.core.config.org_config.SKIP_REFRESH", True):
             output = io.StringIO()
             c.handle(stream=output)
         assert json.loads(output.getvalue()) == {


### PR DESCRIPTION
Remove an unneeded reference to a cumulusci module that changed names. After this change, MetaCI's test suite is compatible with both the old and new names.