### PR TITLE
updated user query to select Active Standard users

### DIFF
--- a/metaci/users/management/commands/packaging_org_users.py
+++ b/metaci/users/management/commands/packaging_org_users.py
@@ -38,7 +38,7 @@ def _handle_packaging_org(org):
         org_config.refresh_oauth_token(keychain=None)
         sf = org_config.salesforce_client
         users = sf.query(
-            "SELECT Name, Email, UserType, IsActive, Profile.Name, Title from User WHERE IsActive=True"
+            "SELECT Name, Email, UserType, IsActive, Profile.Name, Title from User WHERE IsActive=True AND UserType='Standard'"
         )
         name, namespace = None, None
         try:


### PR DESCRIPTION
Updated packaging org user report query to only select UserType=Standard users.
This will make the packaging org report reflect the same user list as in the UI for a packaging org.